### PR TITLE
Add reusable post-training analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,27 @@ conda env create -f env/conda-environment.yml
 conda activate codonlm
 ```
 
-## Training 
+## Training
 
 Running the training scrpt is easy with:
 
 ```
 chmod +x pipeline.sh
 ./pipeline.sh
+```
+
+## How to run the 6-step pipeline
+
+```bash
+RUN_ID=2025-09-30_tiny_2L4H_d128_e5
+python -m scripts.collect_artifacts_yaml $RUN_ID path/to/tiny_mps.yaml
+python -m scripts.analyze_frequencies   $RUN_ID
+python -m scripts.analyze_embeddings    $RUN_ID
+python -m scripts.analyze_attention     $RUN_ID
+python -m scripts.probe_next_token      $RUN_ID
+python -m scripts.analyze_saliency      $RUN_ID
+python -m scripts.probe_linear          $RUN_ID
+python -m scripts.summarize_one_cds     $RUN_ID  # optional
+python -m scripts.compare_runs $RUN_ID <other_run_ids...>
 ```
 

--- a/scripts/_shared.py
+++ b/scripts/_shared.py
@@ -1,0 +1,199 @@
+"""Shared utilities for analysis scripts.
+
+These helpers centralize file-system layout, artifact loading, model
+reconstruction, and token-mapping utilities so that downstream analysis
+scripts stay small and consistent. All functions are intentionally
+side-effect free (other than simple path creation) so they can be reused
+across command-line tools.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+
+# Default location for processed run artifacts.
+RUNS_DIR = Path("runs")
+
+
+class ArtifactError(RuntimeError):
+    """Raised when required artifacts are missing."""
+
+
+@dataclass
+class ModelSpec:
+    """Lightweight description of a TinyGPT variant."""
+
+    model_type: str
+    vocab_size: int
+    block_size: int
+    n_layer: int
+    n_head: int
+    n_embd: int
+    dropout: float = 0.0
+    use_checkpoint: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ModelSpec":
+        required = [
+            "model_type",
+            "vocab_size",
+            "block_size",
+            "n_layer",
+            "n_head",
+            "n_embd",
+        ]
+        missing = [k for k in required if k not in data]
+        if missing:
+            raise ArtifactError(f"model specification missing keys: {missing}")
+        return cls(
+            model_type=str(data["model_type"]),
+            vocab_size=int(data["vocab_size"]),
+            block_size=int(data["block_size"]),
+            n_layer=int(data["n_layer"]),
+            n_head=int(data["n_head"]),
+            n_embd=int(data["n_embd"]),
+            dropout=float(data.get("dropout", 0.0)),
+            use_checkpoint=bool(data.get("use_checkpoint", False)),
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "model_type": self.model_type,
+            "vocab_size": self.vocab_size,
+            "block_size": self.block_size,
+            "n_layer": self.n_layer,
+            "n_head": self.n_head,
+            "n_embd": self.n_embd,
+            "dropout": self.dropout,
+            "use_checkpoint": self.use_checkpoint,
+        }
+
+
+# ----- filesystem helpers -------------------------------------------------
+
+def ensure_run_layout(run_id: str) -> Dict[str, Path]:
+    """Ensure that the standard directory layout for a run exists."""
+
+    run_dir = RUNS_DIR / run_id
+    charts_dir = run_dir / "charts"
+    tables_dir = run_dir / "tables"
+    for path in (run_dir, charts_dir, tables_dir):
+        path.mkdir(parents=True, exist_ok=True)
+    return {"run": run_dir, "charts": charts_dir, "tables": tables_dir}
+
+
+def read_meta(run_dir: Path) -> Dict[str, object]:
+    meta_path = run_dir / "meta.json"
+    if not meta_path.exists():
+        raise ArtifactError(f"meta.json missing for run at {run_dir}")
+    return json.loads(meta_path.read_text())
+
+
+def write_meta(run_dir: Path, meta: Mapping[str, object]) -> None:
+    meta_path = run_dir / "meta.json"
+    meta_path.write_text(json.dumps(meta, indent=2, sort_keys=True))
+
+
+def load_artifacts(run_id: str) -> Mapping[str, np.ndarray]:
+    path = RUNS_DIR / run_id / "artifacts.npz"
+    if not path.exists():
+        raise ArtifactError(f"artifacts.npz missing for run {run_id}")
+    with np.load(path, allow_pickle=False) as data:
+        return {k: data[k] for k in data.files}
+
+
+def load_token_list(run_dir: Path) -> List[str]:
+    tok_path = run_dir / "itos.txt"
+    if not tok_path.exists():
+        raise ArtifactError(f"itos.txt missing under {run_dir}")
+    tokens = [line.strip() for line in tok_path.read_text().splitlines() if line.strip()]
+    if not tokens:
+        raise ArtifactError(f"itos.txt at {tok_path} is empty")
+    return tokens
+
+
+def stoi(tokens: Sequence[str]) -> Dict[str, int]:
+    return {tok: i for i, tok in enumerate(tokens)}
+
+
+# ----- model reconstruction ------------------------------------------------
+
+def detect_model_type(state_dict: Mapping[str, torch.Tensor]) -> str:
+    keys = list(state_dict.keys())
+    if any("qkv" in k for k in keys):
+        return "tiny_gpt"
+    if any("key.weight" in k for k in keys):
+        return "tiny_gpt_v2"
+    raise ArtifactError("Unable to infer model type from checkpoint keys")
+
+
+def build_model(spec: ModelSpec) -> torch.nn.Module:
+    if spec.model_type == "tiny_gpt":
+        from src.codonlm.model_tiny_gpt import Cfg, TinyGPT
+
+        cfg = Cfg(
+            vocab_size=spec.vocab_size,
+            n_layer=spec.n_layer,
+            n_head=spec.n_head,
+            n_embd=spec.n_embd,
+            block_size=spec.block_size,
+            dropout=spec.dropout,
+        )
+        model = TinyGPT(cfg)
+    elif spec.model_type == "tiny_gpt_v2":
+        from src.codonlm.model_tiny_gpt_v2 import TinyGPTv2
+
+        model = TinyGPTv2(
+            vocab_size=spec.vocab_size,
+            block_size=spec.block_size,
+            n_layer=spec.n_layer,
+            n_head=spec.n_head,
+            n_embd=spec.n_embd,
+            dropout=spec.dropout,
+            use_checkpoint=spec.use_checkpoint,
+        )
+    else:
+        raise ArtifactError(f"Unsupported model_type {spec.model_type}")
+    model.eval()
+    return model
+
+
+def load_model(run_dir: Path, device: torch.device | str = "cpu") -> Tuple[torch.nn.Module, ModelSpec]:
+    meta = read_meta(run_dir)
+    spec = ModelSpec.from_dict(meta["model_spec"])
+    weights_path = run_dir / "weights.pt"
+    if not weights_path.exists():
+        raise ArtifactError(f"weights.pt missing under {run_dir}")
+    ckpt = torch.load(weights_path, map_location=device)
+    state_dict = ckpt["model"] if isinstance(ckpt, Mapping) and "model" in ckpt else ckpt
+    model = build_model(spec)
+    model.load_state_dict(state_dict, strict=False)
+    model.to(device)
+    model.eval()
+    return model, spec
+
+
+def softmax(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    return torch.nn.functional.softmax(x, dim=dim)
+
+
+def compute_bincount(values: np.ndarray, size: int) -> np.ndarray:
+    flat = values.reshape(-1)
+    counts = np.bincount(flat, minlength=size)
+    if counts.shape[0] > size:
+        counts = counts[:size]
+    return counts.astype(np.int64)
+
+
+def ensure_numpy(x: torch.Tensor | np.ndarray) -> np.ndarray:
+    if isinstance(x, np.ndarray):
+        return x
+    return x.detach().cpu().numpy()
+
+

--- a/scripts/analyze_attention.py
+++ b/scripts/analyze_attention.py
@@ -1,0 +1,63 @@
+"""Visualize attention maps for a collected run."""
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Optional
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from ._shared import ArtifactError, ensure_run_layout, load_artifacts, load_token_list
+
+
+def _plot_attention(attn: np.ndarray, tokens: list[str], out_path) -> None:
+    plt.figure(figsize=(6, 5))
+    plt.imshow(attn, aspect="auto", origin="lower", cmap="viridis")
+    plt.colorbar(label="Attention weight")
+    n = min(len(tokens), attn.shape[0])
+    plt.xticks(range(n), tokens[:n], rotation=90, fontsize=6)
+    plt.yticks(range(n), tokens[:n], fontsize=6)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, charts_dir = paths["run"], paths["charts"]
+
+    try:
+        artifacts = load_artifacts(args.run_id)
+    except ArtifactError as exc:
+        print(f"[attn] {exc}")
+        return
+
+    attn = artifacts.get("attn")
+    if attn is None or attn.size == 0:
+        print("[attn] no attention tensors captured; skipping")
+        return
+
+    tokens = load_token_list(run_dir)
+    # attn shape: (layers, batch, heads, T, T)
+    layers = attn.shape[0]
+    heads = attn.shape[2]
+    T = attn.shape[3]
+
+    for layer in range(layers):
+        for head in range(heads):
+            # only visualize the first sample for compactness
+            matrix = attn[layer, 0, head]
+            out = charts_dir / f"attn_L{layer}_H{head}_0-{T}.png"
+            _plot_attention(matrix, tokens[:T], out)
+
+    print(f"[attn] saved {layers * heads} attention heatmaps to {charts_dir}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/analyze_embeddings.py
+++ b/scripts/analyze_embeddings.py
@@ -1,0 +1,154 @@
+"""Embedding analysis for TinyGPT runs."""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable, Optional, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ._shared import ArtifactError, ensure_run_layout, load_artifacts, load_token_list
+
+try:
+    from sklearn.cluster import KMeans
+    from sklearn.metrics import silhouette_score
+except Exception:  # pragma: no cover - optional dependency
+    KMeans = None
+    silhouette_score = None
+
+
+def _compute_pca(embeddings: np.ndarray, k: int = 2) -> Tuple[np.ndarray, np.ndarray]:
+    mean = embeddings.mean(axis=0, keepdims=True)
+    centered = embeddings - mean
+    u, s, vh = np.linalg.svd(centered, full_matrices=False)
+    components = vh[:k]
+    transformed = centered @ components.T
+    explained = (s[:k] ** 2) / np.sum(s ** 2)
+    return transformed, explained
+
+
+def _nearest_neighbors(embeddings: np.ndarray, tokens: list[str], top_k: int = 5) -> list[tuple]:
+    norm = np.linalg.norm(embeddings, axis=1, keepdims=True) + 1e-8
+    normed = embeddings / norm
+    sims = normed @ normed.T
+    rows = []
+    for idx in range(embeddings.shape[0]):
+        order = np.argsort(-sims[idx])
+        neighbors = []
+        for j in order:
+            if j == idx:
+                continue
+            neighbors.append((tokens[j], float(sims[idx, j])))
+            if len(neighbors) >= top_k:
+                break
+        rows.append((tokens[idx], neighbors))
+    return rows
+
+
+def _load_motif_overlay(run_dir: Path) -> Optional[dict]:
+    motif_path = run_dir / "motif_clusters.npz"
+    if not motif_path.exists():
+        return None
+    try:
+        with np.load(motif_path, allow_pickle=True) as data:
+            payload = {k: data[k] for k in data.files}
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"[emb] failed to load motif_clusters: {exc}")
+        return None
+    return payload
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, charts_dir, tables_dir = paths["run"], paths["charts"], paths["tables"]
+
+    try:
+        artifacts = load_artifacts(args.run_id)
+    except ArtifactError as exc:
+        print(f"[emb] {exc}")
+        return
+
+    embeddings = artifacts.get("token_embeddings")
+    if embeddings is None or embeddings.size == 0:
+        print("[emb] token_embeddings missing; aborting")
+        return
+
+    tokens = load_token_list(run_dir)
+    coords, explained = _compute_pca(embeddings, k=2)
+
+    plt.figure(figsize=(6, 6))
+    plt.scatter(coords[:, 0], coords[:, 1], alpha=0.7)
+    for token, x, y in zip(tokens, coords[:, 0], coords[:, 1]):
+        plt.text(x, y, token, fontsize=6, ha="center", va="center")
+    plt.xlabel("PC1")
+    plt.ylabel("PC2")
+    plt.title("Token embedding PCA")
+    plt.tight_layout()
+    plt.savefig(charts_dir / "emb_pca.png", dpi=200)
+    plt.close()
+
+    neighbors = _nearest_neighbors(embeddings, tokens, top_k=5)
+    nn_path = tables_dir / "nearest_neighbors.csv"
+    with nn_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        header = ["token"] + [f"neighbor_{i}" for i in range(1, 6)] + [f"sim_{i}" for i in range(1, 6)]
+        writer.writerow(header)
+        for token, neigh in neighbors:
+            row = [token]
+            row.extend([n[0] for n in neigh] + [""] * (5 - len(neigh)))
+            row.extend([f"{n[1]:.4f}" for n in neigh] + [""] * (5 - len(neigh)))
+            writer.writerow(row)
+
+    silhouette = None
+    if KMeans is not None and silhouette_score is not None and embeddings.shape[0] >= 5:
+        try:
+            kmeans = KMeans(n_clusters=min(8, embeddings.shape[0] // 2), n_init="auto")
+            labels = kmeans.fit_predict(embeddings)
+            silhouette = float(silhouette_score(embeddings, labels))
+        except Exception as exc:  # pragma: no cover
+            print(f"[emb] silhouette computation failed: {exc}")
+            silhouette = None
+    else:
+        if KMeans is None:
+            print("[emb] scikit-learn not available; skipping silhouette score")
+
+    quality_path = tables_dir / "embed_quality.txt"
+    lines = [
+        f"PCA explained variance (PC1, PC2): {explained[0]:.4f}, {explained[1]:.4f}",
+    ]
+    if silhouette is not None:
+        lines.append(f"Silhouette score: {silhouette:.4f}")
+    else:
+        lines.append("Silhouette score: NA")
+    quality_path.write_text("\n".join(lines) + "\n")
+
+    overlay = _load_motif_overlay(run_dir)
+    if overlay and {"embeddings", "labels"}.issubset(overlay.keys()):
+        motif_emb = np.asarray(overlay["embeddings"])
+        motif_labels = np.asarray(overlay["labels"]).astype(str)
+        motif_coords, _ = _compute_pca(motif_emb, k=2)
+        plt.figure(figsize=(6, 6))
+        scatter = plt.scatter(motif_coords[:, 0], motif_coords[:, 1], c=motif_labels)
+        plt.legend(*scatter.legend_elements(), title="Motif")
+        plt.xlabel("PC1")
+        plt.ylabel("PC2")
+        plt.title("Motif clusters (PCA)")
+        plt.tight_layout()
+        plt.savefig(charts_dir / "emb_pca_motifs.png", dpi=200)
+        plt.close()
+
+    print(f"[emb] wrote PCA plot and nearest neighbors to {run_dir}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/analyze_frequencies.py
+++ b/scripts/analyze_frequencies.py
@@ -1,0 +1,86 @@
+"""Frequency analysis for a collected run."""
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import Iterable, Optional
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ._shared import ArtifactError, ensure_run_layout, load_artifacts, load_token_list
+
+
+def _top_k_indices(counts: np.ndarray, k: int = 20) -> np.ndarray:
+    k = min(k, counts.shape[0])
+    return np.argsort(counts)[::-1][:k]
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, charts_dir, tables_dir = paths["run"], paths["charts"], paths["tables"]
+
+    try:
+        artifacts = load_artifacts(args.run_id)
+    except ArtifactError as exc:
+        print(f"[freq] {exc}")
+        return
+
+    tokens = load_token_list(run_dir)
+    counts = artifacts.get("token_counts")
+    first_counts = artifacts.get("first_token_counts")
+    if counts is None or counts.size == 0:
+        print("[freq] token_counts missing; nothing to plot")
+        return
+
+    total = counts.sum()
+    freq_rows = []
+    for idx, count in enumerate(counts):
+        token = tokens[idx] if idx < len(tokens) else f"tok_{idx}"
+        freq = (float(count) / float(total)) if total > 0 else 0.0
+        freq_rows.append((token, int(count), freq))
+
+    freq_path = tables_dir / "frequencies.csv"
+    with freq_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["token", "count", "frequency"])
+        writer.writerows(freq_rows)
+
+    top_idx = _top_k_indices(counts, 20)
+    top_tokens = [tokens[i] if i < len(tokens) else f"tok_{i}" for i in top_idx]
+    top_counts = counts[top_idx]
+
+    plt.figure(figsize=(10, 5))
+    plt.bar(top_tokens, top_counts)
+    plt.xticks(rotation=45, ha="right")
+    plt.ylabel("Count")
+    plt.title("Top-20 token frequency")
+    plt.tight_layout()
+    plt.savefig(charts_dir / "top20_freq.png", dpi=200)
+    plt.close()
+
+    if first_counts is not None and first_counts.size == counts.size:
+        plt.figure(figsize=(10, 5))
+        plt.bar(np.arange(first_counts.size), first_counts)
+        plt.xticks(range(len(tokens)), tokens, rotation=45, ha="right")
+        plt.ylabel("Count")
+        plt.title("First-position token counts")
+        plt.tight_layout()
+        plt.savefig(charts_dir / "first_position_counts.png", dpi=200)
+        plt.close()
+    else:
+        print("[freq] first_token_counts missing; skipping plot")
+
+    print(f"[freq] wrote tables to {freq_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/analyze_saliency.py
+++ b/scripts/analyze_saliency.py
@@ -1,0 +1,92 @@
+"""Compute gradient × input saliency for a validation sequence."""
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import Iterable, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from ._shared import ensure_run_layout, load_artifacts, load_model, load_token_list
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, tables_dir = paths["run"], paths["tables"]
+
+    artifacts = load_artifacts(args.run_id)
+    val_inputs = artifacts.get("val_inputs")
+    val_targets = artifacts.get("val_targets")
+    if val_inputs is None or val_inputs.size == 0:
+        print("[saliency] validation inputs missing; aborting")
+        return
+    if val_targets is None or val_targets.size == 0:
+        val_targets = np.roll(val_inputs, -1, axis=1)
+
+    tokens = load_token_list(run_dir)
+
+    model, _ = load_model(run_dir)
+    device = next(model.parameters()).device
+    seq = torch.from_numpy(val_inputs[0:1]).long().to(device)
+    tgt = torch.from_numpy(val_targets[0:1]).long().to(device)
+
+    embedding_output = {}
+
+    def capture(module, inputs, output):
+        embedding_output["activations"] = output
+        output.retain_grad()
+
+    handle = model.tok_emb.register_forward_hook(capture)
+
+    model.zero_grad(set_to_none=True)
+    outputs = model(seq, tgt)
+    if isinstance(outputs, tuple):
+        logits, loss = outputs
+        if loss is None:
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), tgt.view(-1))
+    elif isinstance(outputs, dict):
+        logits = outputs["logits"]
+        loss = outputs.get("loss")
+        if loss is None:
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), tgt.view(-1))
+    else:
+        raise RuntimeError("Unexpected model output")
+
+    loss.backward()
+
+    handle.remove()
+
+    acts = embedding_output.get("activations")
+    if acts is None or acts.grad is None:
+        print("[saliency] failed to capture embedding gradients")
+        return
+
+    grad = acts.grad[0]
+    act = acts.detach()[0]
+    saliency = torch.sum(grad * act, dim=-1)
+
+    rows = []
+    for idx, value in enumerate(saliency.tolist()):
+        token_idx = int(seq[0, idx].cpu())
+        token = tokens[token_idx] if token_idx < len(tokens) else f"tok_{token_idx}"
+        rows.append((idx, token, value))
+
+    out_path = tables_dir / "saliency.csv"
+    with out_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["position", "token", "saliency"])
+        for idx, token, val in rows:
+            writer.writerow([idx, token, f"{val:.6f}"])
+
+    print(f"[saliency] wrote saliency scores to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/collect_artifacts_yaml.py
+++ b/scripts/collect_artifacts_yaml.py
@@ -1,0 +1,362 @@
+"""Collect model artifacts for downstream analysis.
+
+Usage:
+    python -m scripts.collect_artifacts_yaml RUN_ID path/to/config.yaml
+
+The script loads the YAML configuration, locates the trained checkpoint,
+symlinks the weights into ``runs/<run_id>/weights.pt`` and saves a compact
+``artifacts.npz`` bundle with token/positional embeddings, validation
+statistics, logits, probabilities, and attention tensors. Optional files
+(``motif_clusters.npz`` and ``one_cds__best.tsv``) are copied when present.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import yaml
+
+from ._shared import (
+    ArtifactError,
+    ModelSpec,
+    RUNS_DIR,
+    build_model,
+    compute_bincount,
+    detect_model_type,
+    ensure_run_layout,
+    ensure_numpy,
+    write_meta,
+)
+
+BATCH_EVAL_SIZE = 16
+ATTN_DTYPE = np.float32
+
+
+def _load_yaml(yaml_path: Path) -> Mapping[str, object]:
+    if not yaml_path.exists():
+        raise FileNotFoundError(f"Config file not found: {yaml_path}")
+    with yaml_path.open("r") as fh:
+        cfg = yaml.safe_load(fh) or {}
+    if not isinstance(cfg, Mapping):
+        raise ValueError(f"Config at {yaml_path} is not a mapping")
+    return cfg
+
+
+def _resolve_path(base: Path, maybe_path: Optional[str]) -> Optional[Path]:
+    if not maybe_path:
+        return None
+    candidate = Path(maybe_path)
+    if not candidate.is_absolute():
+        candidate = (base / candidate).resolve()
+    return candidate
+
+
+def _find_checkpoint(out_dir: Path) -> Path:
+    for name in ("best.pt", "last.pt"):
+        candidate = out_dir / name
+        if candidate.exists():
+            return candidate.resolve()
+    raise FileNotFoundError(f"No checkpoint found in {out_dir} (expected best.pt or last.pt)")
+
+
+def _maybe_copy(src: Path, dst: Path) -> None:
+    if src.exists():
+        shutil.copy2(src, dst)
+
+
+def _find_token_file(out_dir: Path, yaml_dir: Path, cfg: Mapping[str, object]) -> Optional[Path]:
+    candidate_keys = [
+        "itos_path",
+        "tokenizer_path",
+        "token_map",
+        "token_file",
+    ]
+    for key in candidate_keys:
+        val = cfg.get(key)
+        if isinstance(val, str):
+            path = _resolve_path(yaml_dir, val)
+            if path and path.exists():
+                return path
+    for parent in {out_dir, yaml_dir}:
+        if parent is None:
+            continue
+        cand = parent / "itos.txt"
+        if cand.exists():
+            return cand
+    return None
+
+
+def _load_val_npz(cfg: Mapping[str, object], yaml_dir: Path) -> Optional[Path]:
+    keys = ["val_npz", "val_path", "validation_npz", "val_dataset"]
+    for key in keys:
+        if key in cfg and isinstance(cfg[key], str):
+            path = _resolve_path(yaml_dir, str(cfg[key]))
+            if path and path.exists():
+                return path
+    block_size = cfg.get("block_size")
+    if block_size is None:
+        return None
+    data_dir = cfg.get("data_dir", "data/processed")
+    data_path = _resolve_path(yaml_dir, str(data_dir))
+    if data_path is None:
+        return None
+    candidate = data_path / f"val_bs{block_size}.npz"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _load_npz_dataset(npz_path: Path) -> Dict[str, np.ndarray]:
+    with np.load(npz_path, allow_pickle=False) as data:
+        arrays = {k: np.asarray(data[k]) for k in data.files}
+    return arrays
+
+
+def _infer_spec_from_state(cfg: Mapping[str, object], state_dict: Mapping[str, torch.Tensor]) -> ModelSpec:
+    model_type = cfg.get("model_type")
+    if not model_type:
+        model_type = detect_model_type(state_dict)
+    required_keys = ["vocab_size", "block_size", "n_layer", "n_head", "n_embd"]
+    missing = [k for k in required_keys if k not in cfg]
+    if missing:
+        raise ArtifactError(f"Missing model parameters in config: {missing}")
+    spec = ModelSpec(
+        model_type=model_type,
+        vocab_size=int(cfg["vocab_size"]),
+        block_size=int(cfg["block_size"]),
+        n_layer=int(cfg["n_layer"]),
+        n_head=int(cfg["n_head"]),
+        n_embd=int(cfg["n_embd"]),
+        dropout=float(cfg.get("dropout", 0.0)),
+        use_checkpoint=bool(cfg.get("use_checkpoint", False)),
+    )
+    return spec
+
+
+def _capture_attention(model: torch.nn.Module, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    attn_maps: Dict[int, torch.Tensor] = {}
+    handles = []
+
+    def make_hook(layer_idx: int):
+        def _hook(module: torch.nn.Module, module_inputs: Tuple[torch.Tensor, ...], module_output: torch.Tensor):
+            x = module_inputs[0]
+            with torch.no_grad():
+                if hasattr(module, "qkv"):
+                    qkv = module.qkv(x)
+                    q, k, v = qkv.chunk(3, dim=-1)
+                    B, T, C = q.shape
+                    H = module.n_head
+                    q = q.view(B, T, H, C // H).transpose(1, 2)
+                    k = k.view(B, T, H, C // H).transpose(1, 2)
+                    att = (q @ k.transpose(-2, -1)) / math.sqrt(q.size(-1))
+                    mask = module.attn_mask[:, :, :T, :T]
+                    att = att.masked_fill(mask == 0, float("-inf"))
+                    att = torch.softmax(att, dim=-1)
+                elif hasattr(module, "key"):
+                    B, T, _ = x.shape
+                    n_head = module.n_head
+                    k = module.key(x).view(B, T, n_head, -1).transpose(1, 2)
+                    q = module.query(x).view(B, T, n_head, -1).transpose(1, 2)
+                    att = (q @ k.transpose(-2, -1)) / math.sqrt(q.size(-1))
+                    mask = module.mask[:, :, :T, :T]
+                    att = att.masked_fill(mask == 0, float("-inf"))
+                    att = torch.softmax(att, dim=-1)
+                else:
+                    raise RuntimeError("Unknown attention module; cannot capture attention map")
+            attn_maps[layer_idx] = att.detach().cpu()
+
+        return _hook
+
+    for idx, block in enumerate(getattr(model, "blocks", [])):
+        attn = getattr(block, "attn", None)
+        if attn is None:
+            continue
+        handles.append(attn.register_forward_hook(make_hook(idx)))
+
+    with torch.no_grad():
+        outputs = model(inputs)
+        logits = outputs[0] if isinstance(outputs, (tuple, list)) else outputs["logits"]
+
+    for handle in handles:
+        handle.remove()
+
+    if attn_maps:
+        ordered = [attn_maps[i] for i in sorted(attn_maps.keys())]
+        attn_tensor = torch.stack(ordered, dim=0)
+    else:
+        attn_tensor = torch.zeros(0)
+    return logits, attn_tensor
+
+
+def _evaluate_perplexity(model: torch.nn.Module, inputs: np.ndarray, targets: np.ndarray, vocab: int) -> Optional[float]:
+    if inputs.size == 0 or targets.size == 0:
+        return None
+    device = next(model.parameters()).device
+    batch = BATCH_EVAL_SIZE
+    total_loss = 0.0
+    total_tokens = 0
+    for start in range(0, inputs.shape[0], batch):
+        end = min(start + batch, inputs.shape[0])
+        xb = torch.from_numpy(inputs[start:end]).to(device=device, dtype=torch.long)
+        yb = torch.from_numpy(targets[start:end]).to(device=device, dtype=torch.long)
+        with torch.no_grad():
+            outputs = model(xb, yb)
+            if isinstance(outputs, tuple):
+                loss = outputs[1]
+            elif isinstance(outputs, Mapping):
+                loss = outputs.get("loss")
+                if loss is None:
+                    logits = outputs["logits"]
+                    loss = F.cross_entropy(logits.view(-1, vocab), yb.view(-1))
+            else:
+                raise RuntimeError("Unexpected model output during evaluation")
+        total_loss += float(loss.item()) * (end - start)
+        total_tokens += (end - start)
+    if total_tokens == 0:
+        return None
+    mean_loss = total_loss / total_tokens
+    return float(math.exp(min(50.0, mean_loss)))
+
+
+def _save_artifacts(run_dir: Path, arrays: Dict[str, np.ndarray]) -> None:
+    out_path = run_dir / "artifacts.npz"
+    np.savez_compressed(out_path, **arrays)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    ap.add_argument("config")
+    args = ap.parse_args(argv)
+
+    run_paths = ensure_run_layout(args.run_id)
+    run_dir = run_paths["run"]
+    yaml_path = Path(args.config).resolve()
+    cfg = _load_yaml(yaml_path)
+    yaml_dir = yaml_path.parent
+
+    out_dir = cfg.get("out_dir")
+    if not out_dir:
+        raise ValueError("Config must specify out_dir")
+    out_dir = _resolve_path(yaml_dir, str(out_dir))
+    if out_dir is None or not out_dir.exists():
+        raise FileNotFoundError(f"Output directory not found: {out_dir}")
+
+    checkpoint_path = _find_checkpoint(out_dir)
+
+    weights_dst = run_dir / "weights.pt"
+    if weights_dst.exists() or weights_dst.is_symlink():
+        weights_dst.unlink()
+    weights_dst.symlink_to(checkpoint_path)
+
+    for optional_name in ("motif_clusters.npz", "one_cds__best.tsv"):
+        src = out_dir / optional_name
+        dst = run_dir / optional_name
+        if src.exists():
+            shutil.copy2(src, dst)
+
+    token_path = _find_token_file(out_dir, yaml_dir, cfg)
+    vocab_size = int(cfg.get("vocab_size", 0) or 0)
+    if token_path and token_path.exists():
+        tokens = [line.strip() for line in token_path.read_text().splitlines() if line.strip()]
+    else:
+        tokens = [f"tok_{i}" for i in range(vocab_size)]
+    (run_dir / "itos.txt").write_text("\n".join(tokens) + "\n")
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    if isinstance(checkpoint, Mapping) and "model" in checkpoint:
+        state_dict = checkpoint["model"]
+        ckpt_cfg = checkpoint.get("cfg", {}) if isinstance(checkpoint.get("cfg"), Mapping) else {}
+    else:
+        state_dict = checkpoint
+        ckpt_cfg = {}
+    merged_cfg = dict(cfg)
+    merged_cfg.update(ckpt_cfg)
+
+    spec = _infer_spec_from_state(merged_cfg, state_dict)
+    model = build_model(spec)
+    model.load_state_dict(state_dict, strict=False)
+    model.eval()
+
+    val_npz = _load_val_npz(merged_cfg, yaml_dir)
+    arrays: Dict[str, np.ndarray] = {}
+    token_counts = None
+    first_token_counts = None
+    val_inputs = None
+    val_targets = None
+
+    if val_npz and val_npz.exists():
+        data = _load_npz_dataset(val_npz)
+        if "X" in data:
+            val_inputs = np.asarray(data["X"], dtype=np.int64)
+            token_counts = compute_bincount(val_inputs, spec.vocab_size)
+            if val_inputs.size > 0:
+                first_token_counts = compute_bincount(val_inputs[:, :1], spec.vocab_size)
+        if "Y" in data:
+            val_targets = np.asarray(data["Y"], dtype=np.int64)
+        if val_targets is None and val_inputs is not None:
+            val_targets = np.roll(val_inputs, -1, axis=1)
+        arrays["val_inputs"] = val_inputs[:32].copy() if val_inputs is not None else np.zeros((0,), dtype=np.int64)
+        arrays["val_targets"] = val_targets[:32].copy() if val_targets is not None else np.zeros((0,), dtype=np.int64)
+    else:
+        arrays["val_inputs"] = np.zeros((0,), dtype=np.int64)
+        arrays["val_targets"] = np.zeros((0,), dtype=np.int64)
+
+    batch_inputs = arrays["val_inputs"]
+    logits_arr = np.zeros((0,), dtype=np.float32)
+    probs_arr = np.zeros((0,), dtype=np.float32)
+    attn_arr = np.zeros((0,), dtype=ATTN_DTYPE)
+
+    if batch_inputs.size > 0:
+        batch_tensor = torch.from_numpy(batch_inputs[:4]).long()
+        logits, attn = _capture_attention(model, batch_tensor)
+        probs = torch.softmax(logits, dim=-1)
+        logits_arr = logits.detach().cpu().numpy()
+        probs_arr = probs.detach().cpu().numpy()
+        attn_arr = attn.detach().cpu().numpy().astype(ATTN_DTYPE)
+
+    arrays.update(
+        {
+            "token_embeddings": ensure_numpy(model.tok_emb.weight).astype(np.float32),
+            "pos_embeddings": ensure_numpy(getattr(model, "pos_emb", torch.zeros(0))).astype(np.float32)
+            if hasattr(model, "pos_emb")
+            else np.zeros((0,), dtype=np.float32),
+            "logits": logits_arr,
+            "probs": probs_arr,
+            "attn": attn_arr,
+            "token_counts": token_counts if token_counts is not None else np.zeros((vocab_size,), dtype=np.int64),
+            "first_token_counts": first_token_counts if first_token_counts is not None else np.zeros((vocab_size,), dtype=np.int64),
+        }
+    )
+
+    _save_artifacts(run_dir, arrays)
+
+    val_ppl = None
+    if val_inputs is not None and val_targets is not None and val_inputs.size > 0:
+        val_ppl = _evaluate_perplexity(model, val_inputs, val_targets, spec.vocab_size)
+
+    meta = {
+        "run_id": args.run_id,
+        "config_path": str(yaml_path),
+        "out_dir": str(out_dir),
+        "checkpoint_path": str(checkpoint_path),
+        "val_npz": str(val_npz) if val_npz else None,
+        "val_ppl": val_ppl,
+        "model_spec": spec.to_dict(),
+        "token_count": len(tokens),
+    }
+    write_meta(run_dir, meta)
+
+    print(f"[collect] saved artifacts for {args.run_id} → {run_dir}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/compare_runs.py
+++ b/scripts/compare_runs.py
@@ -1,0 +1,118 @@
+"""Aggregate metrics across multiple runs."""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from ._shared import RUNS_DIR, ensure_run_layout, read_meta
+
+SUMMARY_COLUMNS = [
+    "run_id",
+    "val_ppl",
+    "silhouette",
+    "probe_aa",
+    "probe_class_pol",
+    "probe_class_hydro",
+    "probe_is_stop",
+    "probe_is_start",
+]
+
+TASK_TO_COLUMN = {
+    "AA identity": "probe_aa",
+    "polarity class": "probe_class_pol",
+    "hydropathy class": "probe_class_hydro",
+    "is_stop": "probe_is_stop",
+    "is_start": "probe_is_start",
+}
+
+
+def _read_silhouette(run_dir: Path) -> Optional[float]:
+    path = run_dir / "tables" / "embed_quality.txt"
+    if not path.exists():
+        return None
+    for line in path.read_text().splitlines():
+        if line.lower().startswith("silhouette score:"):
+            value = line.split(":", 1)[1].strip()
+            if value.upper() == "NA":
+                return None
+            try:
+                return float(value)
+            except ValueError:
+                return None
+    return None
+
+
+def _read_probe_results(run_dir: Path) -> dict:
+    path = run_dir / "tables" / "probe_results.csv"
+    if not path.exists():
+        return {}
+    results = {}
+    with path.open("r", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            task = row.get("task")
+            if not task:
+                continue
+            try:
+                score = float(row.get("mean_accuracy", ""))
+            except ValueError:
+                continue
+            results[task] = score
+    return results
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_ids", nargs="+")
+    args = ap.parse_args(argv)
+
+    summary_dir = RUNS_DIR / "_summary"
+    summary_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: List[dict] = []
+    for run_id in args.run_ids:
+        try:
+            paths = ensure_run_layout(run_id)
+        except Exception:
+            continue
+        run_dir = paths["run"]
+        row = {col: "NA" for col in SUMMARY_COLUMNS}
+        row["run_id"] = run_id
+        try:
+            meta = read_meta(run_dir)
+            if meta.get("val_ppl") is not None:
+                row["val_ppl"] = f"{float(meta['val_ppl']):.4f}"
+        except Exception:
+            pass
+        silhouette = _read_silhouette(run_dir)
+        if silhouette is not None:
+            row["silhouette"] = f"{silhouette:.4f}"
+        probe_scores = _read_probe_results(run_dir)
+        for task, column in TASK_TO_COLUMN.items():
+            if task in probe_scores:
+                row[column] = f"{probe_scores[task]:.4f}"
+        rows.append(row)
+
+    def sort_key(row: dict) -> float:
+        try:
+            return float(row.get("val_ppl", float("inf")))
+        except ValueError:
+            return float("inf")
+
+    rows.sort(key=sort_key)
+
+    out_path = summary_dir / "summary.csv"
+    with out_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=SUMMARY_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+    print(f"[compare] wrote summary to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/probe_linear.py
+++ b/scripts/probe_linear.py
@@ -1,0 +1,179 @@
+"""Linear probes on token embeddings."""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from ._shared import ensure_run_layout, load_artifacts, load_token_list, stoi
+
+TASKS = {
+    "AA identity": "aa",
+    "polarity class": "polarity",
+    "hydropathy class": "hydropathy",
+    "is_stop": "is_stop",
+    "is_start": "is_start",
+}
+K_FOLDS = 5
+EPOCHS = 300
+LR = 0.1
+WEIGHT_DECAY = 1e-4
+RNG_SEED = 1337
+
+
+def _read_probe_labels(path: Path, tokens: List[str]) -> List[Dict[str, str]]:
+    rows = []
+    if not path.exists():
+        return rows
+    with path.open("r", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            token = row.get("token")
+            if token is None or token not in tokens:
+                continue
+            rows.append({k: v for k, v in row.items()})
+    return rows
+
+
+def _encode_labels(rows: List[Dict[str, str]], field: str) -> Tuple[np.ndarray, np.ndarray, Dict[str, int]]:
+    valid = [r[field] for r in rows if r.get(field) not in (None, "")]
+    unique = sorted(set(valid))
+    mapping = {v: i for i, v in enumerate(unique)}
+    labels = []
+    mask = []
+    for r in rows:
+        val = r.get(field)
+        if val in (None, ""):
+            mask.append(False)
+            labels.append(0)
+        else:
+            mask.append(True)
+            labels.append(mapping[val])
+    return np.array(labels, dtype=np.int64), np.array(mask, dtype=bool), mapping
+
+
+def _encode_binary(rows: List[Dict[str, str]], field: str) -> Tuple[np.ndarray, np.ndarray]:
+    def to_int(val: str) -> int:
+        if val is None:
+            return -1
+        val = val.strip().lower()
+        if val in {"1", "true", "yes", "y"}:
+            return 1
+        if val in {"0", "false", "no", "n"}:
+            return 0
+        return -1
+
+    labels = []
+    mask = []
+    for r in rows:
+        value = to_int(r.get(field, ""))
+        if value < 0:
+            mask.append(False)
+            labels.append(0)
+        else:
+            mask.append(True)
+            labels.append(value)
+    return np.array(labels, dtype=np.int64), np.array(mask, dtype=bool)
+
+
+def _kfold_indices(n: int, k: int, seed: int = RNG_SEED):
+    rng = np.random.default_rng(seed)
+    indices = np.arange(n)
+    rng.shuffle(indices)
+    fold_sizes = [n // k + (1 if i < n % k else 0) for i in range(k)]
+    start = 0
+    for size in fold_sizes:
+        end = start + size
+        val_idx = indices[start:end]
+        train_idx = np.concatenate([indices[:start], indices[end:]])
+        yield train_idx, val_idx
+        start = end
+
+
+def _train_probe(train_x: torch.Tensor, train_y: torch.Tensor, num_classes: int) -> torch.nn.Module:
+    model = torch.nn.Linear(train_x.shape[1], num_classes)
+    optimizer = torch.optim.Adam(model.parameters(), lr=LR, weight_decay=WEIGHT_DECAY)
+    for _ in range(EPOCHS):
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(train_x)
+        loss = F.cross_entropy(logits, train_y)
+        loss.backward()
+        optimizer.step()
+    return model
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, tables_dir = paths["run"], paths["tables"]
+
+    embeddings = load_artifacts(args.run_id).get("token_embeddings")
+    if embeddings is None or embeddings.size == 0:
+        print("[probe-linear] token embeddings missing; aborting")
+        return
+    tokens = load_token_list(run_dir)
+
+    label_path = run_dir / "probe_labels.csv"
+    rows = _read_probe_labels(label_path, tokens)
+    if not rows:
+        print(f"[probe-linear] probe_labels.csv missing or empty at {label_path}")
+        return
+
+    torch.manual_seed(RNG_SEED)
+
+    token_to_idx = stoi(tokens)
+    indices = [token_to_idx[row["token"]] for row in rows if row.get("token") in token_to_idx]
+    X = torch.tensor(embeddings[indices], dtype=torch.float32)
+
+    results = []
+    for task, field in TASKS.items():
+        if field in {"is_stop", "is_start"}:
+            y, mask = _encode_binary(rows, field)
+        else:
+            y, mask, _ = _encode_labels(rows, field)
+        if mask.sum() < K_FOLDS:
+            print(f"[probe-linear] skipping {task}; insufficient labels")
+            continue
+        valid_idx = np.where(mask)[0]
+        X_task = X[valid_idx]
+        y_task = torch.tensor(y[valid_idx], dtype=torch.long)
+
+        fold_acc = []
+        for train_idx, val_idx in _kfold_indices(X_task.shape[0], K_FOLDS):
+            train_x = X_task[train_idx]
+            val_x = X_task[val_idx]
+            train_y = y_task[train_idx]
+            val_y = y_task[val_idx]
+            if train_x.shape[0] == 0 or val_x.shape[0] == 0:
+                continue
+            num_classes = int(y_task.max().item() + 1)
+            model = _train_probe(train_x, train_y, num_classes)
+            with torch.no_grad():
+                preds = model(val_x).argmax(dim=1)
+                acc = (preds == val_y).float().mean().item()
+            fold_acc.append(acc)
+        if not fold_acc:
+            continue
+        results.append((task, float(np.mean(fold_acc)), float(np.std(fold_acc))))
+
+    out_path = tables_dir / "probe_results.csv"
+    with out_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["task", "mean_accuracy", "std_accuracy"])
+        for task, mean, std in results:
+            writer.writerow([task, f"{mean:.4f}", f"{std:.4f}"])
+
+    print(f"[probe-linear] wrote results to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/probe_next_token.py
+++ b/scripts/probe_next_token.py
@@ -1,0 +1,78 @@
+"""Probe next-token predictions for fixed genomic prefixes."""
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import Iterable, Optional
+
+import torch
+
+from ._shared import ensure_run_layout, load_model, load_token_list, stoi, softmax
+
+PREFIXES = ["ATG", "ATG-AAA", "ATG-GAA", "TAA"]
+TOP_K = 5
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, tables_dir = paths["run"], paths["tables"]
+
+    tokens = load_token_list(run_dir)
+    vocab = stoi(tokens)
+
+    try:
+        model, spec = load_model(run_dir)
+    except Exception as exc:
+        print(f"[probe-next] failed to load model: {exc}")
+        return
+
+    rows = []
+    for prefix in PREFIXES:
+        codons = prefix.split("-")
+        try:
+            indices = [vocab[c] for c in codons]
+        except KeyError:
+            rows.append([prefix, "NA", ""] + [""] * (2 * (TOP_K - 1)))
+            continue
+        input_ids = torch.tensor(indices, dtype=torch.long).unsqueeze(0)
+        with torch.no_grad():
+            outputs = model(input_ids)
+            if isinstance(outputs, tuple):
+                logits = outputs[0]
+            elif isinstance(outputs, dict):
+                logits = outputs["logits"]
+            else:
+                raise RuntimeError("Unexpected model output type")
+            next_logits = logits[0, -1]
+            probs = softmax(next_logits, dim=-1)
+            values, idx = torch.topk(probs, k=min(TOP_K, probs.size(0)))
+        pred_tokens = [tokens[i] if i < len(tokens) else f"tok_{i}" for i in idx.tolist()]
+        pred_probs = [f"{p:.4f}" for p in values.tolist()]
+        row = [prefix]
+        for tok, prob in zip(pred_tokens, pred_probs):
+            row.extend([tok, prob])
+        # pad to fixed width
+        while len(row) < 1 + 2 * TOP_K:
+            row.append("")
+        rows.append(row)
+
+    header = ["prefix"]
+    for k in range(1, TOP_K + 1):
+        header.extend([f"pred_{k}", f"prob_{k}"])
+
+    out_path = tables_dir / "next_token_tests.csv"
+    with out_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+    print(f"[probe-next] wrote results to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/summarize_one_cds.py
+++ b/scripts/summarize_one_cds.py
@@ -1,0 +1,90 @@
+"""Summarize one_cds__best.tsv if present."""
+from __future__ import annotations
+
+import argparse
+import csv
+from typing import Iterable, Optional
+
+import numpy as np
+
+from ._shared import ensure_run_layout
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    args = ap.parse_args(argv)
+
+    paths = ensure_run_layout(args.run_id)
+    run_dir, tables_dir = paths["run"], paths["tables"]
+
+    source = run_dir / "one_cds__best.tsv"
+    if not source.exists():
+        print(f"[one-cds] {source} missing; skipping summary")
+        return
+
+    with source.open("r", newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        rows = list(reader)
+        headers = reader.fieldnames or []
+
+    if not rows:
+        print("[one-cds] no rows to summarize")
+        return
+
+    numeric_cols = []
+    for h in headers:
+        try:
+            float(rows[0][h])
+            numeric_cols.append(h)
+        except (TypeError, ValueError):
+            continue
+
+    summaries = []
+    for col in numeric_cols:
+        values = []
+        for row in rows:
+            try:
+                values.append(float(row[col]))
+            except (TypeError, ValueError):
+                continue
+        if not values:
+            continue
+        arr = np.array(values, dtype=np.float64)
+        summaries.append(
+            {
+                "metric": col,
+                "count": arr.size,
+                "mean": float(arr.mean()),
+                "std": float(arr.std(ddof=1)) if arr.size > 1 else 0.0,
+                "min": float(arr.min()),
+                "max": float(arr.max()),
+            }
+        )
+
+    if not summaries:
+        print("[one-cds] no numeric columns found")
+        return
+
+    out_path = tables_dir / "one_cds__summary.csv"
+    with out_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["metric", "count", "mean", "std", "min", "max"])
+        for row in summaries:
+            writer.writerow(
+                [
+                    row["metric"],
+                    row["count"],
+                    f"{row['mean']:.4f}",
+                    f"{row['std']:.4f}",
+                    f"{row['min']:.4f}",
+                    f"{row['max']:.4f}",
+                ]
+            )
+
+    print(f"[one-cds] wrote summary to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a collection script that symlinks checkpoints, serializes embeddings/attention, and captures validation statistics for downstream runs
- implement analysis utilities for token frequencies, embeddings, attention, next-token probes, saliency, linear probes, run comparison, and optional CDS summaries
- document the repeatable 6-step analysis pipeline in the README for quick reuse across configurations

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68dc36a9d3848332b192bc0dd35a8c9e