### PR TITLE
[codex] Add PDB metadata enrichment pipeline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,6 +111,7 @@ All steps read `runs/<run_id>/artifacts.npz` (plus optional labels) and write ch
   * *Phase 3: Gene Essentiality Classification* - linear probing on sequence embeddings.
   * *Phase 4: Comparative Reports* - compute efficiency density reporting vs. Evo 1 and GenSLM.
 * [ ] **Hybrid DNA-Protein Critic Benchmark**: Integrate the Multi-Task Critic as a bidirectional re-feeding filter (Phase 5 of SOTA Benchmarking).
+* [ ] **Protein-Functional CodonLM Objective Track**: Add long-range multi-offset losses, whole-gene truncation audits, calibrated ProteinCritic rescoring, generated hard negatives, and a final d384/d512 ablation to test whether functional protein generation is objective-limited before scaling capacity.
 * [ ] **Protein Latent Energy-Based Model**: Implement latent Langevin dynamics and NCE training for stability design.
 * [ ] **Multi-Frame Overlapping Gene Modeling**: Sum frame-shift positional context embeddings to predict overprinted genes in viral/bacterial genomes.
 * [ ] **Training Speed & Memory Optimization**: Implement GQA, memory-mapped data loaders, and batch bucketing by length to optimize pre-training throughput.

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -90,8 +90,8 @@ This file tracks all major tracks for the project. Each track has its own detail
 
 - [ ] **Track: Structural-Aware ProteinCritic**
 *Link: [./tracks/structural_aware_protein_critic_20260616/](./tracks/structural_aware_protein_critic_20260616/)*
-*Summary: Add protein-type and foldability labels to ProteinCritic, including soluble, membrane, signal/secreted, disordered/low-complexity, short peptide, enzyme, and structure-supported classes. Also adds dynamic protein batching and masked pooling so low pLDDT can be interpreted by expected protein type.*
+*Summary: Protein-type labels, dynamic protein batching, masked pooling, safe transfer training, imbalance-aware `pos_weight`, and calibrated threshold/top-fraction evaluation are implemented. The weighted critic improves rare-label ranking but hurts raw probability calibration; keep open for generated-library rescoring and integration into selection loops.*
 
 - [ ] **Track: Long-Range CodonLM Objectives**
 *Link: [./tracks/long_range_codon_objectives_20260616/](./tracks/long_range_codon_objectives_20260616/)*
-*Summary: Add config-gated multi-offset future-token losses, denoising/recovery training, and eventually structural auxiliary/preference losses so CodonLM learns longer-range protein constraints and becomes more robust to off-distribution generation.*
+*Summary: Next active implementation target. Add config-gated multi-offset future-token losses (`+4/+8/+16/+32`), whole-gene truncation audits, generated-library rescoring with calibrated critics, hard-negative preparation, and a final d384/d512 capacity ablation only after objective/data changes are evaluated.*

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -86,4 +86,12 @@ This file tracks all major tracks for the project. Each track has its own detail
 
 - [ ] **Track: PDB-Filtered Structural Fine-Tuning**
 *Link: [./tracks/pdb_structural_finetuning_20260616/](./tracks/pdb_structural_finetuning_20260616/)*
-*Summary: Opened as the direct path toward a structural training signal. Starter filter utility, tests, and a conservative Stage 3 fine-tuning config exist; the current blocker is that Stage 2.6 CDS metadata lacks protein/gene identifiers for automatic UniProt/PDB joins, so the first supported path uses curated source line indices.*
+*Summary: Operational structural-training-signal path. Metadata enrichment and exact translated-CDS-to-UniProt structure filtering are implemented; 884/44,953 CDS were selected and the full 3-epoch Stage 3 run improved structure-subset validation loss/perplexity (4.088 → 4.068; ppl 59.75 → 58.45). Next required step is a matched ESMFold comparison to determine whether this improves pLDDT.*
+
+- [ ] **Track: Structural-Aware ProteinCritic**
+*Link: [./tracks/structural_aware_protein_critic_20260616/](./tracks/structural_aware_protein_critic_20260616/)*
+*Summary: Add protein-type and foldability labels to ProteinCritic, including soluble, membrane, signal/secreted, disordered/low-complexity, short peptide, enzyme, and structure-supported classes. Also adds dynamic protein batching and masked pooling so low pLDDT can be interpreted by expected protein type.*
+
+- [ ] **Track: Long-Range CodonLM Objectives**
+*Link: [./tracks/long_range_codon_objectives_20260616/](./tracks/long_range_codon_objectives_20260616/)*
+*Summary: Add config-gated multi-offset future-token losses, denoising/recovery training, and eventually structural auxiliary/preference losses so CodonLM learns longer-range protein constraints and becomes more robust to off-distribution generation.*

--- a/conductor/tracks/long_range_codon_objectives_20260616/plan.md
+++ b/conductor/tracks/long_range_codon_objectives_20260616/plan.md
@@ -1,0 +1,51 @@
+# Long-Range CodonLM Objectives Plan
+
+## Status
+
+Open. This track depends on the PDB-filtered structural fine-tuning results and
+will benefit from the Structural-Aware ProteinCritic labels.
+
+## Tasks
+
+- [ ] Add a config-gated multi-offset LM loss.
+- [ ] Add tests for offset target creation and end-of-sequence masking.
+- [ ] Run a tiny smoke experiment with offsets `+4`, `+16`, `+32`.
+- [ ] Compare validation loss/perplexity against standard next-token training.
+- [ ] Add generated-prefix replay or denoising corruption.
+- [ ] Evaluate whether recovery training improves termination without shortening genes.
+- [ ] Add hooks for structural auxiliary labels from ProteinCritic.
+- [ ] Build an offline preference dataset from ESMFold-scored generations.
+- [ ] Run a conservative preference-training smoke with KL/replay regularization.
+
+## Biology-Informed Priors
+
+- Helical local structure often involves nearby residues such as `i -> i+3/i+4`.
+- Medium/long-range contacts are important for fold topology, beta sheets, and cores.
+- Contact order captures average sequence separation between contacting residues; single-domain proteins commonly span a broad relative contact-order range.
+- Therefore the objective should not only predict `n+2` or `n+10`; it should combine multi-offset sequence losses with structural/foldability labels.
+
+## Initial Experiments
+
+1. **Offset-only ablation**
+   - Base: Stage 2.6 or Stage 3 checkpoint.
+   - Data: PDB-filtered subset plus general-CDS replay.
+   - Loss: next-token + weighted `+4/+16/+32`.
+
+2. **Denoising/recovery ablation**
+   - Corrupt real CDS prefixes.
+   - Train model to continue/recover valid CDS.
+   - Measure termination, length, and ProteinCritic categories.
+
+3. **Preference smoke**
+   - Use ESMFold-scored generated libraries.
+   - Prefer higher-pLDDT sequences from the same prompt.
+   - Include KL/replay to avoid diversity collapse.
+
+## Metrics
+
+- Original validation perplexity.
+- PDB-filtered validation perplexity.
+- termination rate and length distribution.
+- ProteinCritic stability and protein-type labels.
+- mean/max ESMFold pLDDT on matched top-k.
+- diversity: pairwise identity and k-mer coverage.

--- a/conductor/tracks/long_range_codon_objectives_20260616/spec.md
+++ b/conductor/tracks/long_range_codon_objectives_20260616/spec.md
@@ -1,0 +1,76 @@
+# Long-Range CodonLM Objectives Spec
+
+## Objective
+
+Teach CodonLM to represent longer-range protein constraints and recover from
+off-distribution generation, instead of relying only on next-codon prediction.
+
+## Motivation
+
+Next-token language modeling learns local codon grammar well, and our probes
+show it captures DNA electrostatic and 3D shape features. But foldable protein
+generation requires longer-range amino-acid constraints: helices, beta-sheet
+pairing, hydrophobic cores, membrane topology, domain length, contact order, and
+termination placement.
+
+Generation is also off-distribution: during training each prefix comes from a
+real biological sequence, while during sampling the model must condition on its
+own imperfect previous codons.
+
+## Candidate Objectives
+
+### Multi-Offset Future Prediction
+
+Add auxiliary prediction losses at multiple codon offsets:
+
+- `+2`
+- `+4`
+- `+8`
+- `+16`
+- `+32`
+
+This encourages hidden states to encode more than the immediate next codon.
+Offsets should be ablated; the initial safe set is `+4`, `+16`, `+32`.
+
+### Denoising / Recovery
+
+Corrupt real CDS prefixes and train the model to recover:
+
+- random synonymous swaps
+- random codon masking
+- short local codon shuffles
+- generated-prefix replay from previous weak models
+
+### Structural Auxiliary Heads
+
+Use translated proteins and external labels to predict:
+
+- protein type from Structural-Aware ProteinCritic
+- structure-supported vs not structure-supported
+- predicted foldability / pLDDT bucket
+- optional contact-order/contact-density labels when PDB-derived labels are available
+
+### Preference Or Reward Training
+
+Construct paired generations from the same prompt:
+
+- preferred: higher ESMFold pLDDT / higher foldability score
+- rejected: lower ESMFold pLDDT / disordered soluble candidate
+
+Start with offline preference loss before attempting online ESMFold REINFORCE.
+
+## Acceptance Criteria
+
+- Multi-offset loss can be enabled by config without changing default training.
+- Unit tests verify target shifting and masking near sequence ends.
+- A small ablation compares baseline next-token vs multi-offset training on validation perplexity and generation metrics.
+- Off-distribution recovery training improves termination and reduces obviously invalid continuations.
+- Structural auxiliary labels improve at least one downstream generation metric without collapsing diversity.
+
+## Risks
+
+- Multi-offset prediction may improve statistics without improving foldability.
+- Strong auxiliary losses may hurt codon dialect or DNAshape representations.
+- Reward training can collapse sequence diversity if not KL-regularized.
+
+Mitigation: use replay from general CDS data and evaluate original Stage 2.6 metrics after each experiment.

--- a/conductor/tracks/pdb_structural_finetuning_20260616/plan.md
+++ b/conductor/tracks/pdb_structural_finetuning_20260616/plan.md
@@ -16,10 +16,27 @@ ESMFold comparison remain open.
 - [x] Add automatic structure-positive filtering by exact translated CDS sequence against UniProt `Sequence` rows with `3D-structure`/PDB evidence.
 - [x] Tokenize and pack the filtered subset with `block_size=512`.
 - [x] Run a one-epoch smoke fine-tune and compare with the structured-prefix + ESMFold harness.
-- [ ] Run the full 3-epoch fine-tune.
-- [ ] Run a larger matched ESMFold comparison against Stage 2.6 and the structured-generation prefix baseline.
+- [x] Run the full 3-epoch fine-tune.
+- [x] Run a larger matched comparison against Stage 2.6 (critic-scored prefix benchmarks).
+- [ ] Run a matched ESMFold comparison (pending network-based structure prediction).
 
-## Initial Commands
+## Results (3-Epoch Full Fine-Tune)
+
+- Run id: `2026-06-16_stage3_10L8H_d384_e3`
+- Validation loss: 4.0681 (Baseline 2.6: 4.088)
+- Validation perplexity: 58.45 (Baseline 2.6: 59.75)
+- Mean ProteinCritic stability (prefixes): 0.572 (Baseline 2.6: 0.573)
+- Mean Pfam Family confidence: 0.0478 (Baseline 2.6: 0.0458)
+- Summary: The fine-tune successfully lowered validation loss/perplexity on the structure-positive subset. While sequence-based ProteinCritic stability remains stable, Pfam family confidence shows a slight upward trend. Structural validation (ESMFold) is the next definitive step.
+
+| Metric (Prefixes) | Stage 2.6 Baseline | Stage 3 Fine-Tune |
+|---|---:|---:|
+| Median GQS (k=1) | 23.90 | 24.53 |
+| Mean stability_prob | 0.573 | 0.572 |
+| Mean Pfam confidence | 0.0458 | 0.0478 |
+
+## Reproduction Commands
+
 
 ```bash
 python -m scripts.filter_cds_by_pdb \
@@ -56,7 +73,7 @@ Train with:
 python -m src.codonlm.train_codon_lm --config configs/stage3_structured_pdb_finetune.yaml
 ```
 
-## Smoke Results
+## One-Epoch Smoke Results
 
 - Filtered subset: 884 / 44,953 CDS exact translated-protein matches to structured UniProt rows.
 - Packed windows: 728 train, 100 val, 56 test at `block_size=512`.

--- a/conductor/tracks/pdb_structural_finetuning_20260616/plan.md
+++ b/conductor/tracks/pdb_structural_finetuning_20260616/plan.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Open. Starter implementation added; no training run has been launched yet.
+Open. Metadata enrichment and sequence-based UniProt filtering are implemented.
+A one-epoch smoke fine-tune completed successfully; a full fine-tune and larger
+ESMFold comparison remain open.
 
 ## Tasks
 
@@ -10,10 +12,12 @@ Open. Starter implementation added; no training run has been launched yet.
 - [x] Add a CDS filtering utility that can prepare a structure-enriched subset from curated source line indices.
 - [x] Add regression tests for the filtering utility.
 - [x] Add a conservative Stage 3 fine-tuning config based on the best current `10L8H_d384` checkpoint.
-- [ ] Enrich CDS extraction metadata with protein IDs, locus tags, and product/gene names so UniProt/PDB matching can be automated.
-- [ ] Build a curated structure-positive line-index list from PDB/UniProt evidence.
-- [ ] Tokenize and pack the filtered subset with `block_size=512`.
-- [ ] Run the fine-tune and compare against Stage 2.6 using the structured-prefix and ESMFold evaluation harnesses.
+- [x] Enrich CDS extraction metadata with protein IDs, locus tags, gene names, product names, translations, db_xref, coordinates, and strand.
+- [x] Add automatic structure-positive filtering by exact translated CDS sequence against UniProt `Sequence` rows with `3D-structure`/PDB evidence.
+- [x] Tokenize and pack the filtered subset with `block_size=512`.
+- [x] Run a one-epoch smoke fine-tune and compare with the structured-prefix + ESMFold harness.
+- [ ] Run the full 3-epoch fine-tune.
+- [ ] Run a larger matched ESMFold comparison against Stage 2.6 and the structured-generation prefix baseline.
 
 ## Initial Commands
 
@@ -21,15 +25,47 @@ Open. Starter implementation added; no training run has been launched yet.
 python -m scripts.filter_cds_by_pdb \
   --dna data/processed/stage2.6_large_master_dna.txt \
   --meta data/processed/stage2.6_large_master_meta.tsv \
-  --structured_line_indices data/processed/structured_pdb/line_indices.txt \
+  --uniprot_tsv data/raw/uniprot_bacteria_50_512.tsv \
   --out_dir data/processed/structured_pdb
 ```
 
-After filtering, tokenize and pack the subset with the existing codon tokenization and dataset builders, then train with:
+After filtering, tokenize and pack the subset:
+
+```bash
+python -m src.codonlm.codon_tokenize \
+  --inp data/processed/structured_pdb/cds_dna.txt \
+  --out_ids data/processed/structured_pdb/codon_ids.txt \
+  --out_vocab data/processed/structured_pdb/vocab_codon.txt \
+  --out_itos data/processed/structured_pdb/itos_codon.txt \
+  --termination eos
+
+python -m src.codonlm.build_dataset \
+  --ids data/processed/structured_pdb/codon_ids.txt \
+  --group_meta data/processed/structured_pdb/cds_meta.tsv \
+  --block_size 512 \
+  --windows_per_seq 1 \
+  --val_frac 0.1 \
+  --test_frac 0.1 \
+  --out_dir data/processed/structured_pdb_pack \
+  --pack_mode single
+```
+
+Train with:
 
 ```bash
 python -m src.codonlm.train_codon_lm --config configs/stage3_structured_pdb_finetune.yaml
 ```
+
+## Smoke Results
+
+- Filtered subset: 884 / 44,953 CDS exact translated-protein matches to structured UniProt rows.
+- Packed windows: 728 train, 100 val, 56 test at `block_size=512`.
+- One-epoch smoke run: `runs/stage3_structured_pdb_smoke2`.
+- Smoke validation: `val_loss=4.0701`, `ppl=58.564`.
+- Structured-prefix smoke: 6 generated continuations, 0/6 terminated, mean ProteinCritic stability `0.572`, max `0.575`.
+- ESMFold top-3 pLDDT: `0.354`, `0.418`, `0.435`.
+
+The smoke verifies that the structural subset and fine-tuning loop work, but it does not yet show a pLDDT improvement over the prior structured-prefix baseline. A larger/full fine-tune is still needed before drawing a strong conclusion.
 
 ## Notes
 

--- a/conductor/tracks/pdb_structural_finetuning_20260616/smoke_report.md
+++ b/conductor/tracks/pdb_structural_finetuning_20260616/smoke_report.md
@@ -1,0 +1,59 @@
+# PDB-Filtered Structural Fine-Tuning Smoke Report
+
+## Summary
+
+Implemented the first usable structural training-signal path for CodonLM:
+
+- CDS extraction now preserves protein/gene metadata for future corpora.
+- Current Stage 2.6 CDS can be filtered immediately by exact translated protein sequence against UniProt structured-protein rows.
+- A one-epoch Stage 3 smoke fine-tune completed from the Stage 2.6 `10L8H_d384` checkpoint.
+
+## Dataset
+
+Command:
+
+```bash
+python -m scripts.filter_cds_by_pdb \
+  --dna data/processed/stage2.6_large_master_dna.txt \
+  --meta data/processed/stage2.6_large_master_meta.tsv \
+  --uniprot_tsv data/raw/uniprot_bacteria_50_512.tsv \
+  --out_dir data/processed/structured_pdb
+```
+
+Result:
+
+- Source CDS: 44,953
+- Structure-positive exact translated-protein matches: 884
+- Packed windows: 728 train, 100 val, 56 test
+
+## Fine-Tune
+
+The Stage 3 config was corrected to match the transfer checkpoint architecture. The current Stage 2.6 checkpoint uses full multi-head attention key/value tensors, so the fine-tune config must not set `n_kv_head: 4`.
+
+Smoke run:
+
+- Run id: `stage3_structured_pdb_smoke2`
+- Epochs: 1
+- Validation loss: 4.0701
+- Validation perplexity: 58.564
+
+## Generation And Structure Check
+
+Structured-prefix smoke:
+
+- 6 continuations from DHFR/FolA, TEM-1 beta-lactamase, and TPI/TIM-barrel-like prefixes
+- 0/6 naturally terminated
+- Mean ProteinCritic stability: 0.572
+- Max ProteinCritic stability: 0.575
+
+ESMFold top-3:
+
+| rank | prefix | stability | pLDDT |
+|---:|---|---:|---:|
+| 1 | dhfr_folA | 0.575 | 0.354 |
+| 2 | tpiA | 0.575 | 0.418 |
+| 3 | dhfr_folA | 0.572 | 0.435 |
+
+## Interpretation
+
+The smoke validates the full technical path: structure-positive subset creation, packing, fine-tuning, generation, and ESMFold submission. The one-epoch smoke does not yet improve pLDDT over the previous structured-prefix baseline, so the next evidence step is a full 3-epoch fine-tune plus a matched ESMFold comparison at the same sample size as the earlier structured-prefix experiment.

--- a/conductor/tracks/structural_aware_protein_critic_20260616/plan.md
+++ b/conductor/tracks/structural_aware_protein_critic_20260616/plan.md
@@ -1,0 +1,42 @@
+# Structural-Aware ProteinCritic Plan
+
+## Status
+
+Open. This is the next critic-side track after PDB-filtered structural fine-tuning.
+
+## Tasks
+
+- [ ] Define the first protein-type label schema from UniProt columns.
+- [ ] Implement `scripts/prepare_protein_type_dataset.py` from local UniProt TSVs.
+- [ ] Add dynamic length bucketing and a protein collate function.
+- [ ] Update ProteinCritic models to accept `attention_mask`.
+- [ ] Replace naive pooling with masked pooling.
+- [ ] Add multi-label protein-type heads.
+- [ ] Add tests for label extraction, bucketing, dynamic padding, and masked pooling.
+- [ ] Train a first structural-aware ProteinCritic.
+- [ ] Add generation-loop reporting for protein type and foldability.
+- [ ] Compare generated sequence categories before/after PDB-filtered CodonLM fine-tuning.
+
+## Initial Dataset Sources
+
+- `data/raw/uniprot_bacteria_50_512.tsv`
+- Existing ProteinCritic multitask data, if available locally.
+- Generated libraries from:
+  - `outputs/reports/structured_prefix_experiment/`
+  - `outputs/reports/stage3_structured_pdb_smoke_prefix/`
+
+## Evaluation
+
+Report per-label:
+
+- prevalence
+- accuracy
+- macro/micro F1
+- AUROC where positive and negative classes both exist
+- calibration of soluble/foldable predictions against ESMFold pLDDT
+
+## Notes
+
+Do not treat low ESMFold pLDDT as universally bad until the critic knows whether
+the sequence is expected to be soluble, membrane, secreted, peptide-like, or
+disordered.

--- a/conductor/tracks/structural_aware_protein_critic_20260616/plan.md
+++ b/conductor/tracks/structural_aware_protein_critic_20260616/plan.md
@@ -2,20 +2,34 @@
 
 ## Status
 
-Open. This is the next critic-side track after PDB-filtered structural fine-tuning.
+Open. First implementation pass is complete: UniProt protein-type dataset
+preparation, dynamic collation, length bucketing, masked pooling, and a starter
+config are implemented and tested. Training the first structural-aware critic is
+still open.
 
 ## Tasks
 
-- [ ] Define the first protein-type label schema from UniProt columns.
-- [ ] Implement `scripts/prepare_protein_type_dataset.py` from local UniProt TSVs.
-- [ ] Add dynamic length bucketing and a protein collate function.
-- [ ] Update ProteinCritic models to accept `attention_mask`.
-- [ ] Replace naive pooling with masked pooling.
-- [ ] Add multi-label protein-type heads.
-- [ ] Add tests for label extraction, bucketing, dynamic padding, and masked pooling.
+- [x] Define the first protein-type label schema from UniProt columns.
+- [x] Implement `scripts/prepare_protein_type_dataset.py` from local UniProt TSVs.
+- [x] Add dynamic length bucketing and a protein collate function.
+- [x] Update ProteinCritic models to accept `attention_mask`.
+- [x] Replace naive pooling with masked pooling.
+- [x] Add multi-label protein-type heads.
+- [x] Add tests for label extraction, bucketing, dynamic padding, and masked pooling.
 - [ ] Train a first structural-aware ProteinCritic.
 - [ ] Add generation-loop reporting for protein type and foldability.
 - [ ] Compare generated sequence categories before/after PDB-filtered CodonLM fine-tuning.
+
+## Implementation Notes
+
+- Dataset builder:
+  ```bash
+  python -m scripts.prepare_protein_type_dataset \
+    --uniprot_tsv data/raw/uniprot_bacteria_50_512.tsv \
+    --out_dir data/processed/protein_lm/protein_type
+  ```
+- Local dataset build produced 261,968 train and 29,107 validation samples.
+- Starter config: `configs/protein_critic_structural.yaml`.
 
 ## Initial Dataset Sources
 

--- a/conductor/tracks/structural_aware_protein_critic_20260616/spec.md
+++ b/conductor/tracks/structural_aware_protein_critic_20260616/spec.md
@@ -1,0 +1,59 @@
+# Structural-Aware ProteinCritic Spec
+
+## Objective
+
+Extend ProteinCritic from a family/function/stability scorer into a structural
+triage model that can distinguish soluble folded proteins, membrane proteins,
+signal peptides, low-complexity/disordered proteins, short peptides, and
+structure-supported proteins.
+
+## Motivation
+
+The current ProteinCritic can provide useful stability and family signals, but
+generated CodonLM sequences still score low under ESMFold and often look novel
+or disordered. Low pLDDT is not always equivalent to a bad biological product:
+membrane helices, signal peptides, short peptides, and intrinsically disordered
+regions can all be biologically real while scoring poorly as compact soluble
+folds.
+
+Before using ProteinCritic as a stronger training or filtering signal, it needs
+to answer a more basic question: what kind of protein is this sequence expected
+to encode?
+
+## Proposed Labels
+
+Initial multi-label targets should be derived from local UniProt columns:
+
+- `structured_pdb`: UniProt row has `3D-structure` or PDB evidence.
+- `membrane`: keywords/features/location mention membrane or transmembrane.
+- `signal_secreted`: features/location mention signal peptide, secreted, or periplasmic.
+- `disordered_low_complexity`: features mention region, repeat, low complexity, coiled coil, or disorder-related annotations.
+- `enzyme`: EC number is present.
+- `short_peptide`: amino-acid length below a chosen threshold, initially `< 50 aa`.
+- `soluble_candidate`: no membrane/signal/disorder flag and length is in a normal folded-domain range.
+
+These should be multi-label, not mutually exclusive. A protein can be both a
+membrane protein and an enzyme.
+
+## Model/Data Changes
+
+- Add a dataset builder that converts UniProt rows into multi-label targets.
+- Add ProteinCritic heads for protein type and foldability.
+- Add dynamic collation and length bucketing for protein batches.
+- Use masked pooling so padding does not contaminate sequence embeddings.
+- Preserve existing Pfam, EC, and stability heads.
+
+## Acceptance Criteria
+
+- ProteinCritic can train with variable-length batches and an attention mask.
+- Unit tests cover dynamic collation, masked pooling, and multi-label target creation.
+- A first classifier report includes AUROC/F1 for membrane, signal/secreted, enzyme, short-peptide, and structure-supported labels.
+- The generation loop can report protein type predictions alongside family, EC, and stability.
+
+## Downstream Use
+
+This track feeds the next generation-control stage:
+
+- Reject “bad fold” only when the target class is expected to be soluble/folded.
+- Route membrane or peptide-like generations to different evaluation criteria.
+- Create foldability labels for CodonLM preference/reward training.

--- a/configs/protein_critic_structural.yaml
+++ b/configs/protein_critic_structural.yaml
@@ -1,0 +1,27 @@
+# Structural-aware ProteinCritic starter config.
+#
+# Prepare data first:
+#   python -m scripts.prepare_protein_type_dataset \
+#     --uniprot_tsv data/raw/uniprot_bacteria_50_512.tsv \
+#     --out_dir data/processed/protein_lm/protein_type
+
+device: cpu
+train_data: data/processed/protein_lm/protein_type/train.jsonl
+val_data: data/processed/protein_lm/protein_type/val.jsonl
+task_vocabs: data/processed/protein_lm/protein_type/task_vocabs.json
+
+block_size: 512
+n_layer: 4
+n_head: 4
+n_embd: 128
+dropout: 0.1
+
+batch_size: 16
+grad_accum_steps: 4
+epochs: 5
+lr: 0.0001
+max_time_minutes: 240
+
+dynamic_padding: true
+multi_label_tasks:
+  - protein_type

--- a/configs/protein_critic_structural_transfer.yaml
+++ b/configs/protein_critic_structural_transfer.yaml
@@ -1,0 +1,31 @@
+# Structural-aware ProteinCritic initialized from the latest ProteinCritic backbone.
+#
+# This intentionally writes to a new run_id. The source checkpoint remains a
+# rollback point and is never overwritten by transfer training.
+#
+# Prepare data first:
+#   python -m scripts.prepare_protein_type_dataset \
+#     --uniprot_tsv data/raw/uniprot_bacteria_50_512.tsv \
+#     --out_dir data/processed/protein_lm/protein_type
+
+device: cpu
+train_data: data/processed/protein_lm/protein_type/train.jsonl
+val_data: data/processed/protein_lm/protein_type/val.jsonl
+task_vocabs: data/processed/protein_lm/protein_type/task_vocabs.json
+transfer_from: runs/protein_critic/checkpoints/best_critic.pt
+
+block_size: 512
+n_layer: 8
+n_head: 8
+n_embd: 256
+dropout: 0.1
+
+batch_size: 8
+grad_accum_steps: 8
+epochs: 5
+lr: 0.00005
+max_time_minutes: 240
+
+dynamic_padding: true
+multi_label_tasks:
+  - protein_type

--- a/configs/protein_critic_structural_transfer.yaml
+++ b/configs/protein_critic_structural_transfer.yaml
@@ -25,6 +25,10 @@ grad_accum_steps: 8
 epochs: 5
 lr: 0.00005
 max_time_minutes: 240
+log_every_steps: 100
+checkpoint_every_steps: 1000
+multi_label_pos_weight: auto
+multi_label_pos_weight_max: 100
 
 dynamic_padding: true
 multi_label_tasks:

--- a/configs/stage3_structured_pdb_finetune.yaml
+++ b/configs/stage3_structured_pdb_finetune.yaml
@@ -9,7 +9,6 @@ vocab_size: 69
 block_size: 512
 n_layer: 10
 n_head: 8
-n_kv_head: 4
 n_embd: 384
 dropout: 0.1
 label_smoothing: 0.05
@@ -24,8 +23,8 @@ train_npz: "data/processed/structured_pdb_pack/train_bs512.npz"
 val_npz: "data/processed/structured_pdb_pack/val_bs512.npz"
 test_npz: "data/processed/structured_pdb_pack/test_bs512.npz"
 
-batch_size: 8
-grad_accum_steps: 16
+batch_size: 4
+grad_accum_steps: 32
 epochs: 3
 lr: 0.00001
 min_lr: 0.000001

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -328,5 +328,16 @@ Our local models deliver orders of magnitude higher performance density per para
     *   **ESMFold:** 30/30 submissions succeeded; mean pLDDT = 0.317, median = 0.320, max = 0.383, and 0/30 exceeded 0.7. Prefix prompting did not produce confident folds.
     *   **Next structural signal:** opened the PDB-Filtered Structural Fine-Tuning track with a subset filter and Stage 3 config. This is the direct route to teach the generator a foldable-protein distribution rather than only filtering after sampling.
 
+*   **Stage 12 Addendum — Structural-Aware ProteinCritic Calibration (2026-06-17):**
+    *   Added a safe structural-critic transfer path from the existing multi-task ProteinCritic checkpoint into the protein-type head, preserving compatible backbone weights while skipping incompatible task heads.
+    *   Trained a first structural-aware critic on Apple M2/MPS with `batch_size=4`, dynamic padding, and class-imbalance-aware `pos_weight` for rare labels such as `structured_pdb`, `signal_secreted`, and `disordered_low_complexity`.
+    *   Extended [`scripts/eval_multi_task_critic.py`](file:///Users/User/github/genomics-lm/scripts/eval_multi_task_critic.py) to report multi-label AP/AUC, threshold curves, and top-fraction enrichment instead of relying on a single hard `0.5` threshold.
+    *   **Result:** `pos_weight` improved rare-label ranking for `membrane`, `signal_secreted`, `disordered_low_complexity`, and slightly for `structured_pdb`, but worsened raw probability calibration. This means the weighted critic is better as a ranking/filtering tool than as a literal probability estimator.
+    *   **Operational conclusion:** Use calibrated top-k/top-fraction selection rules by label. `structured_pdb` remains too weak to be trusted as the primary foldability signal; PDB-filtered generator fine-tuning and matched ESMFold validation remain necessary.
+
+*   **Stage 12 Addendum — Protein-Functional CodonLM Objective Decision (2026-06-17):**
+    *   The failure mode is now framed as an objective/data mismatch, not just a capacity problem. CodonLM learns gene-like DNA and local codon grammar, but next-codon loss alone does not explicitly reward a translated protein that is folded, family-like, or biologically functional.
+    *   The next implementation track is the open **Long-Range CodonLM Objectives** track: add multi-offset future-token losses (`+4/+8/+16/+32`), audit whole-gene coverage and truncation, rescore generated libraries with calibrated critics, prepare hard negatives, and only then run a controlled `d384` vs. `d512` capacity ablation.
+
 ---
 *End of Log*

--- a/scripts/eval_multi_task_critic.py
+++ b/scripts/eval_multi_task_critic.py
@@ -3,12 +3,89 @@ import json
 import argparse
 import yaml
 import os
+import numpy as np
 from src.protein_lm.tokenizer import ProteinTokenizer
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
 from src.protein_lm.config import ProteinClassifierConfig
-from src.protein_lm.train_multi_task import MultiTaskProteinDataset
+from src.protein_lm.train_multi_task import (
+    LengthBucketBatchSampler,
+    MultiTaskProteinDataset,
+    collate_protein_batch,
+)
 from torch.utils.data import DataLoader
-from sklearn.metrics import accuracy_score, classification_report
+from sklearn.metrics import (
+    accuracy_score,
+    average_precision_score,
+    classification_report,
+    precision_recall_fscore_support,
+    roc_auc_score,
+)
+
+
+def _device(name):
+    if name != "auto":
+        return torch.device(name)
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def _ordered_vocab(vocab):
+    return [name for name, _ in sorted(vocab.items(), key=lambda item: item[1])]
+
+
+def _safe_float(value):
+    if value is None or np.isnan(value):
+        return None
+    return float(value)
+
+
+def parse_float_list(value):
+    return [float(item.strip()) for item in value.split(",") if item.strip()]
+
+
+def threshold_metrics(y_true, y_prob, thresholds):
+    rows = []
+    for threshold in thresholds:
+        pred = y_prob >= threshold
+        precision, recall, f1, _ = precision_recall_fscore_support(
+            y_true, pred, average="binary", zero_division=0
+        )
+        rows.append(
+            {
+                "threshold": float(threshold),
+                "precision": float(precision),
+                "recall": float(recall),
+                "f1": float(f1),
+                "predicted_fraction": float(pred.mean()),
+            }
+        )
+    return rows
+
+
+def top_fraction_enrichment(y_true, y_prob, fractions):
+    rows = []
+    prevalence = float(y_true.mean())
+    order = np.argsort(-y_prob)
+    for fraction in fractions:
+        k = max(1, int(np.ceil(len(y_true) * fraction)))
+        selected = y_true[order[:k]]
+        selected_positive_rate = float(selected.mean())
+        enrichment = (
+            selected_positive_rate / prevalence if prevalence > 0.0 else np.nan
+        )
+        rows.append(
+            {
+                "fraction": float(fraction),
+                "k": int(k),
+                "positive_rate": selected_positive_rate,
+                "enrichment": _safe_float(enrichment),
+                "positives": int(selected.sum()),
+            }
+        )
+    return rows
 
 
 def main():
@@ -22,13 +99,33 @@ def main():
     parser.add_argument(
         "--val_data", default="data/processed/protein_lm/multitask/val.jsonl"
     )
+    parser.add_argument("--task_vocabs", default=None, help="Optional task vocab JSON")
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--device", default="auto", help="auto, cpu, mps, or cuda")
+    parser.add_argument("--out_json", default=None, help="Optional path for metrics JSON")
+    parser.add_argument(
+        "--thresholds",
+        default="0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9",
+        help="Comma-separated thresholds for multi-label calibration metrics",
+    )
+    parser.add_argument(
+        "--top_fractions",
+        default="0.01,0.05,0.1",
+        help="Comma-separated validation fractions for top-k enrichment metrics",
+    )
     args = parser.parse_args()
+    thresholds = parse_float_list(args.thresholds)
+    top_fractions = parse_float_list(args.top_fractions)
 
     # Load YAML configuration if it exists
     cfg = {}
     if os.path.exists(args.config):
         with open(args.config, "r") as f:
             cfg = yaml.safe_load(f)
+    if args.val_data == parser.get_default("val_data") and cfg.get("val_data"):
+        args.val_data = cfg["val_data"]
+    if args.task_vocabs is None:
+        args.task_vocabs = cfg.get("task_vocabs")
 
     tokenizer = ProteinTokenizer()
     state = torch.load(args.ckpt, map_location="cpu")
@@ -43,6 +140,19 @@ def main():
         task_dims["function"] = state_dict["heads.function.weight"].shape[0]
     if "heads.stability.weight" in state_dict:
         task_dims["stability"] = state_dict["heads.stability.weight"].shape[0]
+    multi_label_tasks = list(cfg.get("multi_label_tasks", []))
+    for task in multi_label_tasks:
+        key = f"heads.{task}.weight"
+        if key in state_dict:
+            task_dims[task] = state_dict[key].shape[0]
+
+    vocab_labels = {}
+    if args.task_vocabs:
+        with open(args.task_vocabs, "r") as f:
+            vocabs = json.load(f)
+        for task in multi_label_tasks:
+            if task in vocabs:
+                vocab_labels[task] = _ordered_vocab(vocabs[task])
 
     model_cfg = ProteinClassifierConfig(
         vocab_size=len(tokenizer.vocab),
@@ -56,27 +166,54 @@ def main():
 
     model = MultiTaskProteinClassifier(model_cfg, task_dims)
     model.load_state_dict(state_dict, strict=False)
+    device = _device(args.device)
+    model.to(device)
     model.eval()
 
     val_ds = MultiTaskProteinDataset(
-        args.val_data, tokenizer, max_length=model_cfg.block_size
+        args.val_data,
+        tokenizer,
+        max_length=model_cfg.block_size,
+        dynamic_padding=bool(cfg.get("dynamic_padding", False)),
+        multi_label_tasks=multi_label_tasks,
     )
-    loader = DataLoader(val_ds, batch_size=16, shuffle=False)
+    if cfg.get("dynamic_padding", False):
+        loader = DataLoader(
+            val_ds,
+            batch_sampler=LengthBucketBatchSampler(
+                val_ds, args.batch_size, shuffle=False
+            ),
+            collate_fn=lambda batch: collate_protein_batch(
+                batch, tokenizer.pad_token_id
+            ),
+        )
+    else:
+        loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False)
 
     results = {
         task: {"preds": [], "targets": [], "top5": [], "top10": []}
         for task in task_dims
+        if task not in multi_label_tasks
     }
+    multi_label_results = {
+        task: {"targets": [], "probs": []} for task in multi_label_tasks
+    }
+    bce = torch.nn.BCEWithLogitsLoss(reduction="sum")
+    bce_sum = {task: 0.0 for task in multi_label_tasks}
+    bce_items = {task: 0 for task in multi_label_tasks}
 
     with torch.no_grad():
         for batch in loader:
-            input_ids = batch["input_ids"]
-            logits_dict = model(input_ids)
-            for task in task_dims:
+            input_ids = batch["input_ids"].to(device)
+            attention_mask = batch.get("attention_mask")
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(device)
+            logits_dict = model(input_ids, attention_mask=attention_mask)
+            for task in results:
                 targets = batch[task]
                 mask = targets != -1
                 if mask.any():
-                    logits = logits_dict[task][mask]
+                    logits = logits_dict[task].cpu()[mask]
                     gold = targets[mask]
 
                     # Top-1
@@ -96,8 +233,22 @@ def main():
 
                     results[task]["top5"].extend(has_top5)
                     results[task]["top10"].extend(has_top10)
+            for task in multi_label_tasks:
+                if task not in logits_dict:
+                    continue
+                targets = batch[task].to(device)
+                logits = logits_dict[task]
+                bce_sum[task] += bce(logits, targets).item()
+                bce_items[task] += targets.numel()
+                multi_label_results[task]["targets"].append(targets.cpu().numpy())
+                multi_label_results[task]["probs"].append(
+                    torch.sigmoid(logits).cpu().numpy()
+                )
 
+    summary = {"single_label": {}, "multi_label": {}}
     for task in task_dims:
+        if task in multi_label_tasks:
+            continue
         y_true = results[task]["targets"]
         y_pred = results[task]["preds"]
         if len(y_true) > 0:
@@ -111,10 +262,97 @@ def main():
                 top10_acc = sum(results[task]["top10"]) / len(y_true)
                 print(f"  Top-5 Accuracy: {top5_acc:.4f}")
                 print(f"  Top-10 Accuracy: {top10_acc:.4f}")
+            summary["single_label"][task] = {
+                "samples": len(y_true),
+                "top1_accuracy": float(acc),
+            }
             print("--------------------------------------------------")
             print(classification_report(y_true, y_pred, zero_division=0))
         else:
             print(f"Task: {task} has no valid validation samples.")
+
+    for task, data in multi_label_results.items():
+        if not data["targets"]:
+            print(f"Task: {task} has no valid validation samples.")
+            continue
+        y_true = np.concatenate(data["targets"], axis=0)
+        y_prob = np.concatenate(data["probs"], axis=0)
+        labels = vocab_labels.get(task, [str(i) for i in range(y_true.shape[1])])
+        task_bce = bce_sum[task] / max(bce_items[task], 1)
+        prevalence = y_true.mean(axis=0)
+        clipped = np.clip(prevalence, 1e-6, 1 - 1e-6)
+        baseline_bce = -np.mean(
+            y_true * np.log(clipped) + (1 - y_true) * np.log(1 - clipped)
+        )
+        print("==================================================")
+        print(f"Task: {task}")
+        print(f"  Samples evaluated: {y_true.shape[0]}")
+        print(f"  BCE Loss: {task_bce:.4f}")
+        print(f"  Prevalence BCE baseline: {baseline_bce:.4f}")
+        summary["multi_label"][task] = {
+            "samples": int(y_true.shape[0]),
+            "bce": float(task_bce),
+            "prevalence_bce_baseline": float(baseline_bce),
+            "labels": {},
+        }
+        print("--------------------------------------------------")
+        print("label,prevalence,mean_prob,ap,roc_auc,precision@0.5,recall@0.5,f1@0.5")
+        for i, label in enumerate(labels):
+            yt = y_true[:, i]
+            yp = y_prob[:, i]
+            if yt.min() == yt.max():
+                ap = np.nan
+                auc = np.nan
+            else:
+                ap = average_precision_score(yt, yp)
+                auc = roc_auc_score(yt, yp)
+            pred = yp >= 0.5
+            precision, recall, f1, _ = precision_recall_fscore_support(
+                yt, pred, average="binary", zero_division=0
+            )
+            print(
+                f"{label},{yt.mean():.4f},{yp.mean():.4f},"
+                f"{ap:.4f},{auc:.4f},{precision:.4f},{recall:.4f},{f1:.4f}"
+            )
+            threshold_rows = threshold_metrics(yt, yp, thresholds)
+            enrichment_rows = top_fraction_enrichment(yt, yp, top_fractions)
+            print("  thresholds:")
+            for row in threshold_rows:
+                print(
+                    "    "
+                    f"t={row['threshold']:.2f},"
+                    f"precision={row['precision']:.4f},"
+                    f"recall={row['recall']:.4f},"
+                    f"f1={row['f1']:.4f},"
+                    f"predicted_fraction={row['predicted_fraction']:.4f}"
+                )
+            print("  top_fraction_enrichment:")
+            for row in enrichment_rows:
+                enrichment = row["enrichment"]
+                enrichment_text = "nan" if enrichment is None else f"{enrichment:.2f}"
+                print(
+                    "    "
+                    f"top={row['fraction']:.2%},"
+                    f"k={row['k']},"
+                    f"positive_rate={row['positive_rate']:.4f},"
+                    f"enrichment={enrichment_text}x,"
+                    f"positives={row['positives']}"
+                )
+            summary["multi_label"][task]["labels"][label] = {
+                "prevalence": float(yt.mean()),
+                "mean_probability": float(yp.mean()),
+                "average_precision": _safe_float(ap),
+                "roc_auc": _safe_float(auc),
+                "precision_at_0_5": float(precision),
+                "recall_at_0_5": float(recall),
+                "f1_at_0_5": float(f1),
+                "thresholds": threshold_rows,
+                "top_fraction_enrichment": enrichment_rows,
+            }
+
+    if args.out_json:
+        with open(args.out_json, "w") as f:
+            json.dump(summary, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/scripts/filter_cds_by_pdb.py
+++ b/scripts/filter_cds_by_pdb.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Prepare a CDS subset for PDB/structure-focused fine-tuning.
 
-The current Stage 2.6 CDS metadata only contains ``line_idx`` and ``genome``.
-That is enough to filter by explicit curated line indices, but not enough to
-automatically join to UniProt/PDB metadata. This script supports the line-index
-path now and validates metadata joins so future enriched metadata fails loudly
-instead of producing a misleading empty subset.
+The preferred path is an exact translated-protein sequence match against a
+local UniProt TSV containing a ``Sequence`` column and structure evidence
+(``3D-structure`` keyword). Explicit curated line-index filters are still
+supported for manual experiments.
 """
 
 from __future__ import annotations
@@ -19,6 +18,25 @@ from typing import Iterable
 
 
 DEFAULT_JOIN_KEYS = ("protein_id", "locus_tag", "gene", "gene_name", "entry")
+
+CODON_TABLE = {
+    "TTT": "F", "TTC": "F", "TTA": "L", "TTG": "L",
+    "TCT": "S", "TCC": "S", "TCA": "S", "TCG": "S",
+    "TAT": "Y", "TAC": "Y", "TAA": "*", "TAG": "*",
+    "TGT": "C", "TGC": "C", "TGA": "*", "TGG": "W",
+    "CTT": "L", "CTC": "L", "CTA": "L", "CTG": "L",
+    "CCT": "P", "CCC": "P", "CCA": "P", "CCG": "P",
+    "CAT": "H", "CAC": "H", "CAA": "Q", "CAG": "Q",
+    "CGT": "R", "CGC": "R", "CGA": "R", "CGG": "R",
+    "ATT": "I", "ATC": "I", "ATA": "I", "ATG": "M",
+    "ACT": "T", "ACC": "T", "ACA": "T", "ACG": "T",
+    "AAT": "N", "AAC": "N", "AAA": "K", "AAG": "K",
+    "AGT": "S", "AGC": "S", "AGA": "R", "AGG": "R",
+    "GTT": "V", "GTC": "V", "GTA": "V", "GTG": "V",
+    "GCT": "A", "GCC": "A", "GCA": "A", "GCG": "A",
+    "GAT": "D", "GAC": "D", "GAA": "E", "GAG": "E",
+    "GGT": "G", "GGC": "G", "GGA": "G", "GGG": "G",
+}
 
 
 @dataclass(frozen=True)
@@ -42,6 +60,21 @@ def read_tsv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
         if reader.fieldnames is None:
             raise ValueError(f"{path} has no header")
         return list(reader.fieldnames), list(reader)
+
+
+def translate_dna(dna: str) -> str:
+    """Translate DNA with the standard bacterial CDS convention."""
+    dna = dna.strip().upper().replace("U", "T")
+    aa: list[str] = []
+    for i in range(0, (len(dna) // 3) * 3, 3):
+        codon = dna[i : i + 3]
+        residue = CODON_TABLE.get(codon)
+        if residue is None:
+            return ""
+        if residue == "*":
+            break
+        aa.append(residue)
+    return "".join(aa)
 
 
 def read_line_indices(path: Path) -> set[int]:
@@ -90,19 +123,65 @@ def validate_join_keys(meta_header: list[str], uniprot_header: list[str]) -> Non
     meta_cols = {col.lower() for col in meta_header}
     uniprot_cols = {col.lower() for col in uniprot_header}
     usable_meta = sorted(meta_cols.intersection(DEFAULT_JOIN_KEYS))
-    usable_uniprot = sorted(uniprot_cols.intersection({"entry", "gene names", "gene names (primary)"}))
-    if not usable_meta:
+    has_sequence = "sequence" in uniprot_cols
+    usable_uniprot = sorted(
+        uniprot_cols.intersection({"entry", "gene names", "gene names (primary)", "sequence"})
+    )
+    if not usable_meta and not has_sequence:
         raise ValueError(
-            "Cannot auto-filter by UniProt/PDB yet: CDS metadata has no protein/gene "
-            f"join key. Found metadata columns: {', '.join(meta_header)}. "
-            "Re-run extraction with protein_id, locus_tag, or gene annotations, or "
-            "provide --structured_line_indices."
+            "Cannot auto-filter by UniProt/PDB: CDS metadata has no protein/gene "
+            "join key and UniProt TSV has no Sequence column. "
+            f"Found metadata columns: {', '.join(meta_header)}."
         )
     if not usable_uniprot:
         raise ValueError(
-            "UniProt TSV does not expose a supported join key. Expected Entry or "
+            "UniProt TSV does not expose a supported join key. Expected Sequence, Entry, or "
             f"Gene Names; found: {', '.join(uniprot_header)}."
         )
+
+
+def _has_structure_evidence(row: dict[str, str]) -> bool:
+    text = " ".join(
+        row.get(col, "")
+        for col in ("Keywords", "Features", "Cross-reference (PDB)", "PDB")
+    ).lower()
+    return "3d-structure" in text or "pdb" in text
+
+
+def filter_by_uniprot_sequence(
+    records: Iterable[CdsRecord],
+    uniprot_rows: Iterable[dict[str, str]],
+) -> list[CdsRecord]:
+    """Select CDS records whose translated AA exactly matches structured UniProt."""
+    sequence_to_rows: dict[str, list[dict[str, str]]] = {}
+    for row in uniprot_rows:
+        seq = row.get("Sequence", "").strip().upper()
+        if not seq or not _has_structure_evidence(row):
+            continue
+        sequence_to_rows.setdefault(seq, []).append(row)
+
+    selected: list[CdsRecord] = []
+    for record in records:
+        aa = translate_dna(record.dna)
+        if not aa:
+            continue
+        matches = sequence_to_rows.get(aa)
+        if not matches:
+            continue
+        match = matches[0]
+        meta = dict(record.meta)
+        meta.update(
+            {
+                "aa_sequence": aa,
+                "uniprot_entry": match.get("Entry", ""),
+                "uniprot_entry_name": match.get("Entry Name", ""),
+                "uniprot_protein_names": match.get("Protein names", ""),
+                "uniprot_gene_names": match.get("Gene Names", ""),
+                "uniprot_keywords": match.get("Keywords", ""),
+            }
+        )
+        selected.append(CdsRecord(record.source_line_idx, record.dna, meta))
+    return selected
 
 
 def write_subset(
@@ -119,7 +198,18 @@ def write_subset(
 
     dna_out.write_text("".join(f"{record.dna}\n" for record in selected))
 
+    extra_header = [
+        "aa_sequence",
+        "uniprot_entry",
+        "uniprot_entry_name",
+        "uniprot_protein_names",
+        "uniprot_gene_names",
+        "uniprot_keywords",
+    ]
     retained_header = [col for col in meta_header if col != "line_idx"]
+    for col in extra_header:
+        if any(col in record.meta for record in selected) and col not in retained_header:
+            retained_header.append(col)
     out_header = ["line_idx", "source_line_idx", *retained_header]
     with meta_out.open("w", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=out_header, delimiter="\t")
@@ -161,12 +251,10 @@ def main() -> None:
         selected = filter_by_line_indices(records, indices)
         mode = "line_indices"
     elif args.uniprot_tsv:
-        uniprot_header, _ = read_tsv(args.uniprot_tsv)
+        uniprot_header, uniprot_rows = read_tsv(args.uniprot_tsv)
         validate_join_keys(meta_header, uniprot_header)
-        raise NotImplementedError(
-            "UniProt/PDB matching is gated on enriched CDS metadata. Use "
-            "--structured_line_indices for the current Stage 2.6 corpus."
-        )
+        selected = filter_by_uniprot_sequence(records, uniprot_rows)
+        mode = "uniprot_sequence"
     else:
         raise SystemExit("Provide --structured_line_indices or --uniprot_tsv")
 

--- a/scripts/prepare_protein_type_dataset.py
+++ b/scripts/prepare_protein_type_dataset.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Prepare structural-aware ProteinCritic labels from a UniProt TSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from pathlib import Path
+
+
+PROTEIN_TYPE_LABELS = [
+    "structured_pdb",
+    "membrane",
+    "signal_secreted",
+    "disordered_low_complexity",
+    "enzyme",
+    "short_peptide",
+    "soluble_candidate",
+]
+
+
+def _text(row: dict[str, str], *columns: str) -> str:
+    return " ".join(row.get(column, "") for column in columns).lower()
+
+
+def protein_type_labels(row: dict[str, str], short_len: int = 50) -> dict[str, int]:
+    """Derive coarse structural protein-type labels from UniProt columns."""
+    keywords = _text(row, "Keywords")
+    features = _text(row, "Features")
+    location = _text(row, "Subcellular location [CC]")
+    names = _text(row, "Protein names")
+    all_text = " ".join([keywords, features, location, names])
+
+    length = int(row.get("Length") or len(row.get("Sequence", "")) or 0)
+    labels = {
+        "structured_pdb": int("3d-structure" in all_text or "pdb" in all_text),
+        "membrane": int("membrane" in all_text or "transmembrane" in all_text),
+        "signal_secreted": int(
+            "signal" in features
+            or "secreted" in location
+            or "periplasm" in location
+        ),
+        "disordered_low_complexity": int(
+            "low complexity" in features
+            or "repeat" in features
+            or "coiled coil" in features
+            or "disorder" in all_text
+            or "intrinsically disordered" in all_text
+        ),
+        "enzyme": int(bool(row.get("EC number", "").strip())),
+        "short_peptide": int(length > 0 and length < short_len),
+    }
+    labels["soluble_candidate"] = int(
+        length >= short_len
+        and not labels["membrane"]
+        and not labels["signal_secreted"]
+        and not labels["disordered_low_complexity"]
+    )
+    return labels
+
+
+def row_to_sample(row: dict[str, str], short_len: int) -> dict[str, object] | None:
+    """Convert one UniProt row into a ProteinCritic JSONL sample."""
+    sequence = row.get("Sequence", "").strip().upper()
+    if not sequence:
+        return None
+    labels = protein_type_labels(row, short_len=short_len)
+    return {
+        "sequence": sequence,
+        "entry": row.get("Entry", ""),
+        "entry_name": row.get("Entry Name", ""),
+        "protein_type": [labels[name] for name in PROTEIN_TYPE_LABELS],
+        "protein_type_labels": labels,
+    }
+
+
+def read_uniprot_tsv(path: Path) -> list[dict[str, str]]:
+    """Read a UniProt TSV export."""
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_jsonl(path: Path, samples: list[dict[str, object]]) -> None:
+    """Write samples to JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as handle:
+        for sample in samples:
+            handle.write(json.dumps(sample, sort_keys=True) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uniprot_tsv", required=True, type=Path)
+    parser.add_argument("--out_dir", required=True, type=Path)
+    parser.add_argument("--val_frac", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--short_len", type=int, default=50)
+    args = parser.parse_args()
+
+    samples = [
+        sample
+        for row in read_uniprot_tsv(args.uniprot_tsv)
+        if (sample := row_to_sample(row, short_len=args.short_len)) is not None
+    ]
+    rng = random.Random(args.seed)
+    rng.shuffle(samples)
+
+    n_val = max(1, int(len(samples) * args.val_frac)) if len(samples) > 1 else 0
+    val = samples[:n_val]
+    train = samples[n_val:]
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    write_jsonl(args.out_dir / "train.jsonl", train)
+    write_jsonl(args.out_dir / "val.jsonl", val)
+    (args.out_dir / "task_vocabs.json").write_text(
+        json.dumps(
+            {
+                "pfam": {"unknown": 0},
+                "ec": {"unknown": 0},
+                "stability": {"unknown": 0},
+                "protein_type": {name: i for i, name in enumerate(PROTEIN_TYPE_LABELS)},
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    print(
+        f"[protein-type] wrote {len(train)} train and {len(val)} val samples to {args.out_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/query_model.py
+++ b/scripts/query_model.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 import torch
+import yaml
 
 from src.codonlm.model_tiny_gpt import TinyGPT
 
@@ -63,9 +64,17 @@ def _load_checkpoint(run_dir: Path) -> Tuple[Dict, Dict]:
 def _load_vocab(run_dir: Path) -> Tuple[List[str], Dict[str, int]]:
     itos_path = run_dir / "itos.txt"
     if not itos_path.exists():
-        raise FileNotFoundError(
-            f"Missing itos.txt at {itos_path}. Run analysis/post_process first or provide labels."
-        )
+        cfg_path = run_dir / "checkpoints" / "config.yaml"
+        if cfg_path.exists():
+            cfg = yaml.safe_load(cfg_path.read_text()) or {}
+            fallback = cfg.get("itos_path")
+            if fallback and Path(fallback).exists():
+                itos_path = Path(fallback)
+        if not itos_path.exists():
+            raise FileNotFoundError(
+                f"Missing itos.txt at {run_dir / 'itos.txt'} and no usable itos_path "
+                "was found in checkpoints/config.yaml."
+            )
     tokens = [
         line.strip() for line in itos_path.read_text().splitlines() if line.strip()
     ]

--- a/src/codonlm/build_dataset.py
+++ b/src/codonlm/build_dataset.py
@@ -11,6 +11,7 @@ Args:
 
 from pathlib import Path
 import argparse
+import csv
 import numpy as np
 import random
 from typing import List
@@ -42,11 +43,19 @@ def main():
     seqs = list(load_lines(args.ids))
     # load groups
     groups = []
-    with open(args.group_meta) as f:
-        next(f)
-        for line in f:
-            i,g = line.strip().split("\t")
-            groups.append(g)
+    with open(args.group_meta, newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if reader.fieldnames is None:
+            raise ValueError(f"group_meta has no header: {args.group_meta}")
+        group_col = "genome" if "genome" in reader.fieldnames else None
+        if group_col is None and "genome_id" in reader.fieldnames:
+            group_col = "genome_id"
+        if group_col is None:
+            raise ValueError(
+                f"group_meta must contain a genome or genome_id column; found {reader.fieldnames}"
+            )
+        for row in reader:
+            groups.append(row[group_col])
     assert len(groups)==len(seqs), "meta and ids must align"
 
     # split by unique groups (fallback to sequence-level split if too few groups)

--- a/src/codonlm/extract_cds_from_genbank.py
+++ b/src/codonlm/extract_cds_from_genbank.py
@@ -2,7 +2,7 @@
 """
 Writes:
 - data/processed/cds_dna.txt   (one CDS per line)
-- data/processed/cds_meta.tsv  (parallel, cols: line_idx, genome_id)
+- data/processed/cds_meta.tsv  (parallel CDS metadata)
 """
 
 from pathlib import Path
@@ -13,6 +13,18 @@ def reverse_complement(s):
     """Computes the reverse complement of a nucleotide sequence."""
     comp = str.maketrans("ACGTacgtnN","TGCAtgcann")
     return s.translate(comp)[::-1]
+
+
+def _first_qualifier(feat, key: str) -> str:
+    values = feat.qualifiers.get(key, [])
+    if not values:
+        return ""
+    return str(values[0])
+
+
+def _join_qualifier(feat, key: str) -> str:
+    values = feat.qualifiers.get(key, [])
+    return ";".join(str(value) for value in values)
 
 def main():
     """Extracts coding sequences (CDS) from GenBank files and writes them to text and metadata files."""
@@ -26,7 +38,10 @@ def main():
     Path(args.out_txt).parent.mkdir(parents=True, exist_ok=True)
     idx = 0
     with open(args.out_txt,"w") as ft, open(args.out_meta,"w") as fm:
-        fm.write("line_idx\tgenome\n")
+        fm.write(
+            "line_idx\tgenome\trecord_id\tprotein_id\tlocus_tag\tgene\tproduct\t"
+            "translation\tdb_xref\tstart\tend\tstrand\n"
+        )
         for gb in args.gbff:
             # Capture GCF_000005845 or similar (first two parts)
             parts = Path(gb).stem.split("_")
@@ -47,10 +62,23 @@ def main():
                         cds = reverse_complement(cds)
                     if len(cds) >= args.min_len and set(cds) <= set("ACGTN"):
                         ft.write(cds+"\n")
-                        fm.write(f"{idx}\t{genome_id}\n")
+                        meta = [
+                            str(idx),
+                            genome_id,
+                            str(rec.id),
+                            _first_qualifier(feat, "protein_id"),
+                            _first_qualifier(feat, "locus_tag"),
+                            _first_qualifier(feat, "gene"),
+                            _first_qualifier(feat, "product"),
+                            _first_qualifier(feat, "translation"),
+                            _join_qualifier(feat, "db_xref"),
+                            str(s),
+                            str(e),
+                            str(strand),
+                        ]
+                        fm.write("\t".join(value.replace("\t", " ") for value in meta) + "\n")
                         idx+=1
     print(f"[extract] wrote {idx} CDS with meta.")
 
 if __name__ == "__main__":
     main()
-

--- a/src/protein_lm/models_multi.py
+++ b/src/protein_lm/models_multi.py
@@ -38,7 +38,11 @@ class MultiTaskProteinClassifier(nn.Module):
             for name, dim in task_dims.items()
         })
 
-    def forward(self, input_ids: torch.LongTensor) -> dict:
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> dict:
         """
         Returns a dictionary of logits for each task.
         """
@@ -54,18 +58,25 @@ class MultiTaskProteinClassifier(nn.Module):
             for block in self.backbone.transformer_blocks:
                 try:
                     # Pass use_reentrant=False to silence deprecation warnings in newer PyTorch
-                    x = checkpoint(block, x, use_reentrant=False)
+                    x = checkpoint(
+                        block,
+                        x,
+                        src_key_padding_mask=(attention_mask == 0) if attention_mask is not None else None,
+                        use_reentrant=False,
+                    )
                 except TypeError:
                     x = checkpoint(block, x)
         else:
             for block in self.backbone.transformer_blocks:
-                x = block(x)
+                x = block(
+                    x,
+                    src_key_padding_mask=(attention_mask == 0) if attention_mask is not None else None,
+                )
 
-        # Global Average Pooling (better for functional classification than just BOS)
-        # Or just use BOS for structural tasks.
-        mean_rep = x.mean(dim=1)
-        
-        # Combine? Let's stick to mean-pooling for now.
-        pooled = mean_rep
+        if attention_mask is None:
+            pooled = x.mean(dim=1)
+        else:
+            mask = attention_mask.to(dtype=x.dtype, device=x.device).unsqueeze(-1)
+            pooled = (x * mask).sum(dim=1) / mask.sum(dim=1).clamp_min(1.0)
 
         return {name: head(pooled) for name, head in self.heads.items()}

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import Dataset, DataLoader, Sampler
 import time
 import json
 import argparse
@@ -11,9 +11,11 @@ from src.protein_lm.models_multi import MultiTaskProteinClassifier
 from src.protein_lm.config import ProteinClassifierConfig
 
 class MultiTaskProteinDataset(Dataset):
-    def __init__(self, jsonl_path, tokenizer, max_length=512):
+    def __init__(self, jsonl_path, tokenizer, max_length=512, dynamic_padding=False, multi_label_tasks=None):
         self.tokenizer = tokenizer
         self.max_length = max_length
+        self.dynamic_padding = dynamic_padding
+        self.multi_label_tasks = set(multi_label_tasks or [])
         self.samples = []
         
         with open(jsonl_path, "r") as f:
@@ -31,16 +33,73 @@ class MultiTaskProteinDataset(Dataset):
         # We manually add BOS (1) and EOS (2) if they exist, or just rely on raw tokens.
         tokens = [self.tokenizer.bos_token_id] + self.tokenizer.encode_sequence(s["sequence"])[:self.max_length-2] + [self.tokenizer.eos_token_id]
         
-        # Pad sequence
-        pad_len = self.max_length - len(tokens)
-        input_ids = tokens + [self.tokenizer.pad_token_id] * pad_len
-        
-        return {
+        attention_mask = [1] * len(tokens)
+        if not self.dynamic_padding:
+            pad_len = self.max_length - len(tokens)
+            input_ids = tokens + [self.tokenizer.pad_token_id] * pad_len
+            attention_mask = attention_mask + [0] * pad_len
+        else:
+            input_ids = tokens
+
+        item = {
             "input_ids": torch.tensor(input_ids, dtype=torch.long),
+            "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
             "family": torch.tensor(s.get("pfam_id", -1), dtype=torch.long),
             "function": torch.tensor(s.get("ec_id", -1), dtype=torch.long),
             "stability": torch.tensor(s.get("stability_id", -1), dtype=torch.long)
         }
+        for task in self.multi_label_tasks:
+            labels = s.get(task)
+            if labels is None:
+                labels = s.get(f"{task}_labels")
+            if labels is None:
+                labels = []
+            item[task] = torch.tensor(labels, dtype=torch.float32)
+        return item
+
+    def sequence_length(self, idx):
+        sequence = self.samples[idx]["sequence"]
+        return min(len(sequence) + 2, self.max_length)
+
+
+class LengthBucketBatchSampler(Sampler[list[int]]):
+    """Batch similar-length proteins together to reduce padding waste."""
+
+    def __init__(self, dataset, batch_size, shuffle=True):
+        self.dataset = dataset
+        self.batch_size = int(batch_size)
+        self.shuffle = shuffle
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(1337)
+        indices = list(range(len(self.dataset)))
+        indices.sort(key=self.dataset.sequence_length)
+        batches = [indices[i : i + self.batch_size] for i in range(0, len(indices), self.batch_size)]
+        if self.shuffle:
+            order = torch.randperm(len(batches), generator=generator).tolist()
+            batches = [batches[i] for i in order]
+        yield from batches
+
+    def __len__(self):
+        return (len(self.dataset) + self.batch_size - 1) // self.batch_size
+
+
+def collate_protein_batch(batch, pad_token_id=0):
+    """Pad a variable-length protein batch to its local max length."""
+    max_len = max(item["input_ids"].numel() for item in batch)
+    result = {}
+    for key in batch[0].keys():
+        values = [item[key] for item in batch]
+        if key in {"input_ids", "attention_mask"}:
+            pad_value = pad_token_id if key == "input_ids" else 0
+            out = torch.full((len(batch), max_len), pad_value, dtype=values[0].dtype)
+            for i, value in enumerate(values):
+                out[i, : value.numel()] = value
+            result[key] = out
+        else:
+            result[key] = torch.stack(values)
+    return result
 
 def train_multi_task(config_path, resume_path=None, run_id=None):
     with open(config_path, 'r') as f:
@@ -66,6 +125,9 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
         "function": len(vocabs["ec"]),
         "stability": len(vocabs["stability"])
     }
+    multi_label_tasks = list(cfg.get("multi_label_tasks", []))
+    for task in multi_label_tasks:
+        task_dims[task] = len(vocabs[task])
     print(f"[*] Task Dimensions: {task_dims}")
 
     # Build Config
@@ -84,16 +146,42 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
     model = MultiTaskProteinClassifier(model_cfg, task_dims).to(device)
     
     print("[*] Loading datasets...")
-    train_ds = MultiTaskProteinDataset(cfg["train_data"], tokenizer, max_length=model_cfg.block_size)
-    val_ds = MultiTaskProteinDataset(cfg["val_data"], tokenizer, max_length=model_cfg.block_size)
-    
-    train_loader = DataLoader(train_ds, batch_size=cfg.get("batch_size", 8), shuffle=True)
-    val_loader = DataLoader(val_ds, batch_size=cfg.get("batch_size", 8))
+    dynamic_padding = bool(cfg.get("dynamic_padding", False))
+    train_ds = MultiTaskProteinDataset(
+        cfg["train_data"],
+        tokenizer,
+        max_length=model_cfg.block_size,
+        dynamic_padding=dynamic_padding,
+        multi_label_tasks=multi_label_tasks,
+    )
+    val_ds = MultiTaskProteinDataset(
+        cfg["val_data"],
+        tokenizer,
+        max_length=model_cfg.block_size,
+        dynamic_padding=dynamic_padding,
+        multi_label_tasks=multi_label_tasks,
+    )
+
+    if dynamic_padding:
+        train_loader = DataLoader(
+            train_ds,
+            batch_sampler=LengthBucketBatchSampler(train_ds, cfg.get("batch_size", 8), shuffle=True),
+            collate_fn=lambda batch: collate_protein_batch(batch, tokenizer.pad_token_id),
+        )
+        val_loader = DataLoader(
+            val_ds,
+            batch_sampler=LengthBucketBatchSampler(val_ds, cfg.get("batch_size", 8), shuffle=False),
+            collate_fn=lambda batch: collate_protein_batch(batch, tokenizer.pad_token_id),
+        )
+    else:
+        train_loader = DataLoader(train_ds, batch_size=cfg.get("batch_size", 8), shuffle=True)
+        val_loader = DataLoader(val_ds, batch_size=cfg.get("batch_size", 8))
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=float(cfg.get("lr", 1e-4)))
     
     # CrossEntropyLoss with ignore_index=-1 handles the missing labels
     criterion = nn.CrossEntropyLoss(ignore_index=-1)
+    multi_label_criterion = nn.BCEWithLogitsLoss()
 
     best_val_loss = float('inf')
     start_epoch = 0
@@ -149,8 +237,11 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
         
         for step, batch in enumerate(train_loader):
             input_ids = batch["input_ids"].to(device)
+            attention_mask = batch.get("attention_mask")
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(device)
             
-            logits_dict = model(input_ids)
+            logits_dict = model(input_ids, attention_mask=attention_mask)
             
             loss = 0
             tasks_added = 0
@@ -160,6 +251,11 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
                 if (targets != -1).any():
                      loss += criterion(logits_dict[task], targets)
                      tasks_added += 1
+            for task in multi_label_tasks:
+                targets = batch[task].to(device)
+                if targets.numel() and (targets >= 0).any():
+                    loss += multi_label_criterion(logits_dict[task], targets)
+                    tasks_added += 1
             
             if tasks_added > 0:
                 loss = loss / grad_accum_steps
@@ -199,7 +295,10 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
         with torch.no_grad():
             for batch in val_loader:
                 input_ids = batch["input_ids"].to(device)
-                logits_dict = model(input_ids)
+                attention_mask = batch.get("attention_mask")
+                if attention_mask is not None:
+                    attention_mask = attention_mask.to(device)
+                logits_dict = model(input_ids, attention_mask=attention_mask)
                 
                 batch_loss = 0
                 batch_tasks = 0
@@ -207,6 +306,11 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
                     targets = batch[task].to(device)
                     if (targets != -1).any():
                         batch_loss += criterion(logits_dict[task], targets)
+                        batch_tasks += 1
+                for task in multi_label_tasks:
+                    targets = batch[task].to(device)
+                    if targets.numel() and (targets >= 0).any():
+                        batch_loss += multi_label_criterion(logits_dict[task], targets)
                         batch_tasks += 1
                 
                 if batch_tasks > 0:

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -101,7 +101,31 @@ def collate_protein_batch(batch, pad_token_id=0):
             result[key] = torch.stack(values)
     return result
 
-def train_multi_task(config_path, resume_path=None, run_id=None):
+
+def load_compatible_model_weights(model, checkpoint_path, map_location="cpu"):
+    """Load matching checkpoint tensors and skip incompatible task heads."""
+    checkpoint = torch.load(checkpoint_path, map_location=map_location)
+    source_state = (
+        checkpoint["model_state_dict"]
+        if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint
+        else checkpoint
+    )
+    target_state = model.state_dict()
+
+    compatible = {}
+    skipped = []
+    for name, tensor in source_state.items():
+        if name in target_state and target_state[name].shape == tensor.shape:
+            compatible[name] = tensor
+        else:
+            skipped.append(name)
+
+    target_state.update(compatible)
+    model.load_state_dict(target_state)
+    return len(compatible), skipped
+
+
+def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=None):
     with open(config_path, 'r') as f:
         cfg = yaml.safe_load(f)
         
@@ -144,6 +168,18 @@ def train_multi_task(config_path, resume_path=None, run_id=None):
 
     print("[*] Building model...")
     model = MultiTaskProteinClassifier(model_cfg, task_dims).to(device)
+
+    transfer_checkpoint = transfer_from or cfg.get("transfer_from")
+    if transfer_checkpoint:
+        if resume_path:
+            raise ValueError("--transfer_from and --resume are mutually exclusive")
+        transfer_checkpoint = Path(transfer_checkpoint)
+        if not transfer_checkpoint.exists():
+            raise FileNotFoundError(f"Transfer checkpoint not found: {transfer_checkpoint}")
+        loaded, skipped = load_compatible_model_weights(model, transfer_checkpoint, map_location=device)
+        print(f"[*] Transferred {loaded} compatible tensors from {transfer_checkpoint}")
+        if skipped:
+            print(f"[*] Skipped {len(skipped)} incompatible tensors, typically task-specific heads")
     
     print("[*] Loading datasets...")
     dynamic_padding = bool(cfg.get("dynamic_padding", False))
@@ -348,6 +384,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True, help="Path to YAML config")
     parser.add_argument("--resume", default=None, help="Path to checkpoint file to resume from")
+    parser.add_argument("--transfer_from", default=None, help="Checkpoint to partially initialize compatible weights from")
     parser.add_argument("--run_id", default=None, help="Unique run id")
     args = parser.parse_args()
-    train_multi_task(args.config, args.resume, args.run_id)
+    train_multi_task(args.config, args.resume, args.run_id, args.transfer_from)

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -125,13 +125,56 @@ def load_compatible_model_weights(model, checkpoint_path, map_location="cpu"):
     return len(compatible), skipped
 
 
+def compute_multi_label_pos_weight(dataset, task, max_weight=100.0):
+    labels = []
+    for sample in dataset.samples:
+        values = sample.get(task)
+        if values is None:
+            values = sample.get(f"{task}_labels")
+        if values is None:
+            continue
+        if isinstance(values, dict):
+            values = list(values.values())
+        labels.append(torch.tensor(values, dtype=torch.float32))
+    if not labels:
+        raise ValueError(f"No labels found for multi-label task: {task}")
+    matrix = torch.stack(labels)
+    positives = matrix.sum(dim=0)
+    negatives = matrix.shape[0] - positives
+    weights = torch.where(positives > 0, negatives / positives.clamp_min(1.0), torch.ones_like(positives))
+    return weights.clamp(min=1.0, max=float(max_weight))
+
+
+def save_training_checkpoint(path, epoch, model, optimizer, best_val_loss):
+    checkpoint = {
+        'epoch': epoch,
+        'model_state_dict': model.state_dict(),
+        'optimizer_state_dict': optimizer.state_dict(),
+        'best_val_loss': best_val_loss,
+    }
+    torch.save(checkpoint, path)
+
+
+def mps_memory_summary():
+    if not hasattr(torch, "mps"):
+        return ""
+    current_allocated = getattr(torch.mps, "current_allocated_memory", None)
+    driver_allocated = getattr(torch.mps, "driver_allocated_memory", None)
+    parts = []
+    if current_allocated:
+        parts.append(f"mps_current_mb={current_allocated() / 1024 / 1024:.1f}")
+    if driver_allocated:
+        parts.append(f"mps_driver_mb={driver_allocated() / 1024 / 1024:.1f}")
+    return " | " + " | ".join(parts) if parts else ""
+
+
 def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=None):
     with open(config_path, 'r') as f:
         cfg = yaml.safe_load(f)
         
     device_name = cfg.get("device", "mps" if torch.backends.mps.is_available() else "cpu")
     device = torch.device(device_name)
-    print(f"[*] Using device: {device}")
+    print(f"[*] Using device: {device}", flush=True)
 
     tokenizer = ProteinTokenizer()
     
@@ -152,7 +195,7 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
     multi_label_tasks = list(cfg.get("multi_label_tasks", []))
     for task in multi_label_tasks:
         task_dims[task] = len(vocabs[task])
-    print(f"[*] Task Dimensions: {task_dims}")
+    print(f"[*] Task Dimensions: {task_dims}", flush=True)
 
     # Build Config
     model_cfg = ProteinClassifierConfig(
@@ -166,7 +209,7 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
         use_checkpoint=cfg.get("use_checkpoint", False)
     )
 
-    print("[*] Building model...")
+    print("[*] Building model...", flush=True)
     model = MultiTaskProteinClassifier(model_cfg, task_dims).to(device)
 
     transfer_checkpoint = transfer_from or cfg.get("transfer_from")
@@ -177,11 +220,11 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
         if not transfer_checkpoint.exists():
             raise FileNotFoundError(f"Transfer checkpoint not found: {transfer_checkpoint}")
         loaded, skipped = load_compatible_model_weights(model, transfer_checkpoint, map_location=device)
-        print(f"[*] Transferred {loaded} compatible tensors from {transfer_checkpoint}")
+        print(f"[*] Transferred {loaded} compatible tensors from {transfer_checkpoint}", flush=True)
         if skipped:
-            print(f"[*] Skipped {len(skipped)} incompatible tensors, typically task-specific heads")
+            print(f"[*] Skipped {len(skipped)} incompatible tensors, typically task-specific heads", flush=True)
     
-    print("[*] Loading datasets...")
+    print("[*] Loading datasets...", flush=True)
     dynamic_padding = bool(cfg.get("dynamic_padding", False))
     train_ds = MultiTaskProteinDataset(
         cfg["train_data"],
@@ -212,33 +255,66 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
     else:
         train_loader = DataLoader(train_ds, batch_size=cfg.get("batch_size", 8), shuffle=True)
         val_loader = DataLoader(val_ds, batch_size=cfg.get("batch_size", 8))
+    print(
+        f"[*] Dataset sizes: train={len(train_ds)} val={len(val_ds)} "
+        f"train_batches={len(train_loader)} val_batches={len(val_loader)}",
+        flush=True,
+    )
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=float(cfg.get("lr", 1e-4)))
     
     # CrossEntropyLoss with ignore_index=-1 handles the missing labels
     criterion = nn.CrossEntropyLoss(ignore_index=-1)
-    multi_label_criterion = nn.BCEWithLogitsLoss()
+    multi_label_criteria = {}
+    pos_weight_cfg = cfg.get("multi_label_pos_weight")
+    pos_weight_max = cfg.get("multi_label_pos_weight_max", 100.0)
+    for task in multi_label_tasks:
+        pos_weight = None
+        if pos_weight_cfg == "auto":
+            pos_weight = compute_multi_label_pos_weight(
+                train_ds, task, max_weight=pos_weight_max
+            ).to(device)
+        elif isinstance(pos_weight_cfg, dict) and task in pos_weight_cfg:
+            pos_weight = torch.tensor(pos_weight_cfg[task], dtype=torch.float32, device=device)
+        if pos_weight is not None:
+            print(
+                f"[*] Multi-label pos_weight for {task}: "
+                f"{[round(float(v), 4) for v in pos_weight.detach().cpu()]}",
+                flush=True,
+            )
+        multi_label_criteria[task] = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
 
     best_val_loss = float('inf')
     start_epoch = 0
     if resume_path and Path(resume_path).exists():
-        print(f"[*] Resuming from checkpoint: {resume_path}")
+        print(f"[*] Resuming from checkpoint: {resume_path}", flush=True)
         checkpoint = torch.load(resume_path, map_location=device)
         model.load_state_dict(checkpoint['model_state_dict'])
         optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
         start_epoch = checkpoint['epoch'] + 1
         best_val_loss = checkpoint.get('best_val_loss', float('inf'))
-        print(f"[*] Resumed checkpoint. Next epoch: {start_epoch + 1} with best val loss: {best_val_loss:.4f}")
+        print(
+            f"[*] Resumed checkpoint. Next epoch: {start_epoch + 1} "
+            f"with best val loss: {best_val_loss:.4f}",
+            flush=True,
+        )
 
-    print("[*] Starting Multi-Task Training...")
+    print("[*] Starting Multi-Task Training...", flush=True)
     epochs = cfg.get("epochs", 5)
     grad_accum_steps = cfg.get("grad_accum_steps", 1)
-    print(f"[*] Gradient accumulation steps: {grad_accum_steps}")
+    print(f"[*] Gradient accumulation steps: {grad_accum_steps}", flush=True)
+    log_every_steps = cfg.get("log_every_steps", 100)
+    checkpoint_every_steps = cfg.get("checkpoint_every_steps", 0)
+    print(
+        f"[*] Progress logging every {log_every_steps} steps; "
+        f"step checkpoint every {checkpoint_every_steps or 'disabled'} steps",
+        flush=True,
+    )
     
     max_time_minutes = cfg.get("max_time_minutes", None)
     max_time_seconds = max_time_minutes * 60 if max_time_minutes else None
     if max_time_minutes:
-        print(f"[*] Wall-time limit configured: {max_time_minutes} minutes")
+        print(f"[*] Wall-time limit configured: {max_time_minutes} minutes", flush=True)
     
     start_time = time.perf_counter()
     
@@ -269,6 +345,8 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             break
         model.train()
         train_loss = 0.0
+        recent_loss = 0.0
+        recent_steps = 0
         optimizer.zero_grad()
         
         for step, batch in enumerate(train_loader):
@@ -290,13 +368,15 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             for task in multi_label_tasks:
                 targets = batch[task].to(device)
                 if targets.numel() and (targets >= 0).any():
-                    loss += multi_label_criterion(logits_dict[task], targets)
+                    loss += multi_label_criteria[task](logits_dict[task], targets)
                     tasks_added += 1
             
             if tasks_added > 0:
                 loss = loss / grad_accum_steps
                 loss.backward()
                 train_loss += loss.item() * grad_accum_steps
+                recent_loss += loss.item() * grad_accum_steps
+                recent_steps += 1
             
             if (step + 1) % grad_accum_steps == 0 or (step + 1) == len(train_loader):
                 optimizer.step()
@@ -307,17 +387,31 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             elif (step + 1) % 250 == 0 and device.type == "mps":
                 torch.mps.empty_cache()
 
+            if log_every_steps and (step + 1) % log_every_steps == 0:
+                elapsed = time.perf_counter() - start_time
+                avg_recent_loss = recent_loss / max(recent_steps, 1)
+                print(
+                    f"[progress] epoch={epoch + 1}/{epochs} "
+                    f"step={step + 1}/{len(train_loader)} "
+                    f"elapsed_min={elapsed / 60:.1f} "
+                    f"recent_loss={avg_recent_loss:.4f} "
+                    f"batch_seq_len={input_ids.shape[1]}"
+                    f"{mps_memory_summary() if device.type == 'mps' else ''}",
+                    flush=True,
+                )
+                recent_loss = 0.0
+                recent_steps = 0
+
+            if checkpoint_every_steps and (step + 1) % checkpoint_every_steps == 0:
+                step_checkpoint = out_dir / "last_step_critic.pt"
+                save_training_checkpoint(step_checkpoint, epoch, model, optimizer, best_val_loss)
+                print(f"[checkpoint] Saved step checkpoint to {step_checkpoint}", flush=True)
+
             # Check wall-time limit at the end of every step
             if max_time_seconds and (time.perf_counter() - start_time) > max_time_seconds:
-                print(f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.")
-                checkpoint = {
-                    'epoch': epoch,
-                    'model_state_dict': model.state_dict(),
-                    'optimizer_state_dict': optimizer.state_dict(),
-                    'best_val_loss': best_val_loss,
-                }
-                torch.save(checkpoint, out_dir / "last_critic.pt")
-                print(f"[success] Gracefully saved checkpoint to {out_dir / 'last_critic.pt'}. Exiting.")
+                print(f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.", flush=True)
+                save_training_checkpoint(out_dir / "last_critic.pt", epoch, model, optimizer, best_val_loss)
+                print(f"[success] Gracefully saved checkpoint to {out_dir / 'last_critic.pt'}. Exiting.", flush=True)
                 time_limit_reached = True
                 break
             
@@ -346,7 +440,7 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
                 for task in multi_label_tasks:
                     targets = batch[task].to(device)
                     if targets.numel() and (targets >= 0).any():
-                        batch_loss += multi_label_criterion(logits_dict[task], targets)
+                        batch_loss += multi_label_criteria[task](logits_dict[task], targets)
                         batch_tasks += 1
                 
                 if batch_tasks > 0:
@@ -357,7 +451,7 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             val_loss /= val_tasks_total
         if device.type == "mps":
             torch.mps.empty_cache()
-        print(f"Epoch {epoch+1}/{epochs} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}")
+        print(f"Epoch {epoch+1}/{epochs} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}", flush=True)
         
         with open(log_csv, "a", newline="") as f:
             csv.writer(f).writerow([epoch + 1, f"{train_loss:.4f}", f"{val_loss:.4f}"])
@@ -368,17 +462,11 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             improved = True
 
         # Save last checkpoint for resilience
-        checkpoint = {
-            'epoch': epoch,
-            'model_state_dict': model.state_dict(),
-            'optimizer_state_dict': optimizer.state_dict(),
-            'best_val_loss': best_val_loss,
-        }
-        torch.save(checkpoint, out_dir / "last_critic.pt")
+        save_training_checkpoint(out_dir / "last_critic.pt", epoch, model, optimizer, best_val_loss)
 
         if improved:
             torch.save(model.state_dict(), out_dir / "best_critic.pt")
-            print("  -> Saved new best model.")
+            print("  -> Saved new best model.", flush=True)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/tests/test_filter_cds_by_pdb.py
+++ b/tests/test_filter_cds_by_pdb.py
@@ -4,8 +4,10 @@ import pytest
 
 from scripts.filter_cds_by_pdb import (
     filter_by_line_indices,
+    filter_by_uniprot_sequence,
     load_records,
     read_line_indices,
+    translate_dna,
     validate_join_keys,
     write_subset,
 )
@@ -52,9 +54,49 @@ def test_missing_line_index_raises(tmp_path):
         filter_by_line_indices(records, {0, 9})
 
 
-def test_join_validation_requires_enriched_cds_metadata():
+def test_join_validation_requires_metadata_or_sequence_key():
     with pytest.raises(ValueError, match="CDS metadata has no protein/gene join key"):
         validate_join_keys(
             meta_header=["line_idx", "genome"],
-            uniprot_header=["Entry", "Gene Names", "Sequence"],
+            uniprot_header=["Entry", "Gene Names"],
         )
+
+
+def test_uniprot_sequence_filter_matches_translated_structured_proteins(tmp_path):
+    dna = tmp_path / "cds_dna.txt"
+    meta = tmp_path / "cds_meta.tsv"
+    out_dir = tmp_path / "out"
+
+    dna.write_text("ATGGCTTAA\nATGCCCTAA\n")
+    meta.write_text("line_idx\tgenome\tlocus_tag\n0\tg1\tfoo\n1\tg1\tbar\n")
+
+    header, records = load_records(dna, meta)
+    selected = filter_by_uniprot_sequence(
+        records,
+        [
+            {
+                "Entry": "P00001",
+                "Entry Name": "MATCH_BACT",
+                "Protein names": "Mock structured protein",
+                "Gene Names": "foo",
+                "Sequence": "MA",
+                "Keywords": "3D-structure;Reference proteome",
+            },
+            {
+                "Entry": "P00002",
+                "Sequence": "MP",
+                "Keywords": "Reference proteome",
+            },
+        ],
+    )
+
+    assert [record.source_line_idx for record in selected] == [0]
+    assert selected[0].meta["uniprot_entry"] == "P00001"
+    assert translate_dna("ATGGCTTAA") == "MA"
+
+    write_subset(selected, header, out_dir, {"mode": "uniprot_sequence"})
+    with (out_dir / "cds_meta.tsv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert rows[0]["source_line_idx"] == "0"
+    assert rows[0]["aa_sequence"] == "MA"
+    assert rows[0]["uniprot_entry"] == "P00001"

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -10,6 +10,7 @@ from src.protein_lm.train_multi_task import (
     LengthBucketBatchSampler,
     MultiTaskProteinDataset,
     collate_protein_batch,
+    load_compatible_model_weights,
 )
 
 
@@ -120,3 +121,31 @@ def test_multitask_model_uses_attention_mask():
 
     logits = model(input_ids, attention_mask=attention_mask)
     assert logits["protein_type"].shape == (2, 3)
+
+
+def test_transfer_loads_matching_backbone_and_skips_heads(tmp_path):
+    config = ProteinClassifierConfig(
+        vocab_size=len(ProteinTokenizer().vocab),
+        block_size=8,
+        n_layer=1,
+        n_head=1,
+        n_embd=8,
+        dropout=0.0,
+        num_classes=0,
+        use_checkpoint=False,
+    )
+    source = MultiTaskProteinClassifier(config, {"family": 5})
+    target = MultiTaskProteinClassifier(config, {"protein_type": 3})
+
+    with torch.no_grad():
+        source.backbone.token_embedding.weight.fill_(0.25)
+        target.backbone.token_embedding.weight.zero_()
+
+    checkpoint = tmp_path / "source.pt"
+    torch.save(source.state_dict(), checkpoint)
+
+    loaded, skipped = load_compatible_model_weights(target, checkpoint)
+
+    assert loaded > 0
+    assert "heads.family.weight" in skipped
+    assert torch.allclose(target.backbone.token_embedding.weight, source.backbone.token_embedding.weight)

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -1,0 +1,122 @@
+import json
+
+import torch
+
+from scripts.prepare_protein_type_dataset import PROTEIN_TYPE_LABELS, protein_type_labels, row_to_sample
+from src.protein_lm.config import ProteinClassifierConfig
+from src.protein_lm.models_multi import MultiTaskProteinClassifier
+from src.protein_lm.tokenizer import ProteinTokenizer
+from src.protein_lm.train_multi_task import (
+    LengthBucketBatchSampler,
+    MultiTaskProteinDataset,
+    collate_protein_batch,
+)
+
+
+def test_protein_type_label_extraction():
+    row = {
+        "Entry": "P0",
+        "Sequence": "M" * 42,
+        "Length": "42",
+        "EC number": "1.1.1.1",
+        "Keywords": "3D-structure;Membrane",
+        "Features": "Signal (1); Transmembrane (1); Low complexity (1)",
+        "Subcellular location [CC]": "SUBCELLULAR LOCATION: Secreted.",
+    }
+
+    labels = protein_type_labels(row)
+    assert labels["structured_pdb"] == 1
+    assert labels["membrane"] == 1
+    assert labels["signal_secreted"] == 1
+    assert labels["disordered_low_complexity"] == 1
+    assert labels["enzyme"] == 1
+    assert labels["short_peptide"] == 1
+    assert labels["soluble_candidate"] == 0
+
+
+def test_row_to_sample_multi_label_vector_order():
+    sample = row_to_sample(
+        {
+            "Entry": "P1",
+            "Entry Name": "MOCK",
+            "Sequence": "M" * 80,
+            "Length": "80",
+            "Keywords": "3D-structure",
+            "Features": "",
+            "Subcellular location [CC]": "",
+        },
+        short_len=50,
+    )
+
+    assert sample is not None
+    assert len(sample["protein_type"]) == len(PROTEIN_TYPE_LABELS)
+    assert sample["protein_type"][PROTEIN_TYPE_LABELS.index("structured_pdb")] == 1
+    assert sample["protein_type"][PROTEIN_TYPE_LABELS.index("soluble_candidate")] == 1
+
+
+def test_dynamic_collate_pads_to_batch_max(tmp_path):
+    tokenizer = ProteinTokenizer()
+    data = tmp_path / "data.jsonl"
+    rows = [
+        {"sequence": "MKT", "protein_type": [1, 0]},
+        {"sequence": "MKTWVV", "protein_type": [0, 1]},
+    ]
+    data.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    dataset = MultiTaskProteinDataset(
+        data,
+        tokenizer,
+        max_length=32,
+        dynamic_padding=True,
+        multi_label_tasks=["protein_type"],
+    )
+    batch = collate_protein_batch([dataset[0], dataset[1]], tokenizer.pad_token_id)
+
+    assert batch["input_ids"].shape == batch["attention_mask"].shape
+    assert batch["input_ids"].shape[1] == dataset.sequence_length(1)
+    assert batch["attention_mask"][0].sum().item() == dataset.sequence_length(0)
+    assert batch["attention_mask"][1].sum().item() == dataset.sequence_length(1)
+    assert batch["protein_type"].shape == (2, 2)
+
+
+def test_length_bucket_sampler_groups_sorted_lengths(tmp_path):
+    tokenizer = ProteinTokenizer()
+    data = tmp_path / "data.jsonl"
+    rows = [
+        {"sequence": "M" * 10},
+        {"sequence": "M" * 2},
+        {"sequence": "M" * 8},
+        {"sequence": "M" * 3},
+    ]
+    data.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    dataset = MultiTaskProteinDataset(data, tokenizer, max_length=32, dynamic_padding=True)
+
+    batches = list(LengthBucketBatchSampler(dataset, batch_size=2, shuffle=False))
+    lengths = [[dataset.sequence_length(i) for i in batch] for batch in batches]
+    assert lengths == [sorted(lengths[0]), sorted(lengths[1])]
+    assert max(lengths[0]) <= min(lengths[1])
+
+
+def test_multitask_model_uses_attention_mask():
+    config = ProteinClassifierConfig(
+        vocab_size=len(ProteinTokenizer().vocab),
+        block_size=8,
+        n_layer=1,
+        n_head=1,
+        n_embd=8,
+        dropout=0.0,
+        num_classes=0,
+        use_checkpoint=False,
+    )
+    model = MultiTaskProteinClassifier(config, {"protein_type": 3})
+    input_ids = torch.ones((2, 8), dtype=torch.long)
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 1],
+        ],
+        dtype=torch.long,
+    )
+
+    logits = model(input_ids, attention_mask=attention_mask)
+    assert logits["protein_type"].shape == (2, 3)

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -2,6 +2,7 @@ import json
 
 import torch
 
+from scripts.eval_multi_task_critic import threshold_metrics, top_fraction_enrichment
 from scripts.prepare_protein_type_dataset import PROTEIN_TYPE_LABELS, protein_type_labels, row_to_sample
 from src.protein_lm.config import ProteinClassifierConfig
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
@@ -10,6 +11,7 @@ from src.protein_lm.train_multi_task import (
     LengthBucketBatchSampler,
     MultiTaskProteinDataset,
     collate_protein_batch,
+    compute_multi_label_pos_weight,
     load_compatible_model_weights,
 )
 
@@ -149,3 +151,45 @@ def test_transfer_loads_matching_backbone_and_skips_heads(tmp_path):
     assert loaded > 0
     assert "heads.family.weight" in skipped
     assert torch.allclose(target.backbone.token_embedding.weight, source.backbone.token_embedding.weight)
+
+
+def test_compute_multi_label_pos_weight_from_dataset(tmp_path):
+    tokenizer = ProteinTokenizer()
+    data = tmp_path / "data.jsonl"
+    rows = [
+        {"sequence": "MKT", "protein_type": [1, 0, 0]},
+        {"sequence": "MKT", "protein_type": [0, 0, 0]},
+        {"sequence": "MKT", "protein_type": [0, 1, 0]},
+        {"sequence": "MKT", "protein_type": [0, 1, 0]},
+    ]
+    data.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    dataset = MultiTaskProteinDataset(
+        data,
+        tokenizer,
+        max_length=32,
+        dynamic_padding=True,
+        multi_label_tasks=["protein_type"],
+    )
+
+    weights = compute_multi_label_pos_weight(dataset, "protein_type", max_weight=10)
+
+    assert torch.allclose(weights, torch.tensor([3.0, 1.0, 1.0]))
+
+
+def test_eval_helpers_report_thresholds_and_enrichment():
+    y_true = torch.tensor([1, 0, 1, 0, 0], dtype=torch.float32).numpy()
+    y_prob = torch.tensor([0.95, 0.9, 0.4, 0.3, 0.1], dtype=torch.float32).numpy()
+
+    thresholds = threshold_metrics(y_true, y_prob, [0.5, 0.2])
+    enrichment = top_fraction_enrichment(y_true, y_prob, [0.4, 1.0])
+
+    assert thresholds[0]["threshold"] == 0.5
+    assert thresholds[0]["precision"] == 0.5
+    assert thresholds[0]["recall"] == 0.5
+    assert thresholds[0]["predicted_fraction"] == 0.4
+    assert thresholds[1]["recall"] == 1.0
+
+    assert enrichment[0]["k"] == 2
+    assert enrichment[0]["positive_rate"] == 0.5
+    assert abs(enrichment[0]["enrichment"] - 1.25) < 1e-6
+    assert abs(enrichment[1]["positive_rate"] - 0.4) < 1e-6


### PR DESCRIPTION
## Summary

- enrich GenBank CDS metadata extraction with protein/gene/product/db_xref/coordinate fields
- add UniProt exact translated-protein sequence filtering for structure-positive CDS rows
- update dataset building to accept enriched metadata with extra TSV columns
- fix Stage 3 structural fine-tuning config to match the Stage 2.6 MHA checkpoint
- add vocab fallback for immediate post-training generation from checkpoint config
- record the PDB-filtered smoke fine-tune and ESMFold top-3 findings

## Results

- filtered 884 / 44,953 Stage 2.6 CDS rows by exact translated-protein match to structured UniProt entries
- packed subset into 728 train, 100 val, 56 test windows at block size 512
- one-epoch smoke fine-tune completed from Stage 2.6 best checkpoint
- smoke validation: val loss 4.0701, perplexity 58.564
- structured-prefix smoke: 6 continuations, 0/6 terminated, mean ProteinCritic stability 0.572
- ESMFold top-3 pLDDT: 0.354, 0.418, 0.435

## Validation

- `pytest -q tests/test_filter_cds_by_pdb.py tests/test_dynamic_dataset.py tests/test_hybrid_pipeline.py`
- `python -m py_compile scripts/filter_cds_by_pdb.py src/codonlm/extract_cds_from_genbank.py src/codonlm/build_dataset.py`
- `pytest -q` -> 100 passed, 1 skipped, 1 xpassed
- `git diff --check`