### PR TITLE
Implement synonymous-recoding control suite and repository workflow guide

### DIFF
--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -1,0 +1,77 @@
+# Genomics-LM Workflow Guide
+
+This guide establishes the mandatory scientific and engineering workflow for developers and AI agents working on the Genomics-LM codebase. It ensures all training and evaluation runs remain leakage-free, computationally efficient, and statistically validated.
+
+---
+
+## 1. Data Preparation and Leakage Prevention
+
+### The Golden Rule
+**Never stack independent sequence-level dataset splits.** This leads to P0 genomic and strain-level leakage.
+
+### Mandatory Workflow
+1. Define your dataset sources in a YAML config (e.g. `configs/tiny_mps.yaml`).
+2. Run [`build_global_manifest.py`](file:///Users/User/github/genomics-lm/scripts/build_global_manifest.py) to extract CDS records, group them globally by organism or taxonomy genus, and partition them into train/val/test splits:
+   ```bash
+   python -m scripts.build_global_manifest --config configs/tiny_mps.yaml --run-id <RUN_ID> --run-dir runs/<RUN_ID> --group-by genome
+   ```
+3. Verify that the output splits contain mutually exclusive genome sets by inspecting the generated `data/processed/global/<RUN_ID>/cds_meta.tsv`.
+
+---
+
+## 2. Next-Codon Perplexity Baseline Evaluation
+
+### The Golden Rule
+**Never report perplexity (PPL) points in isolation.** Raw perplexity is meaningless without composition-matched baselines.
+
+### Mandatory Workflow
+For every test evaluation, calculate and compare model performance against Uniform and Markov baselines:
+1. Run [`eval_ppl_baselines.py`](file:///Users/User/github/genomics-lm/scripts/eval_ppl_baselines.py) using the train and test splits:
+   ```bash
+   python -m scripts.eval_ppl_baselines --train_npz data/processed/global/<RUN_ID>/train_bs256.npz --test_npz data/processed/global/<RUN_ID>/test_bs256.npz --vocab_size 69
+   ```
+2. Report the **excess bits per codon** ($\Delta H$) and the perplexity drop over the 2nd-order Markov (Trigram) baseline.
+
+---
+
+## 3. Synonymous and Shuffling Controls
+
+### The Golden Rule
+**Verify if the model learns codon-level biophysics or just amino acid maps.**
+
+### Mandatory Workflow
+1. Generate control datasets from your test split:
+   ```bash
+   python -m scripts.generate_synonymous_controls --test_npz data/processed/global/<RUN_ID>/test_bs256.npz
+   ```
+   This outputs:
+   - `test_control_synonymous_bs256.npz` (random synonymous codons, same protein).
+   - `test_control_codon_shuffle_bs256.npz` (shuffled codons, same composition).
+   - `test_control_protein_shuffle_bs256.npz` (shuffled protein, same codon counts).
+2. Run [`evaluate_test.py`](file:///Users/User/github/genomics-lm/scripts/evaluate_test.py) on each of these control NPZs.
+3. Assert that the model's perplexity is significantly better (lower) on the natural test set compared to the synonymous recoding set.
+
+---
+
+## 4. Downstream Probe Controls
+
+### The Golden Rule
+**Always control for token-identity decodability in shape and classification probes.**
+
+### Mandatory Workflow
+When training linear probes (e.g. for DNA-shape or EC level classification), compare your pretrained embeddings against:
+1. **One-Hot Codon Identity vectors** (proves learning beyond local codon lookup).
+2. **Randomly Initialized Model Embeddings** (proves that the pretraining phase, and not just the neural architecture, is responsible for the representation quality).
+
+---
+
+## 5. Performance and Architectural Ablations
+
+Before merging changes that modify attention kernels (e.g., GQA, SDPA) or data loader structures:
+1. Run the throughput benchmark to record step rates:
+   ```bash
+   python -m scripts.benchmark_training_speed --config configs/tiny_mps.yaml
+   ```
+2. Track peak RAM and VRAM footprint.
+3. Validate that training loss/perplexity curves match baseline configurations to confirm mathematical equivalence.
+4. **Never call `torch.mps.empty_cache()` inside the training step loop** unless recovering from an OOM error. Cache flushes trigger expensive synchronization barriers on Apple Silicon.

--- a/scripts/generate_synonymous_controls.py
+++ b/scripts/generate_synonymous_controls.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+scripts/generate_synonymous_controls.py — Synonymous & Shuffling Control Suite Generator
+
+This script generates control variants of a test dataset to scientifically validate
+whether Genomics-LM encodes biological properties beyond basic composition and protein templates.
+
+It outputs:
+  1. Synonymous Mutated Control (preserves amino acid sequence, randomizes codon selection).
+  2. Codon Shuffled Control (shuffles codon order within each gene, preserving composition).
+  3. Protein Shuffled Control (shuffles amino acids, maintaining codon usage).
+
+Usage:
+  python -m scripts.generate_synonymous_controls --test_npz data/processed/global/my_run/test_bs256.npz
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from pathlib import Path
+import numpy as np
+
+# Standard Genetic Code
+AA_TO_CODONS = {
+    'A': ['GCT', 'GCC', 'GCA', 'GCG'],
+    'R': ['CGT', 'CGC', 'CGA', 'CGG', 'AGA', 'AGG'],
+    'N': ['AAT', 'AAC'],
+    'D': ['GAT', 'GAC'],
+    'C': ['TGT', 'TGC'],
+    'Q': ['CAA', 'CAG'],
+    'E': ['GAA', 'GAG'],
+    'G': ['GGT', 'GGC', 'GGA', 'GGG'],
+    'H': ['CAT', 'CAC'],
+    'I': ['ATT', 'ATC', 'ATA'],
+    'L': ['TTA', 'TTG', 'CTT', 'CTC', 'CTA', 'CTG'],
+    'K': ['AAA', 'AAG'],
+    'M': ['ATG'],
+    'F': ['TTT', 'TTC'],
+    'P': ['CCT', 'CCC', 'CCA', 'CCG'],
+    'S': ['TCT', 'TCC', 'TCA', 'TCG', 'AGT', 'AGC'],
+    'T': ['ACT', 'ACC', 'ACA', 'ACG'],
+    'W': ['TGG'],
+    'Y': ['TAT', 'TAC'],
+    'V': ['GTT', 'GTC', 'GTA', 'GTG'],
+    '*': ['TAA', 'TAG', 'TGA']  # Stop codons
+}
+
+CODON_TO_AA = {codon: aa for aa, codons in AA_TO_CODONS.items() for codon in codons}
+
+# Vocabulary mapping (must match codon_tokenize.py)
+CODONS = [a + b + c for a in "ACGT" for b in "ACGT" for c in "ACGT"]
+SPECIALS = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>"]
+VOCAB = SPECIALS + CODONS
+stoi = {tok: i for i, tok in enumerate(VOCAB)}
+itos = {i: tok for i, tok in enumerate(VOCAB)}
+
+def synonymous_mutate_sequence(seq: np.ndarray, rng: random.Random) -> np.ndarray:
+    out = np.copy(seq)
+    for i in range(len(seq)):
+        val = int(seq[i])
+        # Preserve specials (PAD=0, BOS=1, EOS=2, SEP=3)
+        if val < 4:
+            continue
+        codon_str = itos[val]
+        aa = CODON_TO_AA.get(codon_str)
+        if aa is None:
+            continue
+        synonyms = AA_TO_CODONS[aa]
+        chosen_codon = rng.choice(synonyms)
+        out[i] = stoi[chosen_codon]
+    return out
+
+def codon_shuffle_sequence(seq: np.ndarray, rng: random.Random) -> np.ndarray:
+    out = np.copy(seq)
+    # Find positions of sense codons (ids >= 4)
+    codon_indices = [i for i, val in enumerate(seq) if val >= 4]
+    if not codon_indices:
+        return out
+    
+    # Extract, shuffle, and re-insert
+    codon_vals = [seq[i] for i in codon_indices]
+    rng.shuffle(codon_vals)
+    for idx, i in enumerate(codon_indices):
+        out[i] = codon_vals[idx]
+    return out
+
+def protein_shuffle_sequence(seq: np.ndarray, rng: random.Random) -> np.ndarray:
+    out = np.copy(seq)
+    # Find indices of sense codons (ids >= 4)
+    codon_indices = [i for i, val in enumerate(seq) if val >= 4]
+    if not codon_indices:
+        return out
+        
+    # Translate to amino acids
+    aas = []
+    for i in codon_indices:
+        codon_str = itos[int(seq[i])]
+        aas.append(CODON_TO_AA.get(codon_str, 'M'))  # Default to Methionine if not found
+        
+    # Shuffle amino acids
+    rng.shuffle(aas)
+    
+    # Re-encode back to codon ids (randomly choosing synonymous codons for each shuffled amino acid)
+    for idx, i in enumerate(codon_indices):
+        aa = aas[idx]
+        syns = AA_TO_CODONS[aa]
+        chosen = rng.choice(syns)
+        out[i] = stoi[chosen]
+    return out
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--test_npz", required=True, help="Path to test NPZ dataset")
+    ap.add_argument("--seed", type=int, default=1337)
+    args = ap.parse_args()
+
+    test_path = Path(args.test_npz)
+    if not test_path.exists():
+        raise FileNotFoundError(f"Test NPZ not found: {test_path}")
+
+    print(f"[controls] Loading test dataset from {test_path}...")
+    with np.load(test_path) as data:
+        X = data["X"]
+        Y = data.get("Y", None)
+        lengths = data.get("lengths", None)
+
+    rng = random.Random(args.seed)
+
+    # 1. Synonymous Recoding
+    print("[controls] Generating Synonymous Recoding control...")
+    X_syn = np.copy(X)
+    for i in range(len(X)):
+        X_syn[i] = synonymous_mutate_sequence(X[i], rng)
+    
+    Y_syn = None
+    if Y is not None:
+        Y_syn = np.copy(Y)
+        for i in range(len(Y)):
+            Y_syn[i] = synonymous_mutate_sequence(Y[i], rng)
+
+    # 2. Codon Shuffling
+    print("[controls] Generating Codon Shuffling control...")
+    X_shuf = np.copy(X)
+    for i in range(len(X)):
+        X_shuf[i] = codon_shuffle_sequence(X[i], rng)
+        
+    Y_shuf = None
+    if Y is not None:
+        Y_shuf = np.copy(Y)
+        for i in range(len(Y)):
+            Y_shuf[i] = codon_shuffle_sequence(Y[i], rng)
+
+    # 3. Protein Shuffling
+    print("[controls] Generating Protein Shuffling control...")
+    X_prot = np.copy(X)
+    for i in range(len(X)):
+        X_prot[i] = protein_shuffle_sequence(X[i], rng)
+        
+    Y_prot = None
+    if Y is not None:
+        Y_prot = np.copy(Y)
+        for i in range(len(Y)):
+            Y_prot[i] = protein_shuffle_sequence(Y[i], rng)
+
+    # Save outputs
+    out_dir = test_path.parent
+    
+    npz_syn_path = out_dir / f"test_control_synonymous_bs{X.shape[1] if X.ndim > 1 else 256}.npz"
+    npz_shuf_path = out_dir / f"test_control_codon_shuffle_bs{X.shape[1] if X.ndim > 1 else 256}.npz"
+    npz_prot_path = out_dir / f"test_control_protein_shuffle_bs{X.shape[1] if X.ndim > 1 else 256}.npz"
+
+    def save_npz(path, x_arr, y_arr):
+        if lengths is not None:
+            np.savez_compressed(path, X=x_arr, lengths=lengths)
+        else:
+            np.savez_compressed(path, X=x_arr, Y=y_arr)
+        print(f"[controls] Saved control dataset to {path}")
+
+    save_npz(npz_syn_path, X_syn, Y_syn)
+    save_npz(npz_shuf_path, X_shuf, Y_shuf)
+    save_npz(npz_prot_path, X_prot, Y_prot)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -127,3 +127,33 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
     assert "Unigram" in res_baselines.stdout
     
     print("Baseline PPL run completed successfully.")
+
+    # 4. Run generate_synonymous_controls script
+    cmd_controls = [
+        "python",
+        "-m",
+        "scripts.generate_synonymous_controls",
+        "--test_npz",
+        str(test_npz),
+    ]
+    res_controls = subprocess.run(cmd_controls, capture_output=True, text=True)
+    assert res_controls.returncode == 0, f"Controls generation failed: {res_controls.stderr}"
+    
+    # Check outputs exist and have correct shape
+    out_dir = test_npz.parent
+    control_syn = out_dir / "test_control_synonymous_bs128.npz"
+    control_shuf = out_dir / "test_control_codon_shuffle_bs128.npz"
+    control_prot = out_dir / "test_control_protein_shuffle_bs128.npz"
+    
+    assert control_syn.exists()
+    assert control_shuf.exists()
+    assert control_prot.exists()
+    
+    with np.load(test_npz) as test_data:
+        expected_len = test_data["X"].shape[0]
+
+    with np.load(control_syn) as data:
+        assert data["X"].shape == (expected_len, 128)
+        
+    print("Synonymous controls test completed successfully.")
+


### PR DESCRIPTION
This PR adds scripts/generate_synonymous_controls.py to build synonymous and shuffled control datasets, registers them in test_global_split_and_baselines.py, and adds docs/WORKFLOW_GUIDE.md to define mandatory scientific validation workflows.