### PR TITLE
Implement pretraining split duplicate and near-duplicate auditor

### DIFF
--- a/scripts/audit_duplicates.py
+++ b/scripts/audit_duplicates.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+scripts/audit_duplicates.py — Pretraining Split Cross-Leakage Auditor
+
+This script audits pretraining splits for exact sequence duplicates and near-duplicates
+using sliding-window codon subsequence sharing (for window sizes L = 10, 20, and 30 codons).
+
+Usage:
+  python -m scripts.audit_duplicates --train_npz data/processed/train_bs256.npz --test_npz data/processed/test_bs256.npz
+"""
+
+import argparse
+from pathlib import Path
+import numpy as np
+
+def extract_sequence_tokens(seq_ids):
+    # Strip padding (value 0)
+    return [int(val) for val in seq_ids if val != 0]
+
+def get_sliding_lmers(seq, L):
+    if len(seq) < L:
+        return set()
+    return {tuple(seq[i : i + L]) for i in range(len(seq) - L + 1)}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--train_npz", help="Path to train NPZ dataset")
+    ap.add_argument("--test_npz", help="Path to test NPZ dataset")
+    args = ap.parse_args()
+
+    # 1. Resolve Paths
+    train_path = args.train_npz
+    test_path = args.test_npz
+
+    if not train_path or not test_path:
+        # Fallback to defaults
+        base_dir = Path("data/processed")
+        if not train_path:
+            paths = list(base_dir.glob("**/train*.npz"))
+            train_path = paths[0] if paths else base_dir / "train_bs256.npz"
+        if not test_path:
+            paths = list(base_dir.glob("**/test*.npz"))
+            test_path = paths[0] if paths else base_dir / "test_bs256.npz"
+
+    train_path = Path(train_path)
+    test_path = Path(test_path)
+
+    if not train_path.exists():
+        raise FileNotFoundError(f"Train NPZ not found: {train_path}")
+    if not test_path.exists():
+        raise FileNotFoundError(f"Test NPZ not found: {test_path}")
+
+    print(f"[audit] Loading train dataset: {train_path}...")
+    with np.load(train_path) as data:
+        X_train = data["X"]
+
+    print(f"[audit] Loading test dataset: {test_path}...")
+    with np.load(test_path) as data:
+        X_test = data["X"]
+
+    print(f"[audit] Extracted {len(X_train)} training sequences, {len(X_test)} test sequences.")
+
+    # 2. Extract clean sense codon token sequences
+    train_seqs = [extract_sequence_tokens(seq) for seq in X_train]
+    test_seqs = [extract_sequence_tokens(seq) for seq in X_test]
+
+    # 3. Exact Duplicate Check
+    print("[audit] Running exact sequence duplicate check...")
+    train_hashes = {tuple(seq) for seq in train_seqs if seq}
+    exact_duplicates = 0
+    for seq in test_seqs:
+        if not seq:
+            continue
+        if tuple(seq) in train_hashes:
+            exact_duplicates += 1
+
+    exact_pct = (exact_duplicates / len(test_seqs)) * 100 if test_seqs else 0.0
+    print(f"  Exact duplicate sequences in test split: {exact_duplicates} / {len(test_seqs)} ({exact_pct:.2f}%)")
+
+    # 4. Near-Duplicate Check (Contiguous Subsequence Sharing)
+    print("[audit] Running sliding-window near-duplicate check...")
+    window_sizes = [10, 20, 30]
+    
+    print("\n| Window Size (Codons / bp) | Unique Train L-mers | Shared Test Sequences | Leakage Percentage |")
+    print("| :--- | :---: | :---: | :---: |")
+
+    for L in window_sizes:
+        bp = L * 3
+        # Index all unique L-mers in the training set
+        train_lmers = set()
+        for seq in train_seqs:
+            train_lmers.update(get_sliding_lmers(seq, L))
+
+        # Check test sequences for overlap
+        shared_seqs = 0
+        for seq in test_seqs:
+            test_lmers = get_sliding_lmers(seq, L)
+            if not test_lmers.isdisjoint(train_lmers):
+                shared_seqs += 1
+
+        leak_pct = (shared_seqs / len(test_seqs)) * 100 if test_seqs else 0.0
+        print(f"| {L:2} codons ({bp:2} bp)       | {len(train_lmers):19,} | {shared_seqs:21,} | {leak_pct:17.2f}% |")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_audit_duplicates.py
+++ b/tests/test_audit_duplicates.py
@@ -1,0 +1,51 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+
+def test_audit_duplicates_logic(tmp_path):
+    train_npz = tmp_path / "train.npz"
+    test_npz = tmp_path / "test.npz"
+    
+    # vocab sizes and setup
+    # 0: PAD, 4+: sense codons
+    # Train sequences:
+    # 1. [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] (len 12)
+    # 2. [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30] (len 11)
+    # 3. [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50] (len 11)
+    X_train = np.zeros((3, 16), dtype=np.int64)
+    X_train[0, :12] = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    X_train[1, :11] = [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+    X_train[2, :11] = [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50]
+    
+    # Test sequences:
+    # 1. [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] (Exact duplicate of train seq 1)
+    # 2. [90, 91, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 92] (Shares 10-mer [20-29] with train seq 2)
+    # 3. [100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110] (Completely unique)
+    X_test = np.zeros((3, 16), dtype=np.int64)
+    X_test[0, :12] = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    X_test[1, :13] = [90, 91, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 92]
+    X_test[2, :11] = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110]
+    
+    np.savez(train_npz, X=X_train)
+    np.savez(test_npz, X=X_test)
+    
+    # Run the script
+    cmd = [
+        "python",
+        "-m",
+        "scripts.audit_duplicates",
+        "--train_npz", str(train_npz),
+        "--test_npz", str(test_npz)
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode == 0, f"Script failed: {res.stderr}\nStdout: {res.stdout}"
+    
+    # Expected assertions:
+    # 1 exact duplicate out of 3 -> 33.33%
+    assert "Exact duplicate sequences in test split: 1 / 3 (33.33%)" in res.stdout
+    # L=10: test seq 1 (exact) and test seq 2 (10-mer overlap) should both trigger overlap -> 2 out of 3 -> 66.67%
+    assert "10 codons" in res.stdout
+    assert "66.67%" in res.stdout
+    # L=30: none should trigger overlap except maybe exact (which is len 12 < 30) so 0%
+    assert "30 codons" in res.stdout
+    assert "0.00%" in res.stdout


### PR DESCRIPTION
This PR adds scripts/audit_duplicates.py to perform exact and sliding-window codon sequence duplicate checks across pretraining splits (train vs. test). It reports duplication rates and near-duplicate subsequence sharing at L=10, 20, and 30 codon sizes to help detect plasmid/MGE/housekeeping gene overlap. It also adds tests/test_audit_duplicates.py to verify duplicate checking arithmetic.