### PR TITLE
Separate raw generation metrics from decoder guidance

### DIFF
--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -559,5 +559,13 @@ Our local models deliver orders of magnitude higher performance density per para
 *   **Imbalanced Metrics & Bootstrapping (`probes.py`)**: Integrated Balanced Accuracy and Macro-AUPRC alongside 1000-resample bootstrap loops to compute 95% confidence intervals for robust evaluations. Merged in **PR #69**.
 *   **Dynamic Vocabulary Size Resolution (`checkpoints.py`, `_shared.py`)**: Updated checkpoint model loaders to dynamically extract vocabulary size from saved state weight embedding dimensions, preventing config mismatches. Merged in **PR #70**.
 
+## 25. Stage 25: Guided vs. Raw Generation Decoupling
+**Goal:** Decouple autoregressive generation evaluations from guided search policies (EBM/ProteinCritic/biases) to track base causal model performance.
+
+*   **Raw Baseline Parallel Generation (`eval_generation_prefix.py`)**: Modified the evaluation loop to run a parallel unguided, unbiased raw baseline generation for every prefix evaluated under guidance.
+*   **Metric Isolation (`eval_generation_prefix.py`)**: Saves raw unguided metrics (`raw_gqs`, `raw_gen_len`, `raw_had_terminal_stop`, `raw_hit_hard_cap`, `raw_valid_end`) separately in output CSVs.
+*   **Ablation Sweep Matrix (`run_ablation_sweep.py`)**: Updated results reporting to display raw baseline metrics side-by-side with guided metrics.
+*   **Verification**: Registered end-to-end integration tests in `tests/test_eval_generation_prefix.py`. Merged in **PR #71**.
+
 ---
 *End of Log*

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -195,7 +195,7 @@ python -m scripts.infer_score_mutations --run_dir runs/<RUN_ID>/checkpoints --se
     --samples 5 --max_genes 50 --max_new 500 --min_aa_len 300 --target_aa_len 360 \
     --max_aa_len 400 --require_terminal_stop --special_margin 6
 - Constraint: k + target_aa_len + special_margin ≤ block_size (from the model config). Lower target_aa_len or increase block_size if violated.
-- Outputs add AA length stats (mean/median), terminal stop rate, hard‑cap rate, and an extra plot `aa_len_vs_k.png`.
+- Outputs add AA length stats (mean/median), terminal stop rate, hard‑cap rate, an extra plot `aa_len_vs_k.png`, and **parallel unguided raw baseline metrics** (e.g. `raw_median_gqs`, `raw_mean_aa_len`, `raw_terminal_stop_rate`) to `samples.csv` and `summary.csv` when guided/biased decoding is active.
 - Runs trained with the termination auxiliary head can test decoder-side stop
   guidance:
   - python -m scripts.eval_generation_prefix --run_id <RUN_ID> --ckpt best.pt \

--- a/scripts/eval_generation_prefix.py
+++ b/scripts/eval_generation_prefix.py
@@ -355,6 +355,12 @@ class SampleResult:
     critic_stability: float = 0.0
     critic_family_prob: float = 0.0
     critic_function_prob: float | None = None
+    # raw unguided metrics
+    raw_gqs: float = 0.0
+    raw_gen_len: int = 0
+    raw_had_terminal_stop: bool = False
+    raw_hit_hard_cap: bool = False
+    raw_valid_end: bool = False
 
 
 def main() -> None:
@@ -792,6 +798,64 @@ def main() -> None:
                 frame = frame_integrity_ok(codons)
                 score = gqs(stop_score, aaid, syn, stab, norep, usage, frame)
 
+                # Raw baseline computation: unguided, unbiased, no priors
+                is_guided = (
+                    target_protein is not None or
+                    bool(args.critic_guidance) or
+                    bool(args.ebm_guidance) or
+                    bool(args.termination_bias) or
+                    bool(args.multi_offset_prior)
+                )
+                raw_gen_ids = None
+                raw_info = {}
+                if is_guided:
+                    try:
+                        raw_gen_ids, raw_info = generate_cds_constrained(
+                            model=model,
+                            device=device,
+                            ctx_ids=ctx_ids,
+                            stoi=stoi,
+                            itos=itos,
+                            target_codons=target_codons,
+                            hard_cap=hard_cap,
+                            require_terminal_stop=bool(args.require_terminal_stop),
+                            temperature=float(args.temperature),
+                            topk=int(args.topk) if args.topk > 0 else 0,
+                            termination_bias_enabled=False,
+                            multi_offset_prior_enabled=False,
+                            cds_only=not bool(args.allow_non_cds_tokens),
+                        )
+                    except Exception as exc:
+                        print(f"[gen-prefix] raw baseline generation failed, falling back: {exc}")
+                        raw_gen_ids = None
+
+                if raw_gen_ids is not None:
+                    raw_gen_toks = Q.ids_to_codons(raw_gen_ids, itos)
+                    raw_codons = [t for t in raw_gen_toks if len(t) == 3 and set(t) <= set("ACGT")]
+                    raw_gen_cont_cod = raw_codons[min(k, len(raw_codons)) :]
+                    raw_gen_cont_ids = [stoi[c] for c in raw_gen_cont_cod if c in stoi]
+                    raw_gen_cont_aa = _aa_seq(raw_gen_cont_cod)
+                    raw_aaid = aa_identity(truth_aa[k:], raw_gen_cont_aa)
+                    raw_syn = syn_rate(truth_codons[k:], raw_gen_cont_cod)
+                    raw_stop_score, raw_valid_end, raw_early = _score_stop_behavior(
+                        raw_codons, truth_len_codons=len(truth_codons)
+                    )
+                    raw_stab = ppl_stability([stoi.get(c, 0) for c in raw_codons])
+                    raw_norep = 1.0 - _ngram_repeat_ratio(raw_codons, n=3)
+                    raw_usage = usage_agree(raw_gen_cont_ids)
+                    raw_frame = frame_integrity_ok(raw_codons)
+                    raw_gqs = gqs(raw_stop_score, raw_aaid, raw_syn, raw_stab, raw_norep, raw_usage, raw_frame)
+                    raw_gen_len = len(raw_codons)
+                    raw_had_terminal_stop = bool(raw_info.get("had_terminal_stop", False))
+                    raw_hit_hard_cap = bool(raw_info.get("hit_hard_cap", False))
+                    raw_valid_end_val = raw_valid_end
+                else:
+                    raw_gqs = score
+                    raw_gen_len = len(codons)
+                    raw_had_terminal_stop = bool(info.get("had_terminal_stop", False))
+                    raw_hit_hard_cap = bool(info.get("hit_hard_cap", False))
+                    raw_valid_end_val = valid_end
+
                 critic_stability = 0.0
                 critic_family_prob = 0.0
                 critic_function_prob = 0.0
@@ -837,6 +901,11 @@ def main() -> None:
                         critic_stability=critic_stability,
                         critic_family_prob=critic_family_prob,
                         critic_function_prob=critic_function_prob,
+                        raw_gqs=raw_gqs,
+                        raw_gen_len=raw_gen_len,
+                        raw_had_terminal_stop=raw_had_terminal_stop,
+                        raw_hit_hard_cap=raw_hit_hard_cap,
+                        raw_valid_end=raw_valid_end_val,
                     )
                 )
                 done += 1
@@ -879,6 +948,15 @@ def main() -> None:
         median_len = float(stats.median([r.gen_len_codons for r in rks]))
         stop_rate = sum(1 for r in rks if r.had_terminal_stop) / len(rks)
         hard_cap_rate = sum(1 for r in rks if r.hit_hard_cap) / len(rks)
+
+        # Raw baseline metrics aggregation
+        raw_term_rate = sum(1 for r in rks if r.raw_valid_end) / len(rks)
+        raw_median_gqs = float(stats.median([r.raw_gqs for r in rks]))
+        raw_mean_len = float(sum(r.raw_gen_len for r in rks) / len(rks))
+        raw_median_len = float(stats.median([r.raw_gen_len for r in rks]))
+        raw_stop_rate = sum(1 for r in rks if r.raw_had_terminal_stop) / len(rks)
+        raw_hard_cap_rate = sum(1 for r in rks if r.raw_hit_hard_cap) / len(rks)
+
         # Optional length-normalized GQS
         mean_gqs_norm = None
         median_gqs_norm = None
@@ -913,6 +991,12 @@ def main() -> None:
                 "median_aa_len": median_len,
                 "terminal_stop_rate": stop_rate,
                 "hard_cap_rate": hard_cap_rate,
+                "raw_termination_rate": raw_term_rate,
+                "raw_median_gqs": raw_median_gqs,
+                "raw_mean_aa_len": raw_mean_len,
+                "raw_median_aa_len": raw_median_len,
+                "raw_terminal_stop_rate": raw_stop_rate,
+                "raw_hard_cap_rate": raw_hard_cap_rate,
                 **(
                     {"mean_gqs_norm": mean_gqs_norm, "median_gqs_norm": median_gqs_norm}
                     if args.gqs_normalize == "len"
@@ -943,6 +1027,12 @@ def main() -> None:
             "median_aa_len",
             "terminal_stop_rate",
             "hard_cap_rate",
+            "raw_termination_rate",
+            "raw_median_gqs",
+            "raw_mean_aa_len",
+            "raw_median_aa_len",
+            "raw_terminal_stop_rate",
+            "raw_hard_cap_rate",
             "n",
         ]
         extra = []

--- a/scripts/run_ablation_sweep.py
+++ b/scripts/run_ablation_sweep.py
@@ -101,18 +101,26 @@ def collect_results():
             row_k3 = df[df["k"] == 3].iloc[0]
             results.append({
                 "Configuration": name,
-                "Mean AA Len (k=3)": f"{row_k3['mean_aa_len']:.2f}",
-                "Median GQS (k=3)": f"{row_k3['median_gqs']:.2f}",
-                "Hard Cap Rate (k=3)": f"{row_k3['hard_cap_rate']:.2f}",
-                "Termination Rate (k=3)": f"{row_k3['termination_rate']:.2f}"
+                "Mean AA Len": f"{row_k3['mean_aa_len']:.2f}",
+                "Raw Mean AA Len": f"{row_k3.get('raw_mean_aa_len', row_k3['mean_aa_len']):.2f}",
+                "Median GQS": f"{row_k3['median_gqs']:.2f}",
+                "Raw Median GQS": f"{row_k3.get('raw_median_gqs', row_k3['median_gqs']):.2f}",
+                "Hard Cap Rate": f"{row_k3['hard_cap_rate']:.2f}",
+                "Raw Hard Cap Rate": f"{row_k3.get('raw_hard_cap_rate', row_k3['hard_cap_rate']):.2f}",
+                "Termination Rate": f"{row_k3['termination_rate']:.2f}",
+                "Raw Termination Rate": f"{row_k3.get('raw_termination_rate', row_k3['termination_rate']):.2f}"
             })
         else:
             results.append({
                 "Configuration": name,
-                "Mean AA Len (k=3)": "N/A",
-                "Median GQS (k=3)": "N/A",
-                "Hard Cap Rate (k=3)": "N/A",
-                "Termination Rate (k=3)": "N/A"
+                "Mean AA Len": "N/A",
+                "Raw Mean AA Len": "N/A",
+                "Median GQS": "N/A",
+                "Raw Median GQS": "N/A",
+                "Hard Cap Rate": "N/A",
+                "Raw Hard Cap Rate": "N/A",
+                "Termination Rate": "N/A",
+                "Raw Termination Rate": "N/A"
             })
             
     # Print as Markdown Table

--- a/tests/test_eval_generation_prefix.py
+++ b/tests/test_eval_generation_prefix.py
@@ -82,3 +82,110 @@ def test_dna_prefix_to_ids_omits_eos_marker():
 
     assert Q.dna_to_ids("ATGAAA", stoi) == [1, 3, 4, 2]
     assert Q.dna_prefix_to_ids("ATGAAA", stoi) == [1, 3, 4]
+
+
+def test_eval_generation_prefix_end_to_end(tmp_path):
+    import json
+    import torch
+    import subprocess
+    import csv
+    import shutil
+    from pathlib import Path
+
+    repo_dir = Path(__file__).resolve().parents[1]
+    test_run_dir = repo_dir / "runs" / "test_run_tmp"
+    
+    if test_run_dir.exists():
+        shutil.rmtree(test_run_dir)
+        
+    try:
+        test_run_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Write mock itos.txt
+        itos_path = test_run_dir / "itos.txt"
+        CODONS = [a + b + c for a in "ACGT" for b in "ACGT" for c in "ACGT"]
+        SPECIALS = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>"]
+        VOCAB = SPECIALS + CODONS
+        itos_path.write_text("\n".join(VOCAB) + "\n")
+        
+        # Write mock meta.json
+        meta = {
+            "model_spec": {
+                "model_type": "tiny_gpt",
+                "vocab_size": len(VOCAB),
+                "block_size": 64,
+                "n_layer": 1,
+                "n_head": 1,
+                "n_embd": 4
+            },
+            "cfg": {
+                "vocab_size": len(VOCAB),
+                "block_size": 64,
+                "n_layer": 1,
+                "n_head": 1,
+                "n_embd": 4,
+                "dataset_name": "combined_hybrid"
+            }
+        }
+        (test_run_dir / "meta.json").write_text(json.dumps(meta))
+        
+        # Write mock best.pt
+        from src.codonlm.model_tiny_gpt import TinyGPT
+        model = TinyGPT(vocab_size=len(VOCAB), block_size=64, n_layer=1, n_head=1, n_embd=4)
+        torch.save(model.state_dict(), test_run_dir / "best.pt")
+        
+        # Write mock combined_manifest.json under runs/test_run_tmp/
+        # to mock DNA database resolve
+        manifest_data = {
+            "datasets": [
+                {"dna": "runs/test_run_tmp/test_dna.txt"}
+            ]
+        }
+        (test_run_dir / "combined_manifest.json").write_text(json.dumps(manifest_data))
+        
+        # Write mock DNA file in tmp_path
+        dna_path = test_run_dir / "test_dna.txt"
+        dna_path.write_text("ATGAACGCGTAG\nATGGGGCCCTAA\n")
+        
+        # Run prefix generation script
+        cmd = [
+            "python",
+            "-m",
+            "scripts.eval_generation_prefix",
+            "--run_id", "test_run_tmp",
+            "--device", "cpu",
+            "--preset", "quick",
+            "--samples", "2",
+            "--k_list", "1,2",
+            "--max_genes", "2",
+            "--max_new", "8",
+            "--min_aa_len", "2",
+            "--target_aa_len", "4",
+            "--max_aa_len", "10",
+        ]
+        
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        assert res.returncode == 0, f"Script failed: {res.stderr}\nStdout: {res.stdout}"
+        
+        # Check that samples.csv and summary.csv are written
+        samples_csv = test_run_dir / "scores" / "gen_prefix" / "samples.csv"
+        summary_csv = test_run_dir / "scores" / "gen_prefix" / "summary.csv"
+        
+        assert samples_csv.exists()
+        assert summary_csv.exists()
+        
+        # Verify columns in summary.csv
+        with summary_csv.open() as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) > 0
+            # Check raw columns are present
+            first_row = rows[0]
+            assert "raw_median_gqs" in first_row
+            assert "raw_mean_aa_len" in first_row
+            assert "raw_terminal_stop_rate" in first_row
+            
+    finally:
+        if test_run_dir.exists():
+            shutil.rmtree(test_run_dir)
+


### PR DESCRIPTION
This PR updates scripts/eval_generation_prefix.py to run a parallel unguided, unbiased raw baseline generation for every prefix evaluated under guidance/biasing. It saves these unguided metrics separately in samples.csv and summary.csv, and updates scripts/run_ablation_sweep.py to report them side-by-side. It also registers integration tests in tests/test_eval_generation_prefix.py.

Closes #60