### PR TITLE
Improve MPS training efficiency and benchmarks

### DIFF
--- a/configs/stage2.6_mps_benchmark.yaml
+++ b/configs/stage2.6_mps_benchmark.yaml
@@ -1,0 +1,72 @@
+# Throughput-only matrix. It does not alter the production Stage 2.6 config.
+base_config: configs/stage2.6_large_scaling.yaml
+base_overrides:
+  transfer_from: null
+  force_gpu: true
+warmup_steps: 20
+measure_steps: 100
+variants:
+  - name: baseline_unbucketed
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: true
+      amp: true
+      bucket_batching: false
+  - name: baseline_bucketed
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: true
+      amp: true
+      bucket_batching: true
+      n_buckets: 8
+  - name: b4_e128_no_checkpoint
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: false
+      amp: true
+      bucket_batching: true
+      n_buckets: 8
+  - name: b8_e128_no_checkpoint
+    overrides:
+      batch_size: 8
+      grad_accum_steps: 16
+      use_checkpoint: false
+      amp: true
+      bucket_batching: true
+      n_buckets: 8
+  - name: b4_e32_no_checkpoint
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 8
+      use_checkpoint: false
+      amp: true
+      bucket_batching: true
+      n_buckets: 8
+  - name: b4_e64_no_checkpoint
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 16
+      use_checkpoint: false
+      amp: true
+      bucket_batching: true
+      n_buckets: 8
+  - name: b4_e128_gqa4
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      n_kv_head: 2
+      use_checkpoint: true
+      amp: true
+      bucket_batching: true
+      n_buckets: 8
+  - name: b4_e128_fp32
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: true
+      amp: false
+      bucket_batching: true
+      n_buckets: 8

--- a/configs/stage2.6_mps_followup.yaml
+++ b/configs/stage2.6_mps_followup.yaml
@@ -1,0 +1,31 @@
+# Follow-up matrix combining the strongest settings from stage2.6_mps_benchmark.
+base_config: configs/stage2.6_large_scaling.yaml
+base_overrides:
+  transfer_from: null
+  force_gpu: true
+  use_checkpoint: false
+  bucket_batching: true
+  n_buckets: 8
+warmup_steps: 20
+measure_steps: 100
+variants:
+  - name: b8_e128_no_checkpoint_amp
+    overrides:
+      batch_size: 8
+      grad_accum_steps: 16
+      amp: true
+  - name: b8_e128_no_checkpoint_fp32
+    overrides:
+      batch_size: 8
+      grad_accum_steps: 16
+      amp: false
+  - name: b16_e128_no_checkpoint_amp
+    overrides:
+      batch_size: 16
+      grad_accum_steps: 8
+      amp: true
+  - name: b16_e128_no_checkpoint_fp32
+    overrides:
+      batch_size: 16
+      grad_accum_steps: 8
+      amp: false

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -156,6 +156,52 @@ uses subprocesses for each candidate so OOM/allocation failures can be recorded
 without aborting the whole benchmark. With `force_gpu: true`, it fails fast if
 the run would fall back to CPU instead of MPS/CUDA.
 
+Candidates are ranked by non-PAD tokens per second. Reports also retain raw
+processed-token and sequence throughput, and include padding fraction,
+microbatch timing, optimizer-step timing, and backend memory peaks where the
+installed PyTorch backend exposes them.
+
+For the broader Stage 2.6 checkpointing, batch, GQA, and precision matrix, run:
+
+```bash
+caffeinate -i python -m scripts.benchmark_training_speed \
+  --matrix configs/stage2.6_mps_benchmark.yaml \
+  --out runs/stage2.6_mps_benchmark
+```
+
+Each variant runs in an isolated subprocess. The matrix is throughput-only and
+does not rewrite the production Stage 2.6 configuration.
+
+Before training a similar new dataset, use the same matrix as a short smoke
+test. CLI values override the matrix's default 20 warmup and 100 measured
+microbatches:
+
+```bash
+caffeinate -i python -m scripts.benchmark_training_speed \
+  --matrix configs/stage2.6_mps_benchmark.yaml \
+  --warmup 5 \
+  --steps 20 \
+  --out runs/stage2.6_mps_smoke
+```
+
+`--warmup` and `--steps` count microbatches, not optimizer updates. Both commands
+write `results.csv` and `results.json` under the requested output directory.
+Compare `non_pad_tokens_per_sec` first, then confirm `padding_fraction`,
+`peak_driver_bytes`, and candidate status before selecting a setting.
+
+For a single existing training configuration rather than a variant matrix:
+
+```bash
+python -m scripts.benchmark_training_speed \
+  --config configs/my_training_config.yaml \
+  --warmup 5 \
+  --steps 20 \
+  --out runs/my_training_smoke
+```
+
+For a materially different dataset or model, copy the Stage 2.6 matrix manifest,
+point `base_config` at the new training YAML, and adjust its named overrides.
+
 When resuming mid-epoch, do not force a new sweep unless needed. If `--force`
 selects a different `batch_size` or `grad_accum_steps` than the checkpoint used,
 the trainer restores model/optimizer state but ignores the old mid-epoch skip
@@ -265,7 +311,11 @@ You can convert any `.npz` dataset into uncompressed `.npy` arrays, enabling **t
 python -m scripts.convert_npz_to_npy path/to/dataset.npz
 ```
 
-This generates `_X.npy`, `_Y.npy` (and/or `_lengths.npy`) files in the same directory. The data loaders in `genomics-lm` will automatically detect these `.npy` arrays and load them in memory-mapped mode without changing any YAML training configurations.
+This generates `_X.npy`, `_Y.npy` (and/or `_lengths.npy`) files in the same
+directory. Set `use_mmap: true` in the training YAML to select
+`MmapPackedDataset`; it will report `storage_mode=npy_mmap` when all required
+sidecars are present. If they are absent, it reports `storage_mode=npz_memory`
+and warns that compressed NPZ members are being loaded into memory.
 
 # Compare multiple runs and produce a table + plots
 python -m scripts.compare_runs

--- a/scripts/benchmark_training_speed.py
+++ b/scripts/benchmark_training_speed.py
@@ -1,61 +1,57 @@
-"""
-scripts/benchmark_training_speed.py — Training throughput benchmark.
-
-Measures tokens per second for a mini-run (N steps) under different
-optimization configurations and prints a comparison table.
-
-Usage:
-    python -m scripts.benchmark_training_speed --config configs/stage2.6_large_scaling.yaml
-    python -m scripts.benchmark_training_speed --config configs/stage2.6_optimized.yaml
-    python -m scripts.benchmark_training_speed  # auto-runs both and compares
-"""
+"""Subprocess-isolated CodonLM training throughput benchmarks."""
 
 from __future__ import annotations
 
 import argparse
-import time
+import csv
+import json
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-import numpy as np
 import torch
 import yaml
 
-
-def _load_cfg(path: str) -> dict:
-    with open(path) as f:
-        return yaml.safe_load(f)
+from scripts.optimize_train_batching import run_candidate_benchmark, run_candidate_subprocess
 
 
-def _build_model(cfg: dict, device: torch.device):
-    from src.codonlm.model_tiny_gpt import TinyGPT
-    model = TinyGPT(
-        cfg["vocab_size"],
-        cfg["block_size"],
-        cfg["n_layer"],
-        cfg["n_head"],
-        cfg["n_embd"],
-        cfg.get("dropout", 0.0),
-        n_kv_head=cfg.get("n_kv_head"),
-        use_sdpa=cfg.get("use_sdpa", False),
-    ).to(device)
-    model.train()
-    return model
+def _load_cfg(path: str | Path) -> dict[str, Any]:
+    return yaml.safe_load(Path(path).read_text()) or {}
 
 
-def _build_loader(cfg: dict):
-    from src.codonlm.data_loading import (
-        build_codon_lm_dataloaders,
-        build_codon_lm_datasets,
-    )
-
-    train_npz = cfg.get("train_npz", cfg.get("train_paths", []))
-    if isinstance(train_npz, str):
-        train_npz = [train_npz]
-
-    ds, val_ds = build_codon_lm_datasets(train_npz, train_npz, use_mmap=bool(cfg.get("use_mmap", False)))
-    loader, _, _, _ = build_codon_lm_dataloaders(ds, val_ds, cfg)
-    return loader
+def _result_for_config(
+    cfg: dict[str, Any],
+    *,
+    name: str,
+    n_steps: int,
+    warmup_steps: int,
+    device: Optional[torch.device] = None,
+) -> dict[str, Any]:
+    batch_size = int(cfg["batch_size"])
+    grad_accum_steps = int(cfg.get("grad_accum_steps", 1))
+    if device is None:
+        result = run_candidate_subprocess(
+            cfg,
+            (batch_size, grad_accum_steps),
+            warmup_steps=warmup_steps,
+            measure_steps=n_steps,
+            force_gpu=bool(cfg.get("force_gpu", False)),
+        )
+    else:
+        result = run_candidate_benchmark(
+            cfg,
+            batch_size=batch_size,
+            grad_accum_steps=grad_accum_steps,
+            warmup_steps=warmup_steps,
+            measure_steps=n_steps,
+            force_gpu=device.type != "cpu",
+            device_override=device,
+        )
+    result["config"] = name
+    result["use_checkpoint"] = bool(cfg.get("use_checkpoint", cfg.get("grad_checkpointing", False)))
+    result["n_kv_head"] = cfg.get("n_kv_head")
+    result["sep_mask_enabled"] = bool(cfg.get("sep_mask_enabled", True))
+    result["amp_requested"] = bool(cfg.get("amp", True))
+    return result
 
 
 def benchmark(
@@ -63,122 +59,107 @@ def benchmark(
     n_steps: int = 30,
     warmup_steps: int = 5,
     device: Optional[torch.device] = None,
-) -> dict:
-    """Run N forward+backward steps and return throughput metrics."""
+) -> dict[str, Any]:
     cfg = _load_cfg(config_path)
-    if device is None:
-        if torch.cuda.is_available():
-            device = torch.device("cuda")
-        elif torch.backends.mps.is_available():
-            device = torch.device("mps")
-        else:
-            device = torch.device("cpu")
-
-    model = _build_model(cfg, device)
-    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
-
-    sep_mask_enabled = bool(cfg.get("sep_mask_enabled", True))
-
-    try:
-        loader = _build_loader(cfg)
-        loader_iter = iter(loader)
-    except Exception as exc:
-        return {"error": str(exc), "config": config_path}
-
-    # Metrics
-    total_tokens = 0
-    step_times = []
-
-    for step in range(n_steps + warmup_steps):
-        try:
-            xb, yb = next(loader_iter)
-        except StopIteration:
-            loader_iter = iter(loader)
-            xb, yb = next(loader_iter)
-
-        xb, yb = xb.to(device), yb.to(device)
-
-        t0 = time.perf_counter()
-        optimizer.zero_grad()
-
-        # TinyGPT returns (logits, loss); pass targets for built-in CE loss
-        logits, loss = model(xb, targets=yb)
-        B, T = xb.shape
-        loss.backward()
-        optimizer.step()
-
-        if device.type == "mps":
-            torch.mps.synchronize()
-        elif device.type == "cuda":
-            torch.cuda.synchronize()
-
-        t1 = time.perf_counter()
-
-        if step >= warmup_steps:
-            step_times.append(t1 - t0)
-            total_tokens += B * T
-
-    avg_step_ms = np.mean(step_times) * 1000
-    tokens_per_sec = total_tokens / sum(step_times)
-
-    n_params = sum(p.numel() for p in model.parameters())
-
-    return {
-        "config": Path(config_path).stem,
-        "device": str(device),
-        "n_params": n_params,
-        "batch_size": cfg["batch_size"],
-        "n_kv_head": cfg.get("n_kv_head", "MHA"),
-        "use_mmap": cfg.get("use_mmap", False),
-        "bucket_batching": cfg.get("bucket_batching", False),
-        "sep_mask_enabled": sep_mask_enabled,
-        "use_sdpa": cfg.get("use_sdpa", False),
-        "avg_step_ms": round(avg_step_ms, 1),
-        "tokens_per_sec": round(tokens_per_sec),
-        "n_steps": n_steps,
-    }
+    return _result_for_config(
+        cfg,
+        name=Path(config_path).stem,
+        n_steps=n_steps,
+        warmup_steps=warmup_steps,
+        device=device,
+    )
 
 
-def main(argv=None):
-    ap = argparse.ArgumentParser(description="Training throughput benchmark")
-    ap.add_argument("--config", nargs="+", default=None, help="Config(s) to benchmark")
-    ap.add_argument("--steps", type=int, default=30, help="Benchmark steps (default: 30)")
-    ap.add_argument("--warmup", type=int, default=5, help="Warmup steps (default: 5)")
-    args = ap.parse_args(argv)
+def load_matrix(path: str | Path) -> tuple[list[tuple[str, dict[str, Any]]], int, int]:
+    manifest = _load_cfg(path)
+    base_path = Path(manifest["base_config"])
+    if not base_path.is_absolute():
+        base_path = Path.cwd() / base_path
+    base_cfg = _load_cfg(base_path)
+    base_cfg.update(manifest.get("base_overrides", {}))
+    variants = []
+    for variant in manifest.get("variants", []):
+        cfg = dict(base_cfg)
+        cfg.update(variant.get("overrides", {}))
+        variants.append((str(variant["name"]), cfg))
+    if not variants:
+        raise ValueError("benchmark matrix must define at least one variant")
+    return (
+        variants,
+        int(manifest.get("warmup_steps", 20)),
+        int(manifest.get("measure_steps", 100)),
+    )
 
-    configs = []
-    if args.config:
-        configs = args.config  # already a list from nargs='+'
+
+def write_results(path: str | Path, results: list[dict[str, Any]]) -> None:
+    out_dir = Path(path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "results.json").write_text(json.dumps({"results": results}, indent=2, sort_keys=True) + "\n")
+    fields = [
+        "config",
+        "status",
+        "failure_kind",
+        "device",
+        "batch_size",
+        "grad_accum_steps",
+        "effective_batch_size",
+        "use_checkpoint",
+        "n_kv_head",
+        "amp_requested",
+        "amp_active",
+        "non_pad_tokens_per_sec",
+        "tokens_per_sec",
+        "padding_fraction",
+        "seq_per_sec",
+        "avg_microbatch_ms",
+        "wall_sec_per_optimizer_step",
+        "peak_allocated_bytes",
+        "peak_driver_bytes",
+        "error",
+    ]
+    with (out_dir / "results.csv").open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(results)
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Benchmark CodonLM training throughput")
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--config", nargs="+", help="Training config(s) to benchmark")
+    source.add_argument("--matrix", help="YAML manifest containing a base config and named overrides")
+    parser.add_argument("--steps", type=int, default=None, help="Measured microbatches")
+    parser.add_argument("--warmup", type=int, default=None, help="Warmup microbatches")
+    parser.add_argument("--out", default="runs/training_speed_benchmark", help="CSV/JSON output directory")
+    args = parser.parse_args(argv)
+
+    if args.matrix:
+        variants, default_warmup, default_steps = load_matrix(args.matrix)
     else:
-        # Auto-compare baseline vs optimized
-        configs = [
+        paths = args.config or [
             "configs/stage2.6_large_scaling.yaml",
             "configs/stage2.6_optimized.yaml",
         ]
-        print("[bench] No --config specified. Comparing baseline vs. optimized.")
+        variants = [(Path(path).stem, _load_cfg(path)) for path in paths]
+        default_warmup, default_steps = 5, 30
+    warmup = int(args.warmup if args.warmup is not None else default_warmup)
+    steps = int(args.steps if args.steps is not None else default_steps)
 
     results = []
-    for cfg_path in configs:
-        if not Path(cfg_path).exists():
-            print(f"[bench] Skipping {cfg_path} (not found)")
-            continue
-        print(f"\n[bench] Running: {cfg_path} ...")
-        r = benchmark(cfg_path, n_steps=args.steps, warmup_steps=args.warmup)
-        if "error" in r:
-            print(f"  ERROR: {r['error']}")
+    for name, cfg in variants:
+        print(f"[bench] running {name}", flush=True)
+        result = _result_for_config(cfg, name=name, n_steps=steps, warmup_steps=warmup)
+        results.append(result)
+        if result.get("status") == "ok":
+            print(
+                f"[bench] {name}: {float(result['non_pad_tokens_per_sec']):,.0f} non-pad tok/s, "
+                f"padding={float(result['padding_fraction']):.1%}",
+                flush=True,
+            )
         else:
-            print(f"  tokens/sec: {r['tokens_per_sec']:,}  |  avg step: {r['avg_step_ms']}ms")
-        results.append(r)
-
-    if len(results) >= 2 and "error" not in results[0] and "error" not in results[1]:
-        speedup = results[1]["tokens_per_sec"] / results[0]["tokens_per_sec"]
-        print(f"\n{'='*60}")
-        print(f"SPEEDUP:  {speedup:.2f}×  ({results[1]['tokens_per_sec']:,} vs {results[0]['tokens_per_sec']:,} tok/s)")
-        print(f"{'='*60}")
-
-    print("\n--- Full Results ---")
-    for r in results:
-        print(r)
+            print(f"[bench] {name}: {result.get('failure_kind', 'error')} {result.get('error', '')}")
+    write_results(args.out, results)
+    print(f"[bench] wrote {args.out}")
 
 
 if __name__ == "__main__":

--- a/scripts/optimize_train_batching.py
+++ b/scripts/optimize_train_batching.py
@@ -21,6 +21,7 @@ import yaml
 from src.codonlm.data_loading import build_codon_lm_dataloaders, build_codon_lm_datasets
 from src.codonlm.model_tiny_gpt import TinyGPT
 from src.codonlm.training.checkpoint import _load_transfer_state_dict, _read_itos
+from src.codonlm.training.loop import _average_accumulated_gradients
 from src.codonlm.training.objectives import (
     termination_aux_loss,
     termination_distance_bucket_labels,
@@ -178,6 +179,14 @@ def build_model(cfg: dict[str, Any], device: torch.device) -> TinyGPT:
         use_sdpa=bool(cfg.get("use_sdpa", False)),
         termination_aux=bool(cfg.get("termination_loss_enabled", cfg.get("termination_aux", False))),
         termination_n_classes=int(cfg.get("termination_n_classes", 5)),
+        multi_offset_targets=(
+            [int(value) for value in cfg.get("multi_offset_targets", [])]
+            if bool(cfg.get("multi_offset_loss_enabled", False))
+            else None
+        ),
+        use_swiglu=bool(cfg.get("use_swiglu", False)),
+        use_rope=bool(cfg.get("use_rope", False)),
+        use_shape_guidance=bool(cfg.get("use_shape_guidance", False)),
     ).to(device)
     transfer_from = cfg.get("transfer_from")
     if transfer_from:
@@ -190,6 +199,9 @@ def build_model(cfg: dict[str, Any], device: torch.device) -> TinyGPT:
             source_itos=_read_itos(source_cfg.get("itos_path"), Path.cwd()),
             target_itos=_read_itos(cfg.get("itos_path"), Path.cwd()),
         )
+    if bool(cfg.get("freeze_backbone", False)):
+        for name, param in model.named_parameters():
+            param.requires_grad = "offset_projs" in name or "termination_head" in name
     model.train(True)
     return model
 
@@ -202,12 +214,15 @@ def run_candidate_benchmark(
     warmup_steps: int,
     measure_steps: int,
     force_gpu: bool,
+    device_override: torch.device | None = None,
 ) -> dict[str, Any]:
     cfg = dict(cfg)
     cfg["batch_size"] = int(batch_size)
     cfg["grad_accum_steps"] = int(grad_accum_steps)
-    device = select_device(force_gpu)
-    torch.manual_seed(int(cfg.get("seed", 1337)))
+    device = device_override or select_device(force_gpu)
+    seed = int(cfg.get("seed", 1337))
+    torch.manual_seed(seed)
+    cfg.setdefault("dataloader_seed", seed)
 
     train_paths = _path_list(cfg.get("train_npz", cfg.get("train_paths")))
     if not train_paths:
@@ -228,49 +243,104 @@ def run_candidate_benchmark(
     stop_ids = tuple(int(x) for x in cfg.get("termination_stop_ids", [2]))
     bucket_edges = tuple(int(x) for x in cfg.get("termination_bucket_edges", [0, 3, 10, 30]))
 
-    total_sequences = 0
-    total_tokens = 0
-    times: list[float] = []
-    total_steps = int(warmup_steps) + int(measure_steps)
+    amp = bool(cfg.get("amp", True)) and device.type == "mps"
+    mps_autocast_ok = True
+    parameters = [param for param in model.parameters() if param.requires_grad]
 
-    for idx in range(total_steps):
-        try:
-            xb, yb = next(loader_iter)
-        except StopIteration:
-            loader_iter = iter(loader)
-            xb, yb = next(loader_iter)
-        xb = xb.to(device)
-        yb = yb.to(device)
-
-        t0 = time.perf_counter()
-        if termination_enabled:
-            _, next_loss, aux = model(xb, yb, return_aux=True)
-            term_labels = termination_distance_bucket_labels(yb, stop_ids=stop_ids, bucket_edges=bucket_edges)
-            term_loss = termination_aux_loss(aux["termination_logits"], term_labels)
-            loss = next_loss + (termination_weight * term_loss)
-        else:
-            _, loss = model(xb, yb)
-        (loss / max(1, int(grad_accum_steps))).backward()
-        if (idx + 1) % max(1, int(grad_accum_steps)) == 0:
-            optimizer.step()
-            optimizer.zero_grad(set_to_none=True)
+    def synchronize() -> None:
         if device.type == "mps":
             torch.mps.synchronize()
         elif device.type == "cuda":
             torch.cuda.synchronize()
-        t1 = time.perf_counter()
 
-        if idx >= int(warmup_steps):
-            elapsed = t1 - t0
-            times.append(elapsed)
-            total_sequences += int(xb.shape[0])
-            total_tokens += int(xb.numel())
+    def forward_loss(xb: torch.Tensor, yb: torch.Tensor) -> torch.Tensor:
+        if termination_enabled:
+            _, next_loss, aux = model(xb, yb, return_aux=True)
+            term_labels = termination_distance_bucket_labels(yb, stop_ids=stop_ids, bucket_edges=bucket_edges)
+            term_loss = termination_aux_loss(aux["termination_logits"], term_labels)
+            return next_loss + (termination_weight * term_loss)
+        _, loss = model(xb, yb)
+        return loss
+
+    def run_phase(microbatches: int, *, measure: bool) -> dict[str, Any]:
+        nonlocal loader_iter, mps_autocast_ok
+        stats: dict[str, Any] = {
+            "sequences": 0,
+            "processed_tokens": 0,
+            "non_pad_tokens": 0,
+            "times": [],
+            "optimizer_steps": 0,
+            "peak_allocated_bytes": 0,
+            "peak_driver_bytes": 0,
+        }
+        accumulated = 0
+        optimizer.zero_grad(set_to_none=True)
+        for idx in range(max(0, int(microbatches))):
+            try:
+                xb, yb = next(loader_iter)
+            except StopIteration:
+                loader_iter = iter(loader)
+                xb, yb = next(loader_iter)
+            xb = xb.to(device)
+            yb = yb.to(device)
+            synchronize()
+            t0 = time.perf_counter()
+            if amp and mps_autocast_ok:
+                try:
+                    with torch.amp.autocast(device_type="mps", dtype=torch.float16):
+                        loss = forward_loss(xb, yb)
+                except RuntimeError as exc:
+                    if "autocast" not in str(exc).lower():
+                        raise
+                    mps_autocast_ok = False
+                    loss = forward_loss(xb, yb)
+            else:
+                loss = forward_loss(xb, yb)
+            loss.backward()
+            accumulated += 1
+            if measure and device.type == "mps":
+                stats["peak_allocated_bytes"] = max(
+                    stats["peak_allocated_bytes"], int(torch.mps.current_allocated_memory())
+                )
+                driver_memory = getattr(torch.mps, "driver_allocated_memory", None)
+                if callable(driver_memory):
+                    stats["peak_driver_bytes"] = max(
+                        stats["peak_driver_bytes"], int(driver_memory())
+                    )
+            is_last = idx + 1 == int(microbatches)
+            if accumulated == max(1, int(grad_accum_steps)) or is_last:
+                _average_accumulated_gradients(parameters, accumulated)
+                optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+                accumulated = 0
+                stats["optimizer_steps"] += 1
+            synchronize()
+            elapsed = time.perf_counter() - t0
+            if measure:
+                stats["times"].append(elapsed)
+                stats["sequences"] += int(xb.shape[0])
+                stats["processed_tokens"] += int(yb.numel())
+                stats["non_pad_tokens"] += int(yb.ne(0).sum().item())
+                if device.type == "cuda":
+                    stats["peak_allocated_bytes"] = int(torch.cuda.max_memory_allocated(device))
+        return stats
+
+    run_phase(int(warmup_steps), measure=False)
+    if device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats(device)
+    measured_stats = run_phase(int(measure_steps), measure=True)
 
     if device.type == "mps":
         torch.mps.empty_cache()
+    times = measured_stats["times"]
     measured = max(sum(times), 1e-9)
+    total_sequences = int(measured_stats["sequences"])
+    total_tokens = int(measured_stats["processed_tokens"])
+    non_pad_tokens = int(measured_stats["non_pad_tokens"])
+    optimizer_steps = int(measured_stats["optimizer_steps"])
     seq_per_sec = total_sequences / measured
     tokens_per_sec = total_tokens / measured
+    non_pad_tokens_per_sec = non_pad_tokens / measured
     train_len = len(train_ds)
     return {
         "status": "ok",
@@ -282,6 +352,17 @@ def run_candidate_benchmark(
         "measure_steps": int(measure_steps),
         "seq_per_sec": seq_per_sec,
         "tokens_per_sec": tokens_per_sec,
+        "non_pad_tokens_per_sec": non_pad_tokens_per_sec,
+        "processed_tokens": total_tokens,
+        "non_pad_tokens": non_pad_tokens,
+        "padding_fraction": 1.0 - (non_pad_tokens / max(total_tokens, 1)),
+        "optimizer_steps": optimizer_steps,
+        "avg_microbatch_ms": (sum(times) / max(len(times), 1)) * 1000.0,
+        "wall_sec_per_optimizer_step": measured / max(optimizer_steps, 1),
+        "peak_allocated_bytes": int(measured_stats["peak_allocated_bytes"]),
+        "peak_driver_bytes": int(measured_stats["peak_driver_bytes"]),
+        "amp_requested": bool(cfg.get("amp", True)),
+        "amp_active": amp and mps_autocast_ok,
         "avg_step_ms": (sum(times) / max(len(times), 1)) * 1000.0,
         "train_windows": int(train_len),
         "estimated_epoch_sec": train_len / max(seq_per_sec, 1e-9),
@@ -301,7 +382,11 @@ def select_best_result(results: list[dict[str, Any]]) -> dict[str, Any] | None:
         return None
     return sorted(
         passed,
-        key=lambda r: (-float(r.get("seq_per_sec", 0.0)), int(r["batch_size"]), int(r["grad_accum_steps"])),
+        key=lambda r: (
+            -float(r.get("non_pad_tokens_per_sec", r.get("tokens_per_sec", r.get("seq_per_sec", 0.0)))),
+            int(r["batch_size"]),
+            int(r["grad_accum_steps"]),
+        ),
     )[0]
 
 
@@ -411,6 +496,14 @@ def write_report(
         "effective_batch_size",
         "seq_per_sec",
         "tokens_per_sec",
+        "non_pad_tokens_per_sec",
+        "padding_fraction",
+        "optimizer_steps",
+        "avg_microbatch_ms",
+        "wall_sec_per_optimizer_step",
+        "peak_allocated_bytes",
+        "peak_driver_bytes",
+        "amp_active",
         "avg_step_ms",
         "estimated_epoch_sec",
         "returncode",
@@ -562,7 +655,7 @@ def main(argv: list[str] | None = None) -> int:
             if status == "ok":
                 print(
                     f"[batch-opt] ok {candidate[0]}/{candidate[1]} "
-                    f"seq/sec={float(result['seq_per_sec']):.2f} "
+                    f"non-pad tok/sec={float(result['non_pad_tokens_per_sec']):.2f} "
                     f"epoch_h={float(result['estimated_epoch_sec']) / 3600.0:.2f}",
                     flush=True,
                 )
@@ -595,7 +688,8 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"[batch-opt] selected batch_size={selected['batch_size']} "
         f"grad_accum_steps={selected['grad_accum_steps']} "
-        f"seq/sec={float(selected['seq_per_sec']):.2f}",
+        "non-pad tok/sec="
+        f"{float(selected.get('non_pad_tokens_per_sec', selected.get('tokens_per_sec', selected.get('seq_per_sec', 0.0)))):.2f}",
         flush=True,
     )
     print(f"[batch-opt] wrote report to {out_dir}", flush=True)

--- a/src/codonlm/data_loading.py
+++ b/src/codonlm/data_loading.py
@@ -47,6 +47,7 @@ class PackedDataset(Dataset):
         else:
             paths = list(paths)
 
+        self.storage_mode = "npz_memory"
         self.is_dynamic = False
         if len(paths) > 0:
             with np.load(paths[0], allow_pickle=False) as data:
@@ -54,19 +55,28 @@ class PackedDataset(Dataset):
                     self.is_dynamic = True
 
         if self.is_dynamic:
-            self.seqs = []
-            for path in paths:
+            self._flat_X: list[np.ndarray] = []
+            self._offsets: list[np.ndarray] = []
+            self._lengths: list[np.ndarray] = []
+            global_file = []
+            global_local = []
+            for file_idx, path in enumerate(paths):
                 with np.load(path, allow_pickle=False) as data:
-                    flat_X = data["X"]
-                    lengths = data["lengths"]
-                    offsets = np.insert(np.cumsum(lengths), 0, 0)
-                    for i in range(len(lengths)):
-                        seq = flat_X[offsets[i] : offsets[i + 1]]
-                        self.seqs.append(torch.from_numpy(seq.astype(np.int64)))
+                    flat_X = np.asarray(data["X"])
+                    lengths = np.asarray(data["lengths"])
+                self._flat_X.append(flat_X)
+                self._offsets.append(np.concatenate([[0], np.cumsum(lengths[:-1])]))
+                self._lengths.append(lengths)
+                global_file.append(np.full(len(lengths), file_idx, dtype=np.int32))
+                global_local.append(np.arange(len(lengths), dtype=np.int32))
+            self._global_file = np.concatenate(global_file)
+            self._global_local = np.concatenate(global_local)
         else:
             totals = []
             tail_shape = None
             y_tail_shape = None
+            x_dtype = None
+            y_dtype = None
             for path in paths:
                 with np.load(path, allow_pickle=False) as data:
                     X = data["X"]
@@ -74,6 +84,8 @@ class PackedDataset(Dataset):
                     if tail_shape is None:
                         tail_shape = X.shape[1:]
                         y_tail_shape = Y.shape[1:]
+                    x_dtype = np.result_type(x_dtype, X.dtype) if x_dtype is not None else X.dtype
+                    y_dtype = np.result_type(y_dtype, Y.dtype) if y_dtype is not None else Y.dtype
                     totals.append(X.shape[0])
             total_rows = sum(totals)
             if total_rows == 0:
@@ -81,14 +93,14 @@ class PackedDataset(Dataset):
                 self.Y = torch.empty((0,) + (y_tail_shape or (0,)), dtype=torch.long)
                 return
 
-            X_agg = np.empty((total_rows,) + tail_shape, dtype=np.int64)
-            Y_agg = np.empty((total_rows,) + y_tail_shape, dtype=np.int64)
+            X_agg = np.empty((total_rows,) + tail_shape, dtype=x_dtype)
+            Y_agg = np.empty((total_rows,) + y_tail_shape, dtype=y_dtype)
 
             offset = 0
             for path in paths:
                 with np.load(path, allow_pickle=False) as data:
-                    X = np.asarray(data["X"], dtype=np.int64)
-                    Y = np.asarray(data["Y"], dtype=np.int64)
+                    X = np.asarray(data["X"])
+                    Y = np.asarray(data["Y"])
                     rows = X.shape[0]
                     X_agg[offset : offset + rows] = X
                     Y_agg[offset : offset + rows] = Y
@@ -98,18 +110,22 @@ class PackedDataset(Dataset):
 
     def __len__(self):
         if self.is_dynamic:
-            return len(self.seqs)
+            return len(self._global_file)
         return self.X.shape[0]
 
     def __getitem__(self, i):
         if self.is_dynamic:
-            return self.seqs[i]
-        return self.X[i], self.Y[i]
+            file_idx = int(self._global_file[i])
+            local_idx = int(self._global_local[i])
+            start = int(self._offsets[file_idx][local_idx])
+            length = int(self._lengths[file_idx][local_idx])
+            return torch.from_numpy(self._flat_X[file_idx][start : start + length]).long()
+        return self.X[i].long(), self.Y[i].long()
 
     @property
     def seq_lengths(self) -> np.ndarray:
         if self.is_dynamic:
-            return np.array([len(seq) for seq in self.seqs], dtype=np.int32)
+            return np.concatenate(self._lengths).astype(np.int32, copy=False)
         return np.full(len(self), self.X.shape[1], dtype=np.int32)
 
 
@@ -131,7 +147,7 @@ class MmapPackedDataset(Dataset):
             x_path = p.with_name(p.stem + "_X.npy")
             y_path = p.with_name(p.stem + "_Y.npy")
             len_path = p.with_name(p.stem + "_lengths.npy")
-            if x_path.exists():
+            if x_path.exists() and (len_path.exists() or y_path.exists()):
                 npy_configs.append({
                     "X": x_path,
                     "Y": y_path if y_path.exists() else None,
@@ -143,6 +159,10 @@ class MmapPackedDataset(Dataset):
                 break
 
         if self.use_npy_mmap:
+            dataset_kinds = {cfg["is_dynamic"] for cfg in npy_configs}
+            if len(dataset_kinds) != 1:
+                raise ValueError("all memory-mapped dataset shards must use the same format")
+            self.storage_mode = "npy_mmap"
             self.is_dynamic = npy_configs[0]["is_dynamic"]
             self._mmaps_X = []
             self._mmaps_Y = []
@@ -155,7 +175,7 @@ class MmapPackedDataset(Dataset):
                 self._mmaps_X.append(mmap_X)
                 
                 if self.is_dynamic:
-                    lengths = np.load(cfg["lengths"])
+                    lengths = np.load(cfg["lengths"], mmap_mode="r")
                     offsets = np.concatenate([[0], np.cumsum(lengths[:-1])])
                     self._offsets.append(offsets)
                     self._lengths.append(lengths)
@@ -185,9 +205,11 @@ class MmapPackedDataset(Dataset):
 
         if not is_dynamic:
             self._delegate = PackedDataset(paths)
+            self.storage_mode = self._delegate.storage_mode
             self.is_dynamic = False
             return
 
+        self.storage_mode = "npz_memory"
         self.is_dynamic = True
         self._delegate = None
         self._mmaps: list[np.ndarray] = []
@@ -196,9 +218,9 @@ class MmapPackedDataset(Dataset):
 
         total_seqs = 0
         for path in paths:
-            data = np.load(path, allow_pickle=False, mmap_mode="r")
-            flat_X = data["X"]
-            lengths = data["lengths"]
+            with np.load(path, allow_pickle=False) as data:
+                flat_X = np.asarray(data["X"])
+                lengths = np.asarray(data["lengths"])
             offsets = np.concatenate([[0], np.cumsum(lengths[:-1])])
             self._mmaps.append(flat_X)
             self._offsets.append(offsets)

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -8,6 +8,7 @@ import logging
 import shutil
 from pathlib import Path
 import torch
+import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from src.codonlm.model_tiny_gpt import TinyGPT
@@ -43,6 +44,14 @@ from src.codonlm.training.objectives import (
 
 RUN_ID_ENV = "RUN_ID"
 PAD_ID = 0
+
+
+def _average_accumulated_gradients(parameters, microbatch_count: int) -> None:
+    if microbatch_count <= 0:
+        raise ValueError("microbatch_count must be positive")
+    for param in parameters:
+        if param.grad is not None:
+            param.grad.div_(microbatch_count)
 
 def dev(force_gpu: bool = False):
     device = default_device()
@@ -100,7 +109,14 @@ def run_training(cfg: dict, args) -> None:
     use_mmap = bool(cfg.get("use_mmap", False))
     train_ds, val_ds = build_codon_lm_datasets(train_paths, val_paths, use_mmap=use_mmap)
     if use_mmap:
-        print("[loader] using MmapPackedDataset (memory-mapped, on-demand paging)")
+        train_storage = getattr(train_ds, "storage_mode", "unknown")
+        val_storage = getattr(val_ds, "storage_mode", "unknown")
+        print(f"[loader] storage train={train_storage} val={val_storage}")
+        if train_storage != "npy_mmap" or val_storage != "npy_mmap":
+            print(
+                "[loader] warning: use_mmap=true requires adjacent *_X.npy and "
+                "*_lengths.npy/*_Y.npy sidecars; compressed NPZ data is loaded into memory."
+            )
     train_audit = dataset_length_audit(train_ds, int(cfg["block_size"]))
     val_audit = dataset_length_audit(val_ds, int(cfg["block_size"]))
     cfg["dataset_audit"] = {"train": train_audit, "val": val_audit}
@@ -594,6 +610,7 @@ def run_training(cfg: dict, args) -> None:
             offset_totals = {offset: 0.0 for offset in multi_offset_weights}
             offset_counts = {offset: 0 for offset in multi_offset_weights}
             optim.zero_grad(set_to_none=True)
+            accumulated_microbatches = 0
             skipped = 0
             start_time = time.perf_counter()
             if split == "train" and skip_microbatches > 0:
@@ -675,7 +692,23 @@ def run_training(cfg: dict, args) -> None:
                             raise RuntimeError("replay_loss_enabled=true but model returned no termination logits")
                         replay_loss_ = termination_aux_loss(replay_logits, replay_labels)
                         total_loss_ = total_loss_ + (replay_loss_weight * replay_loss_)
-                    return total_loss_ / gacc, next_loss_, offset_losses_, term_loss_, replay_loss_
+                    return total_loss_, next_loss_, offset_losses_, term_loss_, replay_loss_
+
+                def step_optimizer(group_size: int) -> None:
+                    nonlocal step, current_resume_microbatch_idx
+                    if group_size <= 0:
+                        return
+                    _average_accumulated_gradients(trainable_params, group_size)
+                    if (not use_cosine) and warmup_steps > 0 and step < warmup_steps:
+                        scale = float(step + 1) / max(1, warmup_steps)
+                        for pg in optim.param_groups:
+                            pg["lr"] = base_lr * scale
+                    optim.step()
+                    optim.zero_grad(set_to_none=True)
+                    step += 1
+                    current_resume_microbatch_idx = batch_idx + 1
+                    if use_cosine:
+                        scheduler.step()
 
                 if amp and mps_autocast_ok:
                     try:
@@ -695,24 +728,13 @@ def run_training(cfg: dict, args) -> None:
                     continue
                 if split=="train":
                     loss.backward()
-                    if (n+1) % gacc == 0:
-                        if (not use_cosine) and warmup_steps > 0 and step < warmup_steps:
-                            scale = float(step + 1) / max(1, warmup_steps)
-                            for pg in optim.param_groups:
-                                pg["lr"] = base_lr * scale
-                        optim.step()
-                        optim.zero_grad(set_to_none=True)
-                        step += 1
-                        current_resume_microbatch_idx = batch_idx + 1
-                        if use_cosine:
-                            scheduler.step()
-                        if device.type == "mps":
-                            torch.mps.empty_cache()
+                    accumulated_microbatches += 1
+                    if accumulated_microbatches == gacc:
+                        step_optimizer(accumulated_microbatches)
+                        accumulated_microbatches = 0
                         if split == "train" and periodic_ckpt.should_save(step):
                             save_last_checkpoint(epoch_idx, reason="periodic")
-                            if device.type == "mps":
-                                torch.mps.empty_cache()
-                total += loss.item()*gacc
+                total += loss.item()
                 next_total += float(next_loss.detach().item())
                 if term_loss is not None:
                     term_total += float(term_loss.detach().item())
@@ -726,19 +748,8 @@ def run_training(cfg: dict, args) -> None:
                 n += 1
                 wall_timer.check()
             
-            # Step on remainder if training and loader length is not divisible by gacc
-            if split == "train" and n % gacc != 0:
-                if (not use_cosine) and warmup_steps > 0 and step < warmup_steps:
-                    scale = float(step + 1) / max(1, warmup_steps)
-                    for pg in optim.param_groups:
-                        pg["lr"] = base_lr * scale
-                optim.step()
-                optim.zero_grad(set_to_none=True)
-                step += 1
-                if use_cosine:
-                    scheduler.step()
-                if device.type == "mps":
-                    torch.mps.empty_cache()
+            if split == "train" and accumulated_microbatches:
+                step_optimizer(accumulated_microbatches)
 
             offset_avgs = {
                 offset: (offset_totals[offset] / max(offset_counts[offset], 1))

--- a/tests/test_batch_optimizer.py
+++ b/tests/test_batch_optimizer.py
@@ -4,6 +4,9 @@ import argparse
 import json
 from pathlib import Path
 
+import numpy as np
+import pytest
+import torch
 import yaml
 
 from scripts.optimize_train_batching import (
@@ -17,7 +20,9 @@ from scripts.optimize_train_batching import (
     select_best_result,
     train_command_for,
     write_report,
+    run_candidate_benchmark,
 )
+from scripts.benchmark_training_speed import load_matrix
 
 
 def test_parse_candidates_default_and_explicit():
@@ -103,6 +108,94 @@ def test_select_best_ignores_failed_and_tiebreaks():
     assert selected is not None
     assert selected["batch_size"] == 4
     assert selected["grad_accum_steps"] == 16
+
+
+def test_select_best_prefers_non_pad_token_throughput():
+    results = [
+        {
+            "status": "ok",
+            "batch_size": 8,
+            "grad_accum_steps": 4,
+            "seq_per_sec": 20.0,
+            "tokens_per_sec": 200.0,
+            "non_pad_tokens_per_sec": 80.0,
+        },
+        {
+            "status": "ok",
+            "batch_size": 4,
+            "grad_accum_steps": 8,
+            "seq_per_sec": 10.0,
+            "tokens_per_sec": 150.0,
+            "non_pad_tokens_per_sec": 100.0,
+        },
+    ]
+
+    assert select_best_result(results)["batch_size"] == 4
+
+
+def test_candidate_benchmark_counts_non_pad_tokens_and_partial_step(tmp_path):
+    path = tmp_path / "dynamic.npz"
+    seqs = [np.array([1, 4, 5, 2], dtype=np.int32), np.array([1, 6, 7, 8, 9, 2], dtype=np.int32)]
+    np.savez_compressed(
+        path,
+        X=np.concatenate(seqs),
+        lengths=np.array([len(seq) for seq in seqs], dtype=np.int32),
+    )
+    cfg = {
+        "vocab_size": 16,
+        "block_size": 8,
+        "n_layer": 1,
+        "n_head": 1,
+        "n_embd": 8,
+        "dropout": 0.0,
+        "batch_size": 2,
+        "grad_accum_steps": 2,
+        "lr": 1e-3,
+        "weight_decay": 0.0,
+        "train_npz": str(path),
+        "amp": False,
+        "use_checkpoint": False,
+    }
+
+    result = run_candidate_benchmark(
+        cfg,
+        batch_size=2,
+        grad_accum_steps=2,
+        warmup_steps=1,
+        measure_steps=3,
+        force_gpu=False,
+        device_override=torch.device("cpu"),
+    )
+
+    assert result["status"] == "ok"
+    assert result["optimizer_steps"] == 2
+    assert result["processed_tokens"] == 30
+    assert result["non_pad_tokens"] == 24
+    assert result["padding_fraction"] == pytest.approx(0.2)
+
+
+def test_benchmark_matrix_applies_base_and_variant_overrides(tmp_path, monkeypatch):
+    base = tmp_path / "base.yaml"
+    base.write_text("batch_size: 4\ntransfer_from: old.pt\n")
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        "base_config: base.yaml\n"
+        "base_overrides:\n"
+        "  transfer_from: null\n"
+        "variants:\n"
+        "  - name: checkpoint_off\n"
+        "    overrides:\n"
+        "      use_checkpoint: false\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    variants, warmup, steps = load_matrix(matrix)
+
+    assert warmup == 20
+    assert steps == 100
+    assert variants == [
+        ("checkpoint_off", {"batch_size": 4, "transfer_from": None, "use_checkpoint": False})
+    ]
 
 
 def test_write_report_outputs_files(tmp_path: Path):

--- a/tests/test_dynamic_dataset.py
+++ b/tests/test_dynamic_dataset.py
@@ -18,6 +18,8 @@ def test_dynamic_dataset_loading_and_collate(tmp_path):
     # Load dataset
     ds = PackedDataset(npz_path)
     assert ds.is_dynamic is True
+    assert ds.storage_mode == "npz_memory"
+    assert ds._flat_X[0].dtype == np.int32
     assert len(ds) == 2
     assert torch.equal(ds[0], torch.tensor([1, 10, 20, 2], dtype=torch.long))
     assert torch.equal(ds[1], torch.tensor([1, 15, 25, 35, 45, 2], dtype=torch.long))

--- a/tests/test_mmap_dataset.py
+++ b/tests/test_mmap_dataset.py
@@ -1,11 +1,8 @@
-import os
-import tempfile
 from pathlib import Path
 import numpy as np
 import torch
-import pytest
 
-from src.codonlm.data_loading import MmapPackedDataset, PackedDataset
+from src.codonlm.data_loading import MmapPackedDataset
 
 
 def test_mmap_packed_dataset_npz_fallback(tmp_path: Path):
@@ -19,6 +16,7 @@ def test_mmap_packed_dataset_npz_fallback(tmp_path: Path):
     # Init MmapPackedDataset (will fall back to PackedDataset)
     ds = MmapPackedDataset(npz_path)
     assert not ds.is_dynamic
+    assert ds.storage_mode == "npz_memory"
     assert len(ds) == 10
     
     x_sample, y_sample = ds[3]
@@ -44,6 +42,7 @@ def test_mmap_packed_dataset_npy_fixed(tmp_path: Path):
     # Init MmapPackedDataset (should detect and use npy mmap)
     ds = MmapPackedDataset(npz_path)
     assert ds.use_npy_mmap
+    assert ds.storage_mode == "npy_mmap"
     assert not ds.is_dynamic
     assert len(ds) == 10
     
@@ -70,6 +69,7 @@ def test_mmap_packed_dataset_npy_dynamic(tmp_path: Path):
     # Init MmapPackedDataset (should detect and use npy mmap)
     ds = MmapPackedDataset(npz_path)
     assert ds.use_npy_mmap
+    assert ds.storage_mode == "npy_mmap"
     assert ds.is_dynamic
     assert len(ds) == 3
     

--- a/tests/test_trainer_utils.py
+++ b/tests/test_trainer_utils.py
@@ -1,8 +1,11 @@
+import inspect
+
 import numpy as np
 import torch
 
 from src.codonlm.data_loading import PackedDataset
 from src.codonlm.training.config import _ensure_path_list
+from src.codonlm.training.loop import _average_accumulated_gradients, run_training
 
 
 def test_ensure_path_list_from_string():
@@ -42,3 +45,43 @@ def test_packed_dataset_concatenates(tmp_path):
     assert x0.shape == (6,)
     expected = torch.from_numpy(np.arange(1000, 1012, dtype=np.int64).reshape(2, 6)[0])
     assert torch.equal(ds[2][0], expected)
+
+
+def test_packed_dataset_preserves_compact_backing_dtype(tmp_path):
+    path = tmp_path / "compact.npz"
+    x = np.arange(12, dtype=np.int32).reshape(2, 6)
+    np.savez_compressed(path, X=x, Y=x)
+
+    ds = PackedDataset(path)
+
+    assert ds.storage_mode == "npz_memory"
+    assert ds.X.dtype == torch.int32
+    assert ds.Y.dtype == torch.int32
+    assert ds[0][0].dtype == torch.long
+    assert ds[0][1].dtype == torch.long
+
+
+def test_average_accumulated_gradients_matches_mean_loss():
+    accumulated = torch.nn.Linear(2, 1, bias=False)
+    reference = torch.nn.Linear(2, 1, bias=False)
+    reference.load_state_dict(accumulated.state_dict())
+    batches = [
+        (torch.tensor([[1.0, 2.0]]), torch.tensor([[0.5]])),
+        (torch.tensor([[2.0, -1.0]]), torch.tensor([[1.5]])),
+        (torch.tensor([[-1.0, 3.0]]), torch.tensor([[-0.5]])),
+    ]
+
+    for inputs, targets in batches:
+        torch.nn.functional.mse_loss(accumulated(inputs), targets).backward()
+    _average_accumulated_gradients(accumulated.parameters(), len(batches))
+
+    mean_loss = torch.stack(
+        [torch.nn.functional.mse_loss(reference(inputs), targets) for inputs, targets in batches]
+    ).mean()
+    mean_loss.backward()
+
+    assert torch.allclose(accumulated.weight.grad, reference.weight.grad)
+
+
+def test_training_loop_does_not_clear_mps_cache_on_happy_path():
+    assert "empty_cache" not in inspect.getsource(run_training)


### PR DESCRIPTION
## Summary

- correct gradient accumulation so final partial groups are averaged by their actual microbatch count
- remove per-optimizer-step MPS cache clearing
- preserve compact dataset dtypes and report true `.npy` mmap versus NPZ memory fallback
- make throughput benchmarks deterministic, subprocess-isolated, and PAD-aware
- add Stage 2.6 MPS benchmark matrices, regression coverage, and operator documentation

## Why

The training loop cleared the MPS allocator cache after every optimizer step, forcing avoidable allocation work. Its final partial accumulation group was stepped after every loss had been divided by the full accumulation target, underweighting that update. Benchmark selection also counted PAD tokens and could compare different bucket orders, while compressed NPZ fallback was described as true mmap.

## MPS results

Full benchmarks used 20 warmup and 100 measured microbatches per variant on the M2.

| Variant | Non-PAD tokens/sec | Padding | Driver memory |
| --- | ---: | ---: | ---: |
| Current unbucketed/checkpointed baseline | 2,763 | 34.4% | 1.49 GiB |
| Bucketed baseline | 3,925 | 5.8% | 1.82 GiB |
| Batch 4, no checkpoint | 4,635 | 5.8% | 3.09 GiB |
| Batch 8, no checkpoint, AMP | 5,586 | 6.1% | 3.71 GiB |
| Batch 8, no checkpoint, FP32 | 3,896 | 6.1% | 4.63 GiB |
| Batch 16, no checkpoint, AMP | 294 | 7.3% | 7.88 GiB |

The fastest tested throughput configuration was batch 8, accumulation 16, checkpointing off, AMP on, and 8-bucket dynamic batching: 2.02x the baseline. Production training defaults are not changed by this PR.

## Validation

- `ruff check src/codonlm/training/loop.py src/codonlm/data_loading.py scripts/optimize_train_batching.py scripts/benchmark_training_speed.py tests/test_trainer_utils.py tests/test_dynamic_dataset.py tests/test_mmap_dataset.py tests/test_batch_optimizer.py`
- `pytest -q`: 171 passed, 1 skipped, 1 xpassed
- `git diff --check`
- full MPS primary and follow-up benchmark matrices completed without OOM
