### PR TITLE
Relabel legacy scientific results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Genomics‑LM
 
-A compact codon‑level causal GPT trained on diverse bacterial genomes, with a full downstream evaluation and interpretability pipeline.
+A compact codon‑level causal GPT for bacterial genomes, with downstream
+evaluation and interpretability tooling.
 
-**Stage 2.6 (current best):** 10L·8H·d384 · 20.6M params · 15 genomes · Apple M2 8GB
-**Test PPL: 68.5** | **DNAshape avg R²: 0.569** | **EC AUROC: 0.703** | **AMR AUROC: 0.967**
+> **Scientific status:** Published Stage 2.6 metrics use a legacy protocol that
+> predates mandatory global genome-aware splitting and corrected causal embedding
+> extraction. They are retained for historical auditability, not presented as
+> current validated results. Leakage-controlled revalidation is tracked in
+> [issue #92](https://github.com/AvishaiBarnoy/genomics-lm/issues/92).
 
 ---
 
@@ -63,4 +67,4 @@ Outputs land in `conference/figures/`. All assets and the SOTA table are in [`co
 - [docs/MANUAL.md](docs/MANUAL.md) — full configuration, training, and analysis reference
 - [docs/DEVELOPMENT_LOG.md](docs/DEVELOPMENT_LOG.md) — narrative project history
 - [docs/RELEASE_NOTES.md](docs/RELEASE_NOTES.md) — high-level changelog
-- [conference/sota_benchmark_table.md](conference/sota_benchmark_table.md) — full benchmark table with k-mer baseline comparison
+- [conference/sota_benchmark_table.md](conference/sota_benchmark_table.md) — historical benchmark table with protocol-status labels

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -83,10 +83,10 @@ This file tracks all major tracks for the project. Each track has its own detail
 
 - [x] **Track: AMR Classification Probe (Conference)**
 *Link: [./tracks/amr_classification_20260615/](./tracks/amr_classification_20260615/)*
-*Summary: Completed. Created preparation script for CARD dataset. Integrated strict, homology-aware gene family splits (PR #66) and upgraded evaluations with Balanced Accuracy, Macro-AUPRC, and 1000-resample bootstrapped 95% confidence intervals (PR #69) to handle class imbalance.*
+*Summary: Completed historical implementation. Created CARD preparation, annotation-family-disjoint splits (not protein-homology holdouts), and class-imbalance metrics with bootstrap intervals. Corrected cluster-held-out evaluation remains open in issue #89.*
 
 - [x] **Track: EC & AMR Downstream Evaluation (Conference)**
-*Summary: Completed EC Level-1 probe (AUROC=0.703), homology-aware AMR probe (AUROC=0.893), k-mer baselines, UMAP+attention figures, SOTA table consolidation.*
+*Summary: Historical implementation completed EC/AMR probes, k-mer baselines, figures, and table consolidation. Reported metrics are legacy-protocol results pending corrected causal extraction and controlled group/homology splits (issue #92).*
 
 - [x] **Track: Generative Design Loop**
 *Link: [./tracks/generative_design_loop_20260615/](./tracks/generative_design_loop_20260615/)*

--- a/conductor/tracks/amr_classification_20260615/spec.md
+++ b/conductor/tracks/amr_classification_20260615/spec.md
@@ -4,6 +4,10 @@
 **Priority:** Medium (conference readiness)
 **Depends on:** Stage 2.6 checkpoint (✅ done), EC probe pipeline (✅ done)
 
+> **Historical specification:** Results produced by this track are legacy-protocol
+> artifacts. Annotation-family grouping is not a protein-homology holdout, and the
+> embeddings predate corrected causal extraction. See issues #89 and #92.
+
 ---
 
 ## Objective
@@ -12,7 +16,7 @@ Benchmark the CodonLM Stage 2.6 embeddings on **Antimicrobial Resistance (AMR) g
 
 This is the natural companion to the EC probe:
 - **EC** tests *enzymatic function* separability
-- **AMR** tests *resistance phenotype* separability — clinically significant and highly publishable
+- **AMR** tests annotation-label separability under the selected split protocol
 
 ---
 
@@ -23,7 +27,7 @@ AMR is one of the most critical public health challenges globally. A language mo
 Expected result range based on EC results:
 - LogReg/SVM accuracy: **50–70%** (fewer classes than EC, more biologically coherent)
 - If < 40%: embeddings do not capture AMR signal → negative result worth reporting
-- If ≥ 60%: strong positive result, publishable finding
+- If ≥ 60%: positive result under this protocol, requiring homology-controlled validation
 
 ---
 

--- a/conductor/tracks/progressive_scaling_20260610/plan.md
+++ b/conductor/tracks/progressive_scaling_20260610/plan.md
@@ -10,12 +10,16 @@ This plan details the implementation milestones to execute progressive transfer 
 - **Completed:** 2026-07-10
 - **Primary file:** `scripts/expand_model.py`
 
+> Stage 2.6 PPL, regression-probe, EC, and AMR values below are legacy-protocol
+> historical records. They are not controlled evidence for model selection; see
+> issue #92.
+
 ## Status Update (2026-06-16)
 We have successfully implemented and executed the model scaling ladder for the **`d_embd: 384`** series:
 - **`4L2H_d384`** (Base model trained from scratch)
 - **`6L4H_d384`** (Layer-transfer from `4L2H`, trained successfully)
 - **`10L8H_d384`** (Layer-transfer from `6L4H`, trained successfully)
-- **Stage 2.6 `10L8H_d384` on the expanded 15-genome corpus** became the current best CodonLM (`2026-06-15_stage2.6_10L8H_d384_e10`).
+- **Stage 2.6 `10L8H_d384` on the expanded 15-genome corpus** became the historical mainline checkpoint (`2026-06-15_stage2.6_10L8H_d384_e10`).
 
 Because `d_embd` was kept constant at 384, the linear projections in attention heads had identical tensor shapes `(384, 384)`. This bypassed the need for tensor resizing, allowing PyTorch's native `load_state_dict(..., strict=False)` to transfer weights seamlessly (leaving only the new layers initialized randomly).
 

--- a/conductor/tracks/sota_benchmarking_20260609/spec.md
+++ b/conductor/tracks/sota_benchmarking_20260609/spec.md
@@ -3,6 +3,10 @@
 ## 1. Overview
 This track defines the benchmarking framework to evaluate our models (CodonLM and ProteinLM/Critic) exclusively against State-of-the-Art (SOTA) **prokaryotic foundation models** (such as Evo 1 and GenSLM). Since our models are trained and designed for prokaryotic genomic sequence tasks, comparing against eukaryotic-focused models is omitted to ensure scientific alignment.
 
+> **Historical specification:** The implemented comparisons used different tasks,
+> datasets, and validation protocols across models. Resulting density ratios are
+> descriptive and must not be interpreted as controlled efficiency rankings.
+
 ---
 
 ## 2. Baseline SOTA Prokaryotic Models
@@ -55,4 +59,4 @@ Our models are evaluated against the specific prokaryotic benchmarks established
 ## 5. Evaluation Plan for our CodonLM & ProteinLM
 1.  **Zero-Shot Likelihood Scoring:** Compute sequence perplexity/log-likelihoods for the wild-type and mutated variants of *E. coli* 5S rRNA and prokaryotic proteins. Compare rank correlation (Spearman's $\rho$) against Evo 1 and GenSLM results.
 2.  **Downstream Probes:** Extract mean-pooled sequence embeddings from our backbones, train simple linear classifiers for lambda phage gene essentiality, and compare prediction F1 scores against SOTA.
-3.  **Compute Efficiency Density Ratio:** Evaluate accuracy / parameter count and accuracy / training-hours to show our M2 Mac optimized density performance.
+3.  **Compute Footprint Description:** Record accuracy, parameter count, and training-hours while explicitly avoiding rankings across non-equivalent tasks.

--- a/conference/project_story.md
+++ b/conference/project_story.md
@@ -1,6 +1,12 @@
-# The Genomics-LM Story: From Toy Scale to SOTA Compute-Efficiency Density
+# The Genomics-LM Story: Historical Development Record
 
 This document outlines the end-to-end development journey of the **Genomics-LM** project. It details how we translated biological intuition into data engineering, overcame local hardware constraints (Apple M2, 8GB RAM), and benchmarked local models against massive supercomputer-trained foundations.
+
+> **Validation status: Legacy/leaky.** Stage 2 through Stage 2.6 metrics in this
+> narrative predate mandatory global genome-aware splitting and corrected causal
+> embedding extraction. They are historical observations, not controlled model
+> comparisons. Evidence sources include intrinsic metrics, computational proxies,
+> annotations, and experimental measurements as described per section.
 
 ---
 
@@ -33,7 +39,7 @@ graph TD
 *   **Dataset:** Expanded to 9 diverse bacterial genomes, introducing High-GC and Gram-positive taxa.
 *   **Breakthroughs:**
     *   *Bacterial Dialects:* Validated that the model learned taxon-specific **Codon Usage Bias** (e.g., High-GC bacteria using specific Alanine codons 7x more than Gram-positives).
-    *   *Structural DNA Probing:* Hidden states were mapped using [DNAshapeR](https://bioconductor.org/packages/release/bioc/html/DNAshapeR.html) heuristics to rolling, electrostatic potential (EP), and minor groove width (MGW). High correlations (e.g., $0.61$ EP, $0.54$ Roll) proved the LM implicitly decoded 3D stereochemistry without explicit structural supervision.
+    *   *Structural DNA Probing:* Hidden states correlated with computational [DNAshapeR](https://bioconductor.org/packages/release/bioc/html/DNAshapeR.html) targets under a position-level protocol. Grouped and local-sequence controls are needed before attributing the signal to pretrained representations.
 
 ### 3. Stage 2.5: Genomic Architect (Resolving the Termination Problem)
 *   **Goal:** Overcome the 0.0% termination rate by teaching the model gene boundary transitions.
@@ -61,7 +67,8 @@ graph TD
 
 ## 2. Key Technical Metrics & Efficiency Density
 
-While absolute downstream scores of models like Evo 1 (1.8B) are higher due to parameter scale, the **Compute Efficiency Density Ratio** demonstrates the optimization density of the local model:
+The historical report calculated a **Compute Efficiency Density Ratio** from
+non-equivalent downstream tasks and datasets:
 
 $$\text{Efficiency Density} = \frac{\text{F1 Score}}{\text{Params (M)} \times \text{Pre-training GPU Hours}} \times 1000$$
 
@@ -71,8 +78,9 @@ $$\text{Efficiency Density} = \frac{\text{F1 Score}}{\text{Params (M)} \times \t
 | **Evo 1 (1.8B)** | 1800.00M | 3360.0 | 0.8100 | 0.000134 | 0.000119 |
 | **GenSLM (2.5B)** | 2500.00M | 20480.0 | 0.6800 | 0.000013 | 0.000012 |
 
-> [!TIP]
-> **Key Insight:** Local models deliver orders of magnitude higher efficiency density per parameter-hour on consumer-grade hardware compared to massive A100-supercomputer-trained foundations.
+> [!WARNING]
+> The numerator metrics use different datasets and protocols. These ratios are
+> descriptive arithmetic and do not establish relative model efficiency.
 
 ---
 

--- a/conference/sota_benchmark_table.md
+++ b/conference/sota_benchmark_table.md
@@ -4,16 +4,34 @@
 > [!NOTE]
 > All our models are trained on a single Apple M2 Mac (8 GB unified RAM, MPS GPU). External SOTA models (Evo 1, GenSLM) were trained on hundreds of A100 GPUs. Metrics marked `—` were not evaluated for that run.
 
+> [!WARNING]
+> The Stage 2.6 results in this document are **Legacy/leaky**. They predate
+> mandatory global genome-aware splitting and corrected causal embedding
+> extraction. Values are preserved as historical records and must not be cited as
+> controlled results. Replacement measurements are tracked in
+> [issue #92](https://github.com/AvishaiBarnoy/genomics-lm/issues/92).
+
 ### 🏷️ Scientific Validation Legend
-To maintain rigorous scientific standards, metrics are categorized according to their verification basis:
-*   `[Intrinsic]`: Intrinsic mathematical language model performance on validation/test holdout sequences.
-*   `[in silico]`: Regressions or comparisons against computational structural prediction software models (e.g., DNAshapeR structural profiles).
-*   `[Annotation]`: Downstream linear probes evaluated on curated database annotations representing biochemically characterized functions (e.g., EC numbers, CARD classes, essentiality labels).
-*   `[Experimental]`: Direct comparison against in vitro or in vivo biological laboratory measurements (e.g., Deep Mutational Scanning fitness scores).
+Scientific results use two independent axes. Evidence source does not imply that
+the evaluation protocol is controlled.
+
+**Evidence source**
+*   `[Intrinsic]`: Language-model performance on a repository-defined holdout.
+*   `[in silico]`: Comparison against computational structural predictions.
+*   `[Annotation]`: Evaluation against curated database annotations.
+*   `[Experimental]`: Comparison against laboratory measurements.
+
+**Validation status**
+*   `Legacy/leaky`: Produced before known split or extraction defects were corrected.
+*   `Preliminary`: Correctly described protocol, but incomplete controls or replication.
+*   `Controlled`: Leakage controls and prespecified comparisons passed.
+*   `Independently replicated`: Controlled result reproduced independently.
 
 ---
 
 ## 1. Internal Model Progression
+
+**Validation status: Legacy/leaky.** Evidence sources are marked per metric.
 
 | Run ID | Stage | Architecture | Dataset | Val PPL ↓ [Intrinsic] | Test PPL ↓ [Intrinsic] | DNAshape avg R² ↑ [in silico] | DNAshape avg ρ ↑ [in silico] | Protein DMS ρ ↑ [Experimental] | EC Acc ↑ [Annotation] | EC AUROC ↑ [Annotation] | AMR Acc ↑ [Annotation] | AMR AUROC ↑ [Annotation] |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -22,13 +40,17 @@ To maintain rigorous scientific standards, metrics are categorized according to 
 | `2026-06-11_stage2.5_10L8H_d256_e5` | Stage 2.5 | 10L·8H·d256 | 3-family, anchored | 74.34 | — | — | — | −0.080 | — | — | — | — |
 | `2026-06-12_stage2.5_6L4H_d384_e5` | Stage 2.5 | 6L·4H·d384 | 3-family, dynamic | 84.04 | — | 0.5517 | 0.7407 | −0.085 | — | — | — | — |
 | `2026-06-12_stage2.5_10L8H_d384_e5` | **Stage 2.5 (Baseline)** | **10L·8H·d384** | **3-family, dynamic** | **~74.8** | — | **0.5414** | **0.7344** | — | — | — | — | — |
-| **`2026-06-15_stage2.6_10L8H_d384_e10`** | **Stage 2.6 (Best)** | **10L·8H·d384** | **15-genome diverse** | **59.75** | **68.53** | **0.5690** | **0.7522** | **+0.059** | **39.6%** | **0.703** | **94.2%** | **0.932** |
+| **`2026-06-15_stage2.6_10L8H_d384_e10`** | **Stage 2.6 (Legacy)** | **10L·8H·d384** | **15-genome diverse** | **59.75** | **68.53** | **0.5690** | **0.7522** | **+0.059** | **39.6%** | **0.703** | **94.2%** | **0.932** |
 
 > **Stage 2.6** is the only run with a held-out test set evaluation and the full EC + AMR classification probes. Val PPL for Stage 2.5 10L8H baseline is derived from `last_perplexity` in the checkpoint metadata.
 
 ---
 
 ## 2. EC Level-1 Classification Probe Results (Stage 2.6 Embeddings)
+
+**Validation status: Legacy/leaky. Evidence source: Annotation.** Embeddings were
+created before the causal extraction correction, and the underlying pretraining
+split was not globally genome held out.
 
 > Random baseline accuracy = **1/7 = 14.3%**
 
@@ -39,11 +61,18 @@ To maintain rigorous scientific standards, metrics are categorized according to 
 | MLP 2×128 (`mlp`) | 34.01% | 7.25% | 0.528 | +19.7 pp |
 | *Random Baseline* | *14.3%* | *14.3%* | *0.500* | — |
 
-**Key finding:** Linear probes outperform non-linear MLP, confirming that EC functional classes are **linearly separable** in the learned embedding space — a strong signal of disentangled biological representations.
+**Historical observation:** Under this legacy protocol, linear probes scored above
+the tested MLP and random baselines. The result does not establish disentangled
+representations and requires rerunning with corrected embeddings and controlled
+splits.
 
 ---
 
 ## 2b. AMR Classification Probe Results (Stage 2.6 Embeddings, CARD v3)
+
+**Validation status: Legacy/leaky. Evidence source: Annotation.** These values use
+the earlier random AMR split and pre-correction embeddings; they are not
+homology-held-out results.
 
 > Source: [CARD](https://card.mcmaster.ca) Comprehensive Antibiotic Resistance Database v3 (CC BY 4.0)
 > Random baseline accuracy = **1/7 = 14.3%** | Dataset: 5,108 genes · 7 antibiotic classes · 4,089 train / 1,019 test
@@ -56,12 +85,16 @@ To maintain rigorous scientific standards, metrics are categorized according to 
 
 **Antibiotic classes (train distribution):** β-lactam (4,358) · Aminoglycoside (238) · Fluoroquinolone (167) · Macrolide/MLS (111) · Tetracycline (90) · Glycopeptide (82) · Macrolide (62)
 
-**Key finding:** AMR resistance class is **dramatically more linearly separable** than EC function (AUROC 0.967 vs. 0.703). This is consistent with the biology — AMR genes within each class share conserved enzyme families (β-lactamases, aminoglycoside-modifying enzymes, etc.) with strong sequence-level identity. The model has learned resistance-relevant sequence motifs purely from next-codon prediction, achieving **6.6× random baseline** with a linear probe.
-
-> [!TIP]
-> The high AMR separability vs. moderate EC separability reveals a gradient: resistance phenotype (mechanistically conserved families) > functional class (broader biochemical category). This is a publishable insight about what sequence-level LMs encode.
+**Historical observation:** AMR labels were easier to separate than EC labels under
+this protocol. Conserved family identity and split leakage are plausible
+confounders, so the result does not isolate representations learned from
+next-codon prediction.
 
 ## 3. DNAshape Regression Probe Detail (Stage 2.6 vs. Baseline)
+
+**Validation status: Legacy/leaky. Evidence source: in silico.** Position-level
+cross-validation did not group positions by gene or genome and lacks local-sequence
+controls.
 
 | DNA Shape Feature | Stage 2.6 R² [in silico] | Stage 2.6 ρ [in silico] | Stage 2.5 Baseline R² [in silico] | Stage 2.5 Baseline ρ [in silico] | Δ R² |
 | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -74,9 +107,15 @@ To maintain rigorous scientific standards, metrics are categorized according to 
 | Opening | 0.622 | 0.789 | 0.601 | 0.776 | +0.021 |
 | **Average** | **0.569** | **0.752** | **0.541** | **0.734** | **+0.028** |
 
-**Interpretation:** The taxonomically-diverse Stage 2.6 model improves DNAshape decoding across all 14 features, with the largest gains on helical step parameters (Roll, HelT), suggesting the model learns more generalizable structural grammar across phyla.
+**Historical observation:** Stage 2.6 produced higher decoding scores in this
+position-level evaluation. Grouped cross-validation and 5-mer/7-mer controls are
+required before attributing the difference to generalizable structural grammar.
 
 ## 4. Prokaryotic Gene Essentiality Benchmark Results
+
+**Validation status: Legacy/leaky. Evidence source: Annotation.** Tasks, datasets,
+and evaluation protocols differ across the rows, so values are not direct model
+rankings.
 
 This task measures how well frozen sequence representations encode properties dictating whether a gene is indispensable (essential) for organism survival. We extract mean-pooled gene embeddings and train a linear probe to classify essentiality.
 
@@ -86,11 +125,16 @@ This task measures how well frozen sequence representations encode properties di
 | **Evo 1 (1.8B)** | 1800.0M | 0.810 | **0.720** |
 | **GenSLM (2.5B)** | 2500.0M | 0.680 | 0.620 |
 
-**Interpretation:** Despite being orders of magnitude smaller, our model's pre-trained embeddings achieve highly competitive or superior performance on prokaryotic gene essentiality task boundaries, outperforming GenSLM on both genomes and exceeding Evo 1's F1 score on Lambda phage.
+**Historical observation:** The recorded values came from non-equivalent task and
+split protocols and therefore cannot support a direct superiority claim.
 
 ---
 
 ## 5. External SOTA Comparison (Compute Efficiency Density)
+
+**Validation status: Legacy/leaky. Evidence sources: Experimental and computational
+proxy.** The numerator metrics come from different tasks and datasets; the density
+values are descriptive arithmetic, not a controlled efficiency comparison.
 
 | Model | Architecture | Params | Training Hardware | Pre-train Hours | Protein DMS ρ [Experimental] | Compute Efficiency† |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -98,14 +142,22 @@ This task measures how well frozen sequence representations encode properties di
 | **GenSLM** | GPT-style Transformer | 2.5B | 512× A100 | ~2000+ | ~0.35+ | 0.000013 |
 | **CodonLM (ours, Stage 2.6)** | Causal TinyGPT | **20.6M** | 1× Apple M2 (8GB) | **6.3** | **+0.059** | **23.12** |
 
-> † Compute Efficiency = (F1 Score / (Params_M × Training_GPU_Hours)) × 1000. Our model delivers orders-of-magnitude higher efficiency density on consumer hardware. External SOTA Protein DMS scores are from their published papers; our score is measured on the same synthetic prokaryotic DMS suite.
+> † Compute Efficiency = (F1 Score / (Params_M × Training_GPU_Hours)) × 1000.
+> External scores and the local score use different datasets and protocols, so the
+> resulting ratios are not comparable measures of model efficiency.
 
 > [!IMPORTANT]
-> Our Protein DMS Spearman ρ is measured on the **synthetic prokaryotic benchmark** in `data/benchmarks/`. The external model scores are from their published evaluations on different (larger, curated) DMS datasets. A direct numerical comparison requires caution — the key finding is the **sign flip**: our model went from *negative* correlation (Stage 2.5: −0.105) to *positive* correlation (Stage 2.6: +0.059) as we scaled taxonomic diversity, validating the data-scaling approach.
+> Our Protein DMS Spearman ρ is measured on the **synthetic prokaryotic benchmark**
+> in `data/benchmarks/`. External scores use different curated datasets. The small
+> sign change from Stage 2.5 to Stage 2.6 is a preliminary observation and does not
+> establish an effect of taxonomic scaling.
 
 ---
 
 ## 5. Summary: Model Improvement Story
+
+**Validation status: Legacy/leaky.** This diagram records the historical experiment
+sequence; it is not a validated scaling law.
 
 ```mermaid
 graph LR
@@ -117,9 +169,12 @@ graph LR
 **The scaling narrative:**
 1. **Depth + Heads (2.5→2.5):** Adding layers/heads reduced perplexity from 86 → 74 but didn't fix the negative DMS correlation.
 2. **Width (d256→d384):** Boosted DNAshape decoding to R²=0.54, enabling physical representation.
-3. **Taxonomic Diversity (3→15 genomes, 2.5→2.6):** The critical leap — perplexity dropped to 68.5, DMS flipped positive, EC classification reached 2.8× random, and DNAshape improved across all features.
+3. **Taxonomic Diversity (3→15 genomes, 2.5→2.6):** Legacy metrics changed in the favorable direction, but split and evaluator confounders prevent attributing the changes to taxonomic diversity.
 
 ## 5b. K-mer Baseline vs. LM Embeddings
+
+**Validation status: Legacy/leaky. Evidence source: Annotation.** The baseline and
+probe comparison shares the legacy splits and embeddings described above.
 
 > **Setup:** 3-mer TF-IDF LogReg trained on raw DNA codon sequences (same train/test splits as the LM probe). This isolates the contribution of pre-trained LM representations over simple frequency counting.
 
@@ -141,22 +196,26 @@ graph LR
 | K-mer 3-mer TF-IDF | 87.7% | 26.5% | 0.924 | — |
 | *Random Baseline* | *14.3%* | *14.3%* | *0.500* | — |
 
-**Key finding:** LM embeddings consistently outperform raw k-mer frequency baselines:
+**Historical observation:** LM probes scored above these k-mer baselines under the
+legacy protocol:
 - **EC:** +6.1 AUROC points, +12.7 Macro-F1 points — LM learns functional structure beyond codon composition
 - **AMR:** +4.3 AUROC points, **+38.9 Macro-F1 points** — the k-mer baseline is badly confused by class imbalance (β-lactam dominates) while the LM probe correctly separates minority classes
 
 > [!IMPORTANT]
-> The AMR k-mer accuracy (87.7%) is high but misleading — it's driven by predicting β-lactam for everything. The LM probe's Macro-F1 (65.4% vs. 26.5%) shows it actually classifies minority antibiotic families correctly, confirming that LM embeddings encode *resistance mechanism* beyond codon frequency.
+> The AMR k-mer accuracy is dominated by class imbalance. The Macro-F1 difference
+> is descriptive for this split and does not establish that embeddings encode
+> resistance mechanism beyond family identity.
 
 ---
 
 - [x] Generate and embed **UMAP codon embedding plots** (synonymous codon clustering).
 - [x] Generate **attention specialization heatmaps** (ATG/stop codon heads).
-- [x] Run **Logistic Regression AMR probe** (CARD v3, 7 classes, AUROC=0.967).
+- [x] Run the historical **Logistic Regression AMR probe** (CARD v3, 7 classes; legacy AUROC=0.967).
 - [x] Add **k-mer baseline** to EC/AMR tables — LM embeddings beat raw k-mer on AUROC and Macro-F1. ✅
 
 ---
 
-## 🏆 Conference Ready
+## Historical Conference Artifact Status
 
-All planned evaluation tracks are complete. The full benchmark table, UMAP/attention figures, and k-mer comparison are in [`conference/`](file:///Users/User/github/genomics-lm/conference/).
+The original benchmark artifacts are retained in `conference/` for auditability.
+They require corrected reruns before use as current scientific evidence.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -3,6 +3,13 @@
 
 This document captures the end-to-end journey of Genomics-LM. It details how we translated biological intuition into data engineering, how we overcame the limitations of local hardware (Apple M2, 8GB RAM), and how the model evolved from a naive text-predictor into a physically-aware genomic architect.
 
+> **Historical-results notice:** Stage 2 through Stage 2.6 metrics and downstream
+> probe interpretations in this narrative use a legacy protocol. They predate
+> mandatory global genome-aware splitting and corrected causal embedding
+> extraction. Values are retained to document project history, not as controlled
+> evidence. Corrected revalidation is tracked in
+> [issue #92](https://github.com/AvishaiBarnoy/genomics-lm/issues/92).
+
 ---
 
 ## 1. Stage 1: Toy Scale (The Grammar School)
@@ -28,7 +35,7 @@ We built `scripts/analyze_dialects.py` and discovered the model successfully lea
 **The Physics Breakthrough (Structural Probing):**
 We hypothesized that the model was implicitly learning 3D DNA physics as a shortcut to predicting the next codon. We built `scripts/probe_structural_awareness.py` using DNAshapeR heuristics.
 *   **Result:** The frozen hidden states of the 6-layer model showed strong correlations (e.g., 0.61 EP, 0.54 Roll) with physical properties like Minor Groove Width and Electrostatic Potential.
-*   **Significance:** The AI discovered *on its own* that A-tracts act as "structural rebar" and GC-repeats act as "flexible hinges." It proved that a 1D language model can encode 3D stereochemistry.
+*   **Historical interpretation:** Hidden states correlated with computational DNA-shape targets under a position-level protocol. Grouped controls are required before attributing this to learned 3D stereochemistry.
 
 ---
 
@@ -101,14 +108,14 @@ We designed a domain-aligned benchmarking framework to evaluate our models exclu
 2.  **Gene Essentiality:** Downstream classification using sequence embeddings + linear probes. Stratified 5-fold cross-validation yielded F1 scores of **87.3%** on Lambda Phage essentiality and **70.7%** on *Pseudomonas aeruginosa* essentiality.
 3.  **SOTA Report & Compute Efficiency Density:** Contrasts our local models against published benchmarks of Evo 1 and GenSLM.
 
-**Compute Efficiency Breakthrough:**
-While absolute scores of Evo 1 (1.8B) are higher due to its massive parameter count, computing the **Compute Efficiency Density Ratio** revealed our model's huge efficiency advantage:
+**Historical Compute-Footprint Calculation:**
+The project calculated a **Compute Efficiency Density Ratio** from results produced on different tasks and datasets:
 $$\text{Efficiency Density} = \frac{\text{F1 Score}}{\text{Params (M)} \times \text{Pre-training GPU Hours}} \times 1000$$
 *   **Our Model (TinyGPT):** **23.12** (Lambda Phage) / **18.72** (Pseudomonas)
 *   **Evo 1 (1.8B):** **0.000134** (Lambda Phage) / **0.000119** (Pseudomonas)
 *   **GenSLM (2.5B):** **0.000013** (Lambda Phage) / **0.000012** (Pseudomonas)
 
-Our local models deliver orders of magnitude higher performance density per parameter-hour on consumer-grade hardware compared to massive A100-supercomputer-trained foundations.
+These ratios are descriptive arithmetic only. Because the numerator metrics and evaluation protocols differ, they do not establish a model-efficiency advantage over Evo 1 or GenSLM.
 
 ---
 
@@ -133,13 +140,13 @@ Our local models deliver orders of magnitude higher performance density per para
 *   **The Model Scale-up (`d384`)**:
     We scaled the model embedding dimension from $D=256$ to $D=384$ and expanded the architecture to 10 layers and 8 heads (`10L8H_d384_transfer`). This added network capacity allowed the model to represent both the structural grammar (stop-codon placement, gene length boundaries) and the stereochemical shapes of DNA.
 *   **Industry Context & The Entropy Trade-Off (Codon Tokenization)**:
-    While massive foundation models like Evo (1.8B) or DNABERT-2 (117M) utilize single-nucleotide or Byte Pair Encoding (BPE) tokenization, they suffer from distorted coordinate step alignment when predicting local physical parameters. Industry-level models built specifically for coding DNA and protein expression optimization—such as **CodonTransformer** and InstaDeep's **Codon-NT**—also utilize codon-level (3-mer non-overlapping) tokenization. This uniform spacing ensures a strict 1-to-1 mapping to physical double-helix coordinates, allowing our TinyGPT model to achieve state-of-the-art biophysical probing accuracy on par with models $100\times$ its size.
+    Foundation models such as Evo and DNABERT-2 use nucleotide or subword tokenization, while coding-DNA models such as **CodonTransformer** and **Codon-NT** use codon-level tokenization. Codon tokens provide convenient coordinate alignment, but the legacy probe protocol does not support a state-of-the-art comparison.
     *   **The Entropy/Perplexity Split**: CodonTransformer operates as a *conditional* model. By conditioning on the target amino acid sequence, it restricts the prediction search space at each position to synonymous codons (representing the degeneracy of the genetic code: 1-out-of-2 to 1-out-of-6 options). This conditional search yields a very low perplexity ($1.2 - 1.8$) and guarantees translation fidelity, but *loses* the ability for de novo gene generation and regulatory (non-coding promoter/operon) sequence modeling.
     *   **Our Unconditional Advantage**: Our CodonLM is a causal "biological writer." By predicting the next codon unconditionally out of all 64 options, it has a higher perplexity ($\approx 84.0$) but *gains* the capacity to generate novel gene structures from scratch and implicitly encodes DNA stereochemistry and regulatory spacing in its hidden states.
 *   **The PCA-1 vs. Supervised Regression Probing Story**:
     *   **The Problem**: After training under the dynamic gene-level padding setup, the unsupervised $PCA_1$ structural awareness score dropped significantly (from $\approx 0.60$ to $0.1677$). The model's primary direction of variance ($PCA_1$) was hijacked by the strong grammatical signals of gene boundaries and stop codon positioning.
     *   **The Solution**: We implemented supervised **Ridge Regression Probes** (with 5-fold cross-validation) to scan all 384 hidden dimensions.
-    *   **The Finding**: The regression probe successfully decoded physical DNAshape features (MGW, EP, Roll, ProT, HelT) with high accuracy ($R^2 \approx 0.50$, Pearson $\rho \approx 0.70$), proving that the physical representations were not lost but simply re-organized into secondary orthogonal dimensions. Both the 6L4H baseline and the 10L8H model showed strong, identical biophysical decoding capability (97% agreement).
+    *   **Historical observation**: The regression probe decoded computational DNAshape features ($R^2 \approx 0.50$, Pearson $\rho \approx 0.70$). Because positions were not grouped by gene/genome and local-sequence controls were absent, this does not establish how much signal came from pretrained representations.
 *   **Taxonomic Expansion**:
     Downloaded a fully diverse 15-genome bacterial corpus spanning multiple phyla and balanced GC content (from 30% to 75%), extracting 44,953 coding sequences for scaled training.
 
@@ -196,7 +203,7 @@ Our local models deliver orders of magnitude higher performance density per para
     *   **MLP 2×128 (`mlp`):** Acc = 34.01%, Macro-F1 = 7.25%, AUROC = 0.528
     *   **Random Baseline:** 14.3% (1/7 classes)
 
-    **Key Finding:** Linear probes substantially outperform the non-linear MLP (2.8× random vs. 2.4× random), confirming that EC functional classes are **linearly separable** in the pre-trained embedding space. This is a hallmark of disentangled biological representations and validates the unsupervised pre-training strategy.
+    **Legacy-protocol observation:** Linear probes outperformed the tested MLP and random baselines. The embeddings predate the causal extraction fix, so this result does not establish disentangled representations or validate the pretraining strategy.
 
 *   **Gene Essentiality Officially Retired:**
     Gene essentiality (Lambda Phage, *Pseudomonas aeruginosa*) was formally removed from the core evaluation suite. MCC = 0.0 across all probes confirms it is a multi-gene network-level property unreachable by single-gene linear projections.
@@ -219,8 +226,8 @@ Our local models deliver orders of magnitude higher performance density per para
     3. **Lazy/memmap dataset** to eliminate host-memory preloading overhead.
     Updated [`ROADMAP.md`](file:///Users/User/github/genomics-lm/ROADMAP.md) and [`conductor/tracks.md`](file:///Users/User/github/genomics-lm/conductor/tracks.md) to reflect the new track.
 
-*   **Conference Readiness Status:**
-    The project has reached a clear "first-draft conference" state with: a physically-aware pre-trained model (DNAshape R²=0.57), confirmed functional linear separability (EC AUROC=0.703), and a systematic plan for UMAP visualizations, attention heatmaps, and generative design evaluation (ProteinCritic + ESMFold).
+*   **Historical Conference Draft Status:**
+    The project assembled a first-draft artifact set around legacy DNAshape and EC results. Those values now require grouped controls, corrected embeddings, and leakage-controlled revalidation before scientific use.
 
 ---
 
@@ -240,7 +247,7 @@ Our local models deliver orders of magnitude higher performance density per para
     *   **Logistic Regression (`probe_logreg`):** Acc = 93.1%, Macro-F1 = 59.5%, AUROC = **0.967** ← Best AUROC
     *   **Random Baseline:** 14.3% (1/7 classes)
 
-    **Key Finding:** AMR resistance class is **dramatically more linearly separable than EC function** (AUROC 0.967 vs. 0.703, 6.6× vs. 2.8× random). This is biologically expected — AMR gene families (β-lactamases, aminoglycoside-modifying enzymes) share high sequence identity within class. The result confirms that CodonLM embeddings encode **resistance-relevant sequence motifs** from next-codon prediction alone, a clinically significant finding for conference presentation.
+    **Legacy-protocol observation:** AMR labels were easier to separate than EC labels in the original split. Conserved family identity, the random split, and pre-correction embeddings are confounders; the result does not isolate resistance-relevant representations learned during pretraining.
 
 *   **Conference Figure Generation:**
     Wrote two reusable conference figure scripts:
@@ -263,7 +270,7 @@ Our local models deliver orders of magnitude higher performance density per para
     *   **AMR family** (AUROC 0.967): Highest — mechanistically conserved enzyme families with strong seq identity
     *   **EC class** (AUROC 0.703): Moderate — broader biochemical function, more diverse seq space
     *   **Gene Essentiality** (MCC 0.0): Lowest — network-level systemic property, not sequence-encodable
-    This gradient is itself a publishable result about the limits and strengths of sequence-level genomic LMs.
+    This historical gradient is a hypothesis for controlled re-evaluation, not a validated comparison of representation content.
 
 ---
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -502,6 +502,11 @@ By default, the client will start a local server (typically at `http://localhost
 
 ## SOTA Benchmarking & Compute Footprint Profiling
 
+> **Legacy protocol:** Existing Stage 2.6 reports were produced before mandatory
+> global genome-aware splitting and corrected causal embedding extraction. The
+> commands below reproduce historical tooling; their output is not a controlled
+> cross-model comparison. See issue #92 for the replacement protocol.
+
 To evaluate our model against published SOTA prokaryotic models (Evo 1, GenSLM) on aligned prokaryotic benchmarks:
 
 1.  **Prepare mock/synthetic benchmark datasets:**
@@ -608,7 +613,7 @@ The repository uses two output directory conventions due to a historical migrati
 | `outputs/checkpoints/` | **Legacy** — Stage 1 checkpoints from before the `runs/` layout | ⚠️ Safe to archive |
 | `outputs/reports/` | Downstream probe outputs (EC, AMR, k-mer classifiers) | ✅ Current |
 | `outputs/scores/` | Legacy benchmark scores | ⚠️ Historical |
-| `conference/` | Publication assets — figures, SOTA table, abstracts, slides | ✅ Current |
+| `conference/` | Historical figures, benchmark table, abstracts, and slides | ⚠️ Legacy protocol |
 
 > **Why is `outputs/` so large?**
 > `outputs/checkpoints/` (~4.4 GB) contains 31 old Stage 1 and early Stage 2 model checkpoints that predate the migration to the `runs/` layout. They are not used by any current script and can be safely deleted or moved to cold storage:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,9 +4,9 @@ This document tracks notable changes to the project. We follow a simple date‑b
 
 ## Unreleased
 
-- **SOTA Benchmarking & Compute Footprint Profiling**: Added a target prokaryotic evaluation suite comparing our models against published SOTA prokaryotic models (Evo 1 and GenSLM). Implemented zero-shot mutation scoring (`scripts/benchmark_zero_shot_mutations.py`) on protein and rRNA DMS, and linear probing (`scripts/benchmark_gene_essentiality.py`) on gene essentiality datasets. Added comparison reporting (`scripts/generate_sota_report.py`) demonstrating orders of magnitude higher compute-efficiency density ratio for locally-trained models on consumer hardware.
+- **SOTA Benchmarking & Compute Footprint Profiling (legacy protocol)**: Added a prokaryotic evaluation suite, zero-shot mutation scoring, essentiality probes, and descriptive compute-footprint reporting. The historical cross-model ratios combine non-equivalent datasets and tasks and are not controlled efficiency comparisons. Corrected revalidation is tracked in issue #92.
 - **Stage 2.5: Genomic Tapes & Anchored Operons**: `src/codonlm/extract_genomic_tape.py` and `extract_anchored_operons.py` enable training on contiguous chromosomal data and targeted gene-boundary transitions.
-- **Structural DNA Probing**: `scripts/probe_structural_awareness.py` validates model physics by mapping hidden states to Roll, EP, and MGW using DNAshape heuristics.
+- **Structural DNA Probing (legacy protocol)**: `scripts/probe_structural_awareness.py` maps hidden states to computational Roll, EP, and MGW targets. Grouped controls are required before attributing the signal to pretrained structural representations.
 - **Stage 3: Multi-Task Protein Critic Implemented & Trained**: Completed training of the `MultiTaskProteinClassifier` (`configs/protein_critic.yaml` with an 8L8H_d256 architecture) over 50 epochs on Apple Silicon GPU (`mps`), achieving 76.81% validation accuracy on thermodynamic stability, 6.15% on Pfam (1,000 classes), and 5.50% on EC function (500 classes). Added full train-resumption features (`--resume`) and automatic epoch-end checkpoints (`last_critic.pt`).
 - **Stage 3 Preparations**: `scripts/fetch_uniprot_metadata.py` and `scripts/build_multitask_dataset.py` introduced to create unified Pfam/Stability datasets for the Protein-Critic.
 - **Hardware Optimization**: Re-enabled SDPA (Flash-like attention) in `model_tiny_gpt.py` providing a 3x speedup on Apple Silicon, alongside gradient accumulation fixes to respect 8GB RAM ceilings.
@@ -38,4 +38,3 @@ This document tracks notable changes to the project. We follow a simple date‑b
 Guidelines for maintainers:
 - Add entries to "Unreleased" during development (link PRs if desired). On tagging a release, copy Unreleased to a dated section and clear Unreleased.
 - Keep entries concise and focused on user‑visible changes (new scripts/flags, behavior changes, deprecations).
-

--- a/tests/test_scientific_claims_docs.py
+++ b/tests/test_scientific_claims_docs.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_readme_does_not_present_legacy_stage26_metrics_as_current_headlines():
+    readme = _read("README.md")
+
+    assert "Stage 2.6 (current best)" not in readme
+    assert "**Test PPL: 68.5**" not in readme
+    assert "legacy protocol" in readme.lower()
+
+
+def test_benchmark_table_declares_evidence_and_validation_axes():
+    table = _read("conference/sota_benchmark_table.md")
+
+    assert "Evidence source" in table
+    assert "Validation status" in table
+    assert "Legacy/leaky" in table
+    assert "Controlled" in table
+    assert "Independently replicated" in table
+
+
+def test_active_scientific_docs_do_not_make_banned_unqualified_claims():
+    paths = [
+        "conference/sota_benchmark_table.md",
+        "conference/project_story.md",
+        "docs/DEVELOPMENT_LOG.md",
+        "docs/RELEASE_NOTES.md",
+    ]
+    banned = [
+        "orders of magnitude higher performance density",
+        "publishable insight",
+        "clinically significant finding",
+        "hallmark of disentangled biological representations",
+        "validating the data-scaling approach",
+    ]
+
+    combined = "\n".join(_read(path).lower() for path in paths)
+    for claim in banned:
+        assert claim not in combined


### PR DESCRIPTION
Closes #87

## Summary

- remove unqualified Stage 2.6 metrics from the README headline
- separate evidence source from validation status in the historical benchmark table
- label affected PPL, shape, EC, AMR, essentiality, and efficiency results as legacy protocol
- replace unsupported biological and cross-model conclusions with protocol-bounded observations
- add a regression test preventing the strongest unqualified claims from returning

Historical numbers remain available for auditability; this PR does not replace them with corrected measurements.

## Validation

- `pytest -q`: 174 passed, 1 skipped, 1 xpassed
- `pytest -q tests/test_scientific_claims_docs.py`: 3 passed
- `ruff check tests/test_scientific_claims_docs.py`
- `git diff --check`