### PR TITLE
Require global genome-aware dataset splits

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -21,7 +21,7 @@ A compact codon‑level GPT‑style LM with a reproducible training + analysis p
 
 - TinyGPT model (src/codonlm/model_tiny_gpt.py) with optional grad checkpointing and segment‑masked attention for <SEP>.
 - Trainer with AMP, cosine warmup, early stopping, CSV curves (src/codonlm/train_codon_lm.py).
-- Data prep that extracts CDS, tokenizes codons, builds NPZ datasets, and checks integrity (scripts/pipeline_prepare.py).
+- Global genome-aware data preparation that extracts CDS, resolves accessions, splits groups before packing, and records provenance (`scripts/build_global_manifest.py`).
 - Analysis scripts for frequencies, embeddings, attention, next‑token probes, saliency, and linear probes (scripts/*).
 
 ### Compare Runs

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -11,10 +11,16 @@ This guide establishes the mandatory scientific and engineering workflow for dev
 
 ### Mandatory Workflow
 1. Define your dataset sources in a YAML config (e.g. `configs/tiny_mps.yaml`).
-2. Run [`build_global_manifest.py`](file:///Users/User/github/genomics-lm/scripts/build_global_manifest.py) to extract CDS records, group them globally by organism or taxonomy genus, and partition them into train/val/test splits:
+2. Run [`build_global_manifest.py`](../scripts/build_global_manifest.py) to extract CDS records, resolve stable accessions, group records globally by genome or genus, and partition groups before packing. This is also the default preparation route used by `main.sh`:
    ```bash
    python -m scripts.build_global_manifest --config configs/tiny_mps.yaml --run-id <RUN_ID> --run-dir runs/<RUN_ID> --group-by genome
    ```
+
+   Scientific preparation fails when fewer than three groups are available.
+   `--allow-sequence-split` is an explicit development-only escape hatch and marks
+   the resulting manifest as non-scientific. The older
+   `scripts.pipeline_prepare` route is disabled unless
+   `--allow-legacy-per-dataset-split` is supplied for historical reproduction.
 3. Verify that the output splits contain mutually exclusive genome sets by inspecting the generated `data/processed/global/<RUN_ID>/cds_meta.tsv`.
 
 ---

--- a/main.sh
+++ b/main.sh
@@ -173,7 +173,7 @@ sed 's/^/[config] /' "$CONF" | tee -a "$LOG"
 echo "[info] extra_datasets_cli=${EXTRA_DATASETS[*]:-none}" | tee -a "$LOG"
 
 # Config fingerprint (sha256) and git commit
-python - <<'PY' "$CONF" | tee -a "$LOG"
+python - "$CONF" <<'PY' | tee -a "$LOG"
 import hashlib, sys, pathlib, subprocess
 conf_path = pathlib.Path(sys.argv[1])
 try:
@@ -248,19 +248,19 @@ print(cfg.get('test_npz') or data.get('test_npz', ''))
       fi
 
       eval "$(
-      python - <<'PY' "$PREP_JSON"
-      import json, shlex, sys
-      info = json.load(open(sys.argv[1]))
-      mapping = {
-          "TRAIN_NPZ": info["train_npz"],
-          "VAL_NPZ": info["val_npz"],
-          "TEST_NPZ": info["test_npz"],
-          "PRIMARY_DNA": info["primary_dna"],
-          "COMBINED_MANIFEST": info["combined_manifest"],
-      }
-      for key, value in mapping.items():
-          print(f'{key}={shlex.quote(str(value))}')
-      PY
+      python - "$PREP_JSON" <<'PY'
+import json, shlex, sys
+info = json.load(open(sys.argv[1]))
+mapping = {
+    "TRAIN_NPZ": info["train_npz"],
+    "VAL_NPZ": info["val_npz"],
+    "TEST_NPZ": info["test_npz"],
+    "PRIMARY_DNA": info["primary_dna"],
+    "COMBINED_MANIFEST": info["combined_manifest"],
+}
+for key, value in mapping.items():
+    print(f'{key}={shlex.quote(str(value))}')
+PY
       )"
     fi
   fi
@@ -325,7 +325,7 @@ if [[ "$TRAINER" == "codon_lm" ]]; then
 
   # Fingerprint combined manifest contents
   if [[ $DRY_RUN -eq 0 ]]; then
-    python - <<'PY' "$COMBINED_MANIFEST" | tee -a "$LOG"
+    python - "$COMBINED_MANIFEST" <<'PY' | tee -a "$LOG"
 import hashlib, sys, pathlib
 p = pathlib.Path(sys.argv[1])
 try:

--- a/main.sh
+++ b/main.sh
@@ -4,8 +4,22 @@
 # It does NOT handle downstream sequence generation/inference. For sequence
 # generation, use scripts/generative_design_loop.py.
 
-eval "$(conda shell.bash hook)" || true
-conda activate codonlm || true
+activate_codonlm_conda() {
+  if [[ "${CODONLM_SKIP_CONDA:-0}" == "1" ]]; then
+    return
+  fi
+  if ! command -v conda >/dev/null 2>&1; then
+    return
+  fi
+  if ! conda env list 2>/dev/null | awk '$1 == "codonlm" { found=1 } END { exit !found }'; then
+    echo "[info] conda environment 'codonlm' not found; using current Python environment" >&2
+    return
+  fi
+  eval "$(conda shell.bash hook)"
+  conda activate codonlm
+}
+
+activate_codonlm_conda
 
 set -euo pipefail
 

--- a/main.sh
+++ b/main.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<USAGE
-Usage: $0 [-c|--config PATH] [-r|--resume CHECKPOINT] [--dataset NAME,GBFF[,MIN_LEN]] [--force] [--with-artifacts] [--with-motifs] [--preprocess-only] [--dry-run]
+Usage: $0 [-c|--config PATH] [-r|--resume CHECKPOINT] [--dataset NAME,GBFF[,MIN_LEN]] [--force] [--allow-sequence-split] [--with-artifacts] [--with-motifs] [--preprocess-only] [--dry-run]
 USAGE
   exit 1
 }
@@ -28,6 +28,7 @@ DEFAULT_CONF="configs/tiny_mps.yaml"
 CONF="$DEFAULT_CONF"
 RESUME=""
 FORCE=0
+ALLOW_SEQUENCE_SPLIT=0
 RUN_ID_WAS_SET=0
 if [[ -n "${RUN_ID:-}" ]]; then
   RUN_ID_WAS_SET=1
@@ -51,6 +52,8 @@ while [[ $# -gt 0 ]]; do
       EXTRA_DATASETS+=("$2"); shift 2 ;;
     --force)
       FORCE=1; shift ;;
+    --allow-sequence-split)
+      ALLOW_SEQUENCE_SPLIT=1; shift ;;
     --with-artifacts)
       WITH_ARTIFACTS=1; shift ;;
     --with-motifs)
@@ -207,25 +210,26 @@ print(cfg.get('test_npz') or data.get('test_npz', ''))
     PRIMARY_DNA=""
     COMBINED_MANIFEST=""
   else
-    # Prepare datasets via Python helper
+    # Prepare all CodonLM records globally before assigning grouped splits.
     PREP_ARGS=(--config "$CONF" --run-id "$RUN_ID" --run-dir "$RUN_DIR")
     if [[ $FORCE -eq 1 ]]; then PREP_ARGS+=(--force); fi
+    if [[ $ALLOW_SEQUENCE_SPLIT -eq 1 ]]; then PREP_ARGS+=(--allow-sequence-split); fi
     if [[ ${#EXTRA_DATASETS[@]} -gt 0 ]]; then
       for spec in "${EXTRA_DATASETS[@]}"; do PREP_ARGS+=(--extra-dataset "$spec"); done
     fi
     if [[ $DRY_RUN -eq 1 ]]; then
-      echo "[dry-run] Planned dataset preparation: python -m scripts.pipeline_prepare ${PREP_ARGS[*]}"
-      TRAIN_NPZ="data/processed/train_bs512.npz"
-      VAL_NPZ="data/processed/val_bs512.npz"
-      TEST_NPZ="data/processed/test_bs512.npz"
-      PRIMARY_DNA="data/processed/primary.fasta"
-      COMBINED_MANIFEST="data/processed/manifest.json"
+      echo "[dry-run] Planned dataset preparation: python -m scripts.build_global_manifest ${PREP_ARGS[*]}"
+      TRAIN_NPZ="data/processed/global/${RUN_ID}/train_bs512.npz"
+      VAL_NPZ="data/processed/global/${RUN_ID}/val_bs512.npz"
+      TEST_NPZ="data/processed/global/${RUN_ID}/test_bs512.npz"
+      PRIMARY_DNA="data/processed/global/${RUN_ID}/cds_dna.txt"
+      COMBINED_MANIFEST="data/processed/global/${RUN_ID}/manifest.json"
     else
-      python -m scripts.pipeline_prepare "${PREP_ARGS[@]}" 2>&1 | tee -a "$LOG"
+      python -m scripts.build_global_manifest "${PREP_ARGS[@]}" 2>&1 | tee -a "$LOG"
 
       PREP_JSON="${RUN_DIR}/pipeline_prepare.json"
       if [[ ! -f "$PREP_JSON" ]]; then
-        echo "[error] pipeline_prepare did not produce ${PREP_JSON}" | tee -a "$LOG"
+        echo "[error] build_global_manifest did not produce ${PREP_JSON}" | tee -a "$LOG"
         exit 1
       fi
 

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -6,7 +6,7 @@ This script implements a global, leakage-resistant data preparation pipeline.
 Instead of splitting datasets individually and stacking them (which causes P0 genomic/homology leakage),
 it:
   1. Gathers all CDS sequences and metadata across all configured GenBank (GBFF) files.
-  2. Groups sequence records by genome_id (filename-derived) or taxonomic genus.
+  2. Resolves stable genome accessions and groups records by genome or genus.
   3. Splits groups globally into train/val/test partitions (Option A).
   4. Tokenizes all sequences using the standard codon tokenizer.
   5. Packs split tokenized IDs into final NPZ files directly.
@@ -22,14 +22,20 @@ import argparse
 import csv
 import json
 import random
+import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Tuple
 import numpy as np
 import yaml
 from Bio import SeqIO
 
 from src.codonlm.codon_tokenize import to_ids, stoi, itos
 from src.codonlm.extract_cds_from_genbank import reverse_complement, _first_qualifier, _join_qualifier
+
+
+ASSEMBLY_ACCESSION_RE = re.compile(
+    r"(?<![A-Z0-9])(GC[AF]_\d+(?:\.\d+)?)(?![\d.])", re.IGNORECASE
+)
 
 def _load_config(path: Path) -> dict:
     cfg = yaml.safe_load(path.read_text()) or {}
@@ -39,6 +45,90 @@ def _load_config(path: Path) -> dict:
         for k, v in cfg["data"].items():
             cfg.setdefault(k, v)
     return cfg
+
+
+def _parse_extra_dataset(spec: str) -> dict:
+    parts = spec.split(",")
+    if len(parts) < 2:
+        raise SystemExit(
+            f"[error] Bad --extra-dataset spec (need name,gbff[,min_len]): {spec}"
+        )
+    entry: dict = {"name": parts[0], "gbff": parts[1]}
+    if len(parts) > 2:
+        entry["min_len"] = int(parts[2])
+    return entry
+
+
+def resolve_genome_identity(dataset: dict, gbff_path: Path, record) -> tuple[str, str]:
+    """Resolve a stable genome identity and describe its provenance."""
+    for key in ("genome_id", "assembly_accession", "accession"):
+        value = str(dataset.get(key, "")).strip()
+        if value:
+            return value, f"config.{key}"
+
+    for component in (gbff_path.name, *(parent.name for parent in gbff_path.parents)):
+        match = ASSEMBLY_ACCESSION_RE.search(component)
+        if match:
+            return match.group(1).upper(), "path_accession"
+
+    accessions = record.annotations.get("accessions", [])
+    if isinstance(accessions, str):
+        accessions = [accessions]
+    for value in accessions:
+        accession = str(value).strip()
+        if accession:
+            return accession, "genbank.annotations.accessions"
+
+    record_id = str(getattr(record, "id", "")).strip()
+    if record_id and record_id.lower() not in {"unknown", "<unknown id>"}:
+        return record_id, "genbank.record_id"
+
+    raise ValueError(
+        f"Cannot resolve genome identity for {gbff_path}; set genome_id or assembly_accession in the dataset config"
+    )
+
+
+def _assign_sequence_splits(
+    records: List[dict], rng: random.Random, val_frac: float, test_frac: float
+) -> None:
+    if len(records) < 3:
+        raise ValueError("Sequence-level splitting requires at least 3 records")
+    indices = list(range(len(records)))
+    rng.shuffle(indices)
+    n_test = min(max(1, int(len(records) * test_frac)), len(records) - 2)
+    n_val = min(max(1, int(len(records) * val_frac)), len(records) - n_test - 1)
+    test_idx = set(indices[:n_test])
+    val_idx = set(indices[n_test : n_test + n_val])
+    for idx, record in enumerate(records):
+        record["split"] = "test" if idx in test_idx else "val" if idx in val_idx else "train"
+
+
+def _assign_group_splits(
+    records: List[dict],
+    group_key: str,
+    rng: random.Random,
+    val_frac: float,
+    test_frac: float,
+) -> dict[str, set[str]]:
+    groups = sorted({str(record[group_key]) for record in records})
+    if len(groups) < 3:
+        raise ValueError(
+            f"Scientific splitting requires at least 3 distinct {group_key} groups; found {len(groups)}"
+        )
+    rng.shuffle(groups)
+    n_test = min(max(1, int(len(groups) * test_frac)), len(groups) - 2)
+    n_val = min(max(1, int(len(groups) * val_frac)), len(groups) - n_test - 1)
+    split_groups = {
+        "test": set(groups[:n_test]),
+        "val": set(groups[n_test : n_test + n_val]),
+        "train": set(groups[n_test + n_val :]),
+    }
+    for record in records:
+        group = str(record[group_key])
+        record["split"] = next(
+            split for split, assigned in split_groups.items() if group in assigned
+        )
+    return split_groups
 
 def extract_genus(rec) -> str:
     """Extract Genus from BioPython SeqRecord annotation taxonomy or organism."""
@@ -57,8 +147,20 @@ def main() -> None:
     ap.add_argument("--config", required=True, help="YAML config file path")
     ap.add_argument("--run-id", required=True, help="Run identifier")
     ap.add_argument("--run-dir", required=True, help="Run output directory")
-    ap.add_argument("--group-by", choices=["genome", "genus", "sequence"], default="genome",
+    ap.add_argument("--group-by", choices=["genome", "genus", "sequence"], default=None,
                     help="Split grouping criterion to avoid leakage.")
+    ap.add_argument(
+        "--allow-sequence-split",
+        action="store_true",
+        help="Explicitly allow a non-scientific sequence-level split when grouped splitting is impossible.",
+    )
+    ap.add_argument(
+        "--extra-dataset", action="append", default=[], help="NAME,GBFF[,MIN_LEN]"
+    )
+    ap.add_argument(
+        "--output-dir",
+        help="Prepared dataset directory (default: data/processed/global/<run-id>).",
+    )
     ap.add_argument("--seed", type=int, default=1337)
     ap.add_argument("--force", action="store_true", help="Force rebuild")
     args = ap.parse_args()
@@ -70,20 +172,34 @@ def main() -> None:
     block_size = int(cfg.get("block_size", 256))
     val_frac = float(cfg.get("val_frac", 0.1))
     test_frac = float(cfg.get("test_frac", 0.1))
+    if not (0.0 < val_frac < 1.0 and 0.0 < test_frac < 1.0):
+        raise SystemExit("[error] val_frac and test_frac must both be between 0 and 1")
+    if val_frac + test_frac >= 1.0:
+        raise SystemExit("[error] val_frac + test_frac must be less than 1")
     pack_mode = cfg.get("pack_mode", "multi")
     windows_per_seq = int(float(cfg.get("windows_per_seq", 2)))
     min_len = int(cfg.get("min_len", 90))
+    requested_group_by = args.group_by or str(cfg.get("split_group_by", "genome"))
+    if requested_group_by not in {"genome", "genus", "sequence"}:
+        raise SystemExit(
+            f"[error] split_group_by must be genome, genus, or sequence; got {requested_group_by!r}"
+        )
+    if requested_group_by == "sequence" and not args.allow_sequence_split:
+        raise SystemExit(
+            "[error] Sequence-level splitting is non-scientific and requires --allow-sequence-split"
+        )
 
     rng = random.Random(args.seed)
-    np.random.seed(args.seed)
-
-    datasets = cfg.get("datasets", [])
+    datasets = list(cfg.get("datasets", []))
+    datasets.extend(_parse_extra_dataset(spec) for spec in args.extra_dataset)
     if not datasets:
         raise SystemExit("[error] No datasets found in config.")
 
     # 1. Extraction phase
     print(f"[global-prep] Extracting sequences from {len(datasets)} datasets...")
     all_records: List[dict] = []
+    genome_sources: Dict[str, dict] = {}
+    announced_genomes: set[str] = set()
     
     for ds in datasets:
         name = ds["name"]
@@ -91,16 +207,29 @@ def main() -> None:
         if not gbff_path.exists():
             raise FileNotFoundError(f"GBFF not found: {gbff_path}")
         
-        # Determine genome_id
-        parts = gbff_path.stem.split("_")
-        if len(parts) >= 2:
-            genome_id = "_".join(parts[:2])
-        else:
-            genome_id = parts[0]
-            
-        print(f"  Processing {name} ({gbff_path.name}) with genome_id={genome_id}...")
-        
+        dataset_min_len = int(ds.get("min_len", min_len))
         for rec in SeqIO.parse(gbff_path, "genbank"):
+            try:
+                genome_id, identity_source = resolve_genome_identity(ds, gbff_path, rec)
+            except ValueError as exc:
+                raise SystemExit(f"[error] {exc}") from exc
+            resolved_path = str(gbff_path.resolve())
+            previous = genome_sources.get(genome_id)
+            if previous is not None and previous["gbff"] != resolved_path:
+                raise SystemExit(
+                    f"[error] Genome identity collision for {genome_id!r}: "
+                    f"{previous['gbff']} and {resolved_path}. Set distinct genome_id values explicitly."
+                )
+            genome_sources.setdefault(
+                genome_id,
+                {"gbff": resolved_path, "identity_source": identity_source},
+            )
+            if genome_id not in announced_genomes:
+                print(
+                    f"  Processing {name} ({gbff_path.name}) with "
+                    f"genome_id={genome_id} ({identity_source})..."
+                )
+                announced_genomes.add(genome_id)
             seq = str(rec.seq).upper()
             genus = extract_genus(rec)
             
@@ -113,10 +242,11 @@ def main() -> None:
                 if strand == -1:
                     cds_seq = reverse_complement(cds_seq)
                 
-                if len(cds_seq) >= min_len and set(cds_seq) <= set("ACGTN"):
+                if len(cds_seq) >= dataset_min_len and set(cds_seq) <= set("ACGTN"):
                     all_records.append({
                         "sequence": cds_seq,
                         "genome": genome_id,
+                        "genome_identity_source": identity_source,
                         "genus": genus,
                         "dataset": name,
                         "record_id": str(rec.id),
@@ -133,73 +263,32 @@ def main() -> None:
 
     total_seqs = len(all_records)
     print(f"[global-prep] Extracted {total_seqs} total CDS records.")
+    if not all_records:
+        raise SystemExit("[error] No eligible CDS records were extracted.")
 
     # 2. Splitting phase
-    if args.group_by == "sequence":
+    effective_group_by = requested_group_by
+    split_groups: dict[str, set[str]] | None = None
+    if requested_group_by == "sequence":
         print("[global-prep] Performing sequence-level random split...")
-        indices = list(range(total_seqs))
-        rng.shuffle(indices)
-        n_test = max(1, int(total_seqs * test_frac))
-        n_val = max(1, int(total_seqs * val_frac))
-        test_idx = set(indices[:n_test])
-        val_idx = set(indices[n_test:n_test + n_val])
-        
-        for idx, rec in enumerate(all_records):
-            if idx in val_idx:
-                rec["split"] = "val"
-            elif idx in test_idx:
-                rec["split"] = "test"
-            else:
-                rec["split"] = "train"
+        _assign_sequence_splits(all_records, rng, val_frac, test_frac)
     else:
-        group_key = args.group_by  # "genome" or "genus"
-        groups = [rec[group_key] for rec in all_records]
-        uniq_groups = list(sorted(set(groups)))
-        rng.shuffle(uniq_groups)
-        
-        n_groups = len(uniq_groups)
-        print(f"[global-prep] Found {n_groups} unique groups based on '{group_key}': {uniq_groups}")
-        
-        if n_groups < 3:
-            print(f"[global-prep] WARNING: Too few groups ({n_groups}) for group split. Falling back to sequence-level split.")
-            indices = list(range(total_seqs))
-            rng.shuffle(indices)
-            n_test = max(1, int(total_seqs * test_frac))
-            n_val = max(1, int(total_seqs * val_frac))
-            test_idx = set(indices[:n_test])
-            val_idx = set(indices[n_test:n_test + n_val])
-            for idx, rec in enumerate(all_records):
-                if idx in val_idx:
-                    rec["split"] = "val"
-                elif idx in test_idx:
-                    rec["split"] = "test"
-                else:
-                    rec["split"] = "train"
+        try:
+            split_groups = _assign_group_splits(
+                all_records, requested_group_by, rng, val_frac, test_frac
+            )
+        except ValueError as exc:
+            if not args.allow_sequence_split:
+                raise SystemExit(f"[error] {exc}") from exc
+            print(
+                f"[global-prep] NON-SCIENTIFIC: falling back from {requested_group_by} "
+                "to an explicitly allowed sequence-level split."
+            )
+            effective_group_by = "sequence"
+            _assign_sequence_splits(all_records, rng, val_frac, test_frac)
         else:
-            n_test = max(1, int(n_groups * test_frac))
-            n_val = max(1, int(n_groups * val_frac))
-            
-            if n_test + n_val >= n_groups:
-                n_val = max(0, n_groups - 1 - n_test)
-                if n_test + n_val >= n_groups:
-                    n_test = max(0, n_groups - 1)
-            
-            test_groups = set(uniq_groups[:n_test])
-            val_groups = set(uniq_groups[n_test:n_test + n_val])
-            train_groups = set(uniq_groups[n_test + n_val:])
-            
-            print(f"  Train groups: {train_groups}")
-            print(f"  Val groups: {val_groups}")
-            print(f"  Test groups: {test_groups}")
-            
-            for rec in all_records:
-                g = rec[group_key]
-                if g in train_groups:
-                    rec["split"] = "train"
-                elif g in val_groups:
-                    rec["split"] = "val"
-                else:
-                    rec["split"] = "test"
+            for split, groups in split_groups.items():
+                print(f"  {split.title()} groups: {groups}")
 
     # Count split stats
     counts = {"train": 0, "val": 0, "test": 0}
@@ -208,14 +297,27 @@ def main() -> None:
     print(f"[global-prep] Split counts: train={counts['train']}, val={counts['val']}, test={counts['test']}")
 
     # 3. Save combined metadata & DNA
-    out_dir = Path("data/processed/global") / args.run_id
+    out_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else Path("data/processed/global") / args.run_id
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
     
     meta_path = out_dir / "cds_meta.tsv"
     dna_path = out_dir / "cds_dna.txt"
     
     with open(meta_path, "w", newline="") as fm, open(dna_path, "w") as fd:
-        writer = csv.DictWriter(fm, fieldnames=["line_idx", "split"] + [k for k in all_records[0].keys() if k != "sequence"], delimiter="\t")
+        metadata_fields = [
+            key
+            for key in all_records[0]
+            if key not in {"sequence", "line_idx", "split"}
+        ]
+        writer = csv.DictWriter(
+            fm,
+            fieldnames=["line_idx", "split", *metadata_fields],
+            delimiter="\t",
+        )
         writer.writeheader()
         
         for idx, rec in enumerate(all_records):
@@ -257,7 +359,7 @@ def main() -> None:
         offsets = [0] * len(seqs)
         
         for _ in range(windows_goal):
-            random.shuffle(indices)
+            rng.shuffle(indices)
             buf: List[int] = []
             for idx in indices:
                 if len(buf) >= block_size:
@@ -307,7 +409,7 @@ def main() -> None:
                     x = (x + pad)[:block_size]
                     y = (y + pad)[:block_size]
                 else:
-                    i = random.randrange(0, len(arr) - block_size - 1)
+                    i = rng.randrange(0, len(arr) - block_size - 1)
                     x = arr[i : i + block_size]
                     y = arr[i + 1 : i + 1 + block_size]
                 Xs.append(x)
@@ -329,6 +431,7 @@ def main() -> None:
         return flat_X, lengths
 
     out_paths = {}
+    empty_windows: dict[str, int] = {}
     for name in ("train", "val", "test"):
         if pack_mode == "single":
             X, Y = pack_single(name, splits[name])
@@ -340,8 +443,10 @@ def main() -> None:
         out_npz = out_dir / f"{name}_bs{block_size}.npz"
         if pack_mode == "dynamic":
             np.savez_compressed(out_npz, X=X, lengths=Y)
+            empty_windows[name] = int(np.count_nonzero(Y == 0))
         else:
             np.savez_compressed(out_npz, X=X, Y=Y)
+            empty_windows[name] = int(np.count_nonzero((Y != 0).sum(axis=1) == 0))
         out_paths[name] = out_npz
         print(f"[global-prep] Packed split {name} to {out_npz} with shape {X.shape}")
 
@@ -358,17 +463,51 @@ def main() -> None:
             f.write(f"{k} {v}\n")
 
     # 6. Save combined manifest & pipeline_prepare.json
+    achieved_fractions = {
+        split: (counts[split] / total_seqs if total_seqs else 0.0)
+        for split in ("train", "val", "test")
+    }
+    group_counts = None
+    groups_by_split = None
+    if split_groups is not None and effective_group_by != "sequence":
+        groups_by_split = {
+            split: sorted(groups) for split, groups in split_groups.items()
+        }
+        group_counts = {
+            split: len(groups) for split, groups in split_groups.items()
+        }
+
     manifest = {
         "train": str(out_paths["train"]),
         "val": str(out_paths["val"]),
         "test": str(out_paths["test"]),
         "datasets": datasets,
-        "group_by": args.group_by,
+        "seed": args.seed,
+        "split_policy": {
+            "requested_group_by": requested_group_by,
+            "effective_group_by": effective_group_by,
+            "allow_sequence_split": bool(args.allow_sequence_split),
+            "scientific_valid": effective_group_by != "sequence",
+            "requested_fractions": {"val": val_frac, "test": test_frac},
+            "achieved_record_fractions": achieved_fractions,
+            "record_counts": counts,
+            "group_counts": group_counts,
+            "groups_by_split": groups_by_split,
+        },
+        "genome_sources": genome_sources,
+        "packing": {
+            "mode": pack_mode,
+            "block_size": block_size,
+            "windows_per_seq": windows_per_seq,
+            "seed": args.seed,
+        },
     }
     
     manifest_json_path = out_dir / "manifest.json"
-    manifest_json_path.write_text(json.dumps(manifest, indent=2))
-    (run_dir / "combined_manifest.json").write_text(json.dumps(manifest, indent=2))
+    manifest_json_path.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    (run_dir / "combined_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True)
+    )
     
     pipeline_prepare_json = {
         "train_npz": str(out_paths["train"]),
@@ -382,7 +521,6 @@ def main() -> None:
     result_path.write_text(json.dumps(pipeline_prepare_json, indent=2))
     
     # Save integrity check data
-    empty_windows = {"train": 0, "val": 0, "test": 0}
     integrity = {
         "train_npz": str(out_paths["train"]),
         "val_npz": str(out_paths["val"]),

--- a/scripts/pipeline_prepare.py
+++ b/scripts/pipeline_prepare.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Prepare datasets for the training pipeline.
+Legacy per-dataset preparation pipeline.
 
 Responsibilities:
   * read YAML config + optional CLI dataset overrides
@@ -10,7 +10,9 @@ Responsibilities:
   * concatenate NPZs across datasets into a combined manifest scoped to the run id
   * emit a small JSON summary in runs/<RUN_ID>/pipeline_prepare.json
 
-The shell wrapper calls this module instead of embedding large Python blocks.
+This route splits each configured dataset independently before stacking. It is
+retained only for reproducibility of historical runs. New scientific runs must use
+``scripts.build_global_manifest``.
 """
 
 from __future__ import annotations
@@ -253,9 +255,21 @@ def main() -> None:
     ap.add_argument("--run-dir", required=True)
     ap.add_argument("--force", action="store_true")
     ap.add_argument(
+        "--allow-legacy-per-dataset-split",
+        action="store_true",
+        help="Explicitly opt into the legacy, non-scientific per-dataset split route.",
+    )
+    ap.add_argument(
         "--extra-dataset", action="append", default=[], help="NAME,GBFF[,MIN_LEN]"
     )
     args = ap.parse_args()
+
+    if not args.allow_legacy_per_dataset_split:
+        raise SystemExit(
+            "[error] scripts.pipeline_prepare uses legacy per-dataset splitting. "
+            "Use scripts.build_global_manifest for scientific runs, or pass "
+            "--allow-legacy-per-dataset-split only to reproduce a historical run."
+        )
 
     config_path = Path(args.config)
     run_dir = Path(args.run_dir)

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -2,32 +2,197 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 import subprocess
 from pathlib import Path
+
 import numpy as np
-import pytest
 import yaml
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
 
-def create_mock_genome(path: Path, genome_id: str, organism: str):
+from scripts.build_global_manifest import resolve_genome_identity
+
+
+def create_mock_genome(
+    path: Path,
+    genome_id: str,
+    organism: str,
+    *,
+    record_id: str | None = None,
+    cds_count: int = 1,
+):
     # Generates a mock genome with a coding sequence
     seq = "A" * 60 + "ATG" + "GCT" * 40 + "TAA" + "C" * 80
-    record = SeqRecord(Seq(seq), id="test_rec", name="test", description="mock")
+    record = SeqRecord(
+        Seq(seq), id=record_id or f"record_{genome_id}", name="test", description="mock"
+    )
     record.annotations["molecule_type"] = "DNA"
     record.annotations["organism"] = organism
     cds_start = 60
     cds_end = 60 + 3 + (40 * 3) + 3
-    record.features.append(
-        SeqFeature(
-            FeatureLocation(cds_start, cds_end, strand=1),
-            type="CDS",
-            qualifiers={"locus_tag": [f"mock_{genome_id}"]},
+    for cds_idx in range(cds_count):
+        record.features.append(
+            SeqFeature(
+                FeatureLocation(cds_start, cds_end, strand=1),
+                type="CDS",
+                qualifiers={"locus_tag": [f"mock_{genome_id}_{cds_idx}"]},
+            )
         )
-    )
     SeqIO.write(record, path, "genbank")
+
+
+def _run_global_builder(
+    config_file: Path,
+    run_dir: Path,
+    output_dir: Path,
+    *extra_args: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "python",
+            "-m",
+            "scripts.build_global_manifest",
+            "--config",
+            str(config_file),
+            "--run-id",
+            run_dir.name,
+            "--run-dir",
+            str(run_dir),
+            "--output-dir",
+            str(output_dir),
+            "--group-by",
+            "genome",
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_config(path: Path, genomes: list[Path], **overrides) -> None:
+    config = {
+        "block_size": 128,
+        "windows_per_seq": 1,
+        "val_frac": 0.33,
+        "test_frac": 0.33,
+        "datasets": [
+            {"name": f"genome_{idx}", "gbff": str(genome), "min_len": 90}
+            for idx, genome in enumerate(genomes)
+        ],
+    }
+    config.update(overrides)
+    path.write_text(yaml.safe_dump(config))
+
+
+def test_resolve_genome_identity_prefers_explicit_config(tmp_path):
+    gbff = tmp_path / "genomic.gbff"
+    record = SeqRecord(Seq("ATG"), id="NC_000001.1")
+
+    genome_id, source = resolve_genome_identity(
+        {"genome_id": "GCF_123456789.1"}, gbff, record
+    )
+
+    assert genome_id == "GCF_123456789.1"
+    assert source == "config.genome_id"
+
+
+def test_resolve_genome_identity_uses_parent_accession_for_generic_filename(tmp_path):
+    gbff = tmp_path / "GCF_000005845.2_ASM584v2" / "genomic.gbff"
+    record = SeqRecord(Seq("ATG"), id="NC_000001.1")
+
+    genome_id, source = resolve_genome_identity({}, gbff, record)
+
+    assert genome_id == "GCF_000005845.2"
+    assert source == "path_accession"
+
+
+def test_group_split_fails_closed_with_too_few_groups(tmp_path):
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(2)]
+    for idx, genome in enumerate(genomes):
+        create_mock_genome(genome, str(idx), f"Genus{idx} species", cds_count=2)
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes)
+
+    result = _run_global_builder(
+        config, tmp_path / "run", tmp_path / "processed"
+    )
+
+    assert result.returncode != 0
+    assert "at least 3 distinct genome groups" in (result.stderr + result.stdout)
+
+
+def test_sequence_fallback_requires_explicit_flag_and_is_marked_non_scientific(tmp_path):
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(2)]
+    for idx, genome in enumerate(genomes):
+        create_mock_genome(genome, str(idx), f"Genus{idx} species", cds_count=2)
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes)
+    run_dir = tmp_path / "run"
+
+    result = _run_global_builder(
+        config,
+        run_dir,
+        tmp_path / "processed",
+        "--allow-sequence-split",
+    )
+
+    assert result.returncode == 0, result.stderr
+    manifest_path = Path(json.loads((run_dir / "pipeline_prepare.json").read_text())["combined_manifest"])
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["split_policy"]["effective_group_by"] == "sequence"
+    assert manifest["split_policy"]["scientific_valid"] is False
+
+
+def test_global_packing_is_deterministic_for_same_seed(tmp_path):
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(3)]
+    for idx, genome in enumerate(genomes):
+        create_mock_genome(genome, str(idx), f"Genus{idx} species")
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes)
+
+    outputs = []
+    for suffix in ("a", "b"):
+        run_dir = tmp_path / f"run_{suffix}"
+        output_dir = tmp_path / f"processed_{suffix}"
+        result = _run_global_builder(config, run_dir, output_dir, "--seed", "2027")
+        assert result.returncode == 0, result.stderr
+        prep = json.loads((run_dir / "pipeline_prepare.json").read_text())
+        outputs.append(prep)
+
+    for split_key in ("train_npz", "val_npz", "test_npz"):
+        with np.load(outputs[0][split_key]) as first, np.load(outputs[1][split_key]) as second:
+            assert first.files == second.files
+            for key in first.files:
+                assert np.array_equal(first[key], second[key])
+
+    first_manifest = json.loads(Path(outputs[0]["combined_manifest"]).read_text())
+    second_manifest = json.loads(Path(outputs[1]["combined_manifest"]).read_text())
+    for key in ("seed", "split_policy", "genome_sources", "packing"):
+        assert first_manifest[key] == second_manifest[key]
+
+
+def test_global_builder_rejects_identity_collisions_across_files(tmp_path):
+    genomes = []
+    for dirname in ("first", "second", "third"):
+        directory = tmp_path / dirname
+        directory.mkdir()
+        genome = directory / "genomic.gbff"
+        create_mock_genome(
+            genome, dirname, f"Genus{dirname} species", record_id="NC_DUPLICATE.1"
+        )
+        genomes.append(genome)
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes)
+
+    result = _run_global_builder(
+        config, tmp_path / "run", tmp_path / "processed"
+    )
+
+    assert result.returncode != 0
+    assert "Genome identity collision" in (result.stderr + result.stdout)
 
 def test_global_split_and_baselines_end_to_end(tmp_path):
     # Create 3 distinct genomes/gbff files
@@ -40,40 +205,14 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
     create_mock_genome(gb3, "000006945", "Salmonella enterica")
 
     # Set up config with these 3 datasets
-    config_data = {
-        "block_size": 128,
-        "windows_per_seq": 1,
-        "val_frac": 0.33,
-        "test_frac": 0.33,
-        "datasets": [
-            {"name": "ecoli", "gbff": str(gb1), "min_len": 90},
-            {"name": "kleb", "gbff": str(gb2), "min_len": 90},
-            {"name": "salm", "gbff": str(gb3), "min_len": 90},
-        ]
-    }
-    
     config_file = tmp_path / "test_config.yaml"
-    config_file.write_text(yaml.dump(config_data))
+    _write_config(config_file, [gb1, gb2, gb3])
     
     run_dir = tmp_path / "runs" / "test_global_run"
     run_dir.mkdir(parents=True, exist_ok=True)
     
-    # 1. Run build_global_manifest script
-    cmd = [
-        "python",
-        "-m",
-        "scripts.build_global_manifest",
-        "--config",
-        str(config_file),
-        "--run-id",
-        "test_global_run",
-        "--run-dir",
-        str(run_dir),
-        "--group-by",
-        "genome",
-    ]
-    
-    res = subprocess.run(cmd, capture_output=True, text=True)
+    output_dir = tmp_path / "processed" / "test_global_run"
+    res = _run_global_builder(config_file, run_dir, output_dir)
     assert res.returncode == 0, f"Global split failed: {res.stderr}\nStdout: {res.stdout}"
     
     # 2. Verify splits and outputs
@@ -90,7 +229,7 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
     assert test_npz.exists()
     
     # Verify metadata and ensure zero genomic leakage (each split must have mutually exclusive genomes)
-    meta_tsv = Path("data/processed/global/test_global_run/cds_meta.tsv")
+    meta_tsv = output_dir / "cds_meta.tsv"
     assert meta_tsv.exists()
     
     # Read splits and genomes
@@ -157,3 +296,57 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
         
     print("Synonymous controls test completed successfully.")
 
+
+def test_main_dry_run_uses_global_builder(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "trainer": "codon_lm",
+                "datasets": [
+                    {"name": "placeholder", "gbff": "does-not-need-to-exist.gbff"}
+                ],
+            }
+        )
+    )
+
+    result = subprocess.run(
+        ["bash", str(repo_root / "main.sh"), "--config", str(config), "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(repo_root),
+            "RUN_ID": "test-global-dry-run",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "python -m scripts.build_global_manifest" in result.stdout
+    assert "python -m scripts.pipeline_prepare" not in result.stdout
+
+
+def test_legacy_per_dataset_pipeline_requires_explicit_opt_in(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"datasets": []}))
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "scripts.pipeline_prepare",
+            "--config",
+            str(config),
+            "--run-id",
+            "legacy",
+            "--run-dir",
+            str(tmp_path / "run"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "--allow-legacy-per-dataset-split" in (result.stderr + result.stdout)

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -299,6 +299,22 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
 
 def test_main_dry_run_uses_global_builder(tmp_path):
     repo_root = Path(__file__).resolve().parents[1]
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_conda = fake_bin / "conda"
+    fake_conda.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1 $2\" = \"env list\" ]; then\n"
+        "  printf '# conda environments:\\nbase /opt/conda\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ \"$1 $2\" = \"shell.bash hook\" ]; then\n"
+        "  printf 'export PATH=/missing-python\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n"
+    )
+    fake_conda.chmod(0o755)
     config = tmp_path / "config.yaml"
     config.write_text(
         yaml.safe_dump(
@@ -318,6 +334,7 @@ def test_main_dry_run_uses_global_builder(tmp_path):
         cwd=tmp_path,
         env={
             **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "PYTHONPATH": str(repo_root),
             "RUN_ID": "test-global-dry-run",
         },


### PR DESCRIPTION
Closes #79

## Summary

- make `main.sh` use the global grouped preparation route by default
- fail closed when genome/genus splitting has fewer than three groups
- require explicit flags for sequence-level fallback and the legacy per-dataset stacker
- resolve genome identity from config, assembly/path accession, or GenBank metadata
- reject cross-file identity collisions
- use one seeded RNG for splitting and packing
- record split policy, achieved fractions, group assignments, accession provenance, and packing settings
- isolate integration-test artifacts under temporary directories

Sequence-level fallback remains available for development but is explicitly recorded as `scientific_valid: false`.

## Validation

- `pytest -q`: 179 passed, 1 skipped, 1 xpassed
- focused data-preparation tests: 11 passed
- `ruff check scripts/build_global_manifest.py scripts/pipeline_prepare.py tests/test_global_split_and_baselines.py`
- `bash -n main.sh`
- `git diff --check`