### PR TITLE
Strengthen core CI correctness and coverage gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    env:
-      COVERAGE_FILE: ${{ runner.temp }}/.coverage
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -54,6 +51,8 @@ jobs:
           python -m pip install -r requirements.txt
 
       - name: Run core tests with coverage
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/.coverage
         run: >-
           pytest -q
           -m "not slow and not external and not mps"
@@ -63,6 +62,8 @@ jobs:
           --cov-report=xml:${{ runner.temp }}/coverage.xml
 
       - name: Publish coverage summary
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/.coverage
         run: |
           {
             echo '### Python 3.11 coverage'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,33 @@ on:
       - "codex/**"
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Ruff
+        run: python -m pip install ruff
+
+      - name: Check for fatal Python errors
+        run: ruff check . --select E9,F63,F7,F82
+
   pytest:
+    name: core-tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    env:
+      COVERAGE_FILE: ${{ runner.temp }}/.coverage
 
     steps:
       - name: Check out repository
@@ -29,5 +53,32 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
-      - name: Run tests
-        run: pytest -q
+      - name: Run core tests with coverage
+        run: >-
+          pytest -q
+          -m "not slow and not external and not mps"
+          --cov=src
+          --cov=scripts
+          --cov-report=term
+          --cov-report=xml:${{ runner.temp }}/coverage.xml
+
+      - name: Publish coverage summary
+        run: |
+          {
+            echo '### Python 3.11 coverage'
+            echo '```text'
+            python -m coverage report
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-python-3.11
+          path: ${{ runner.temp }}/coverage.xml
+
+      - name: Verify tests left the checkout clean
+        if: always()
+        run: |
+          git status --short
+          test -z "$(git status --porcelain)"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ python -m scripts.query_model <RUN_ID> --mode next --dna ATGAAACCC --topk 5
 streamlit run scripts/web_dashboard.py                # interactive dashboard
 ```
 
+## Development Checks
+
+Run the same core checks required by GitHub Actions:
+
+```bash
+ruff check . --select E9,F63,F7,F82
+pytest -q -m "not slow and not external and not mps" --cov=src --cov=scripts --cov-report=term
+git status --short
+```
+
+The required CPU suite runs on the supported Python 3.11 environment. Tests marked `slow`,
+`external`, or `mps` are opt-in and must not be used to claim CPU CI coverage.
+MPS performance benchmarks must be run manually on Apple Silicon using the
+documented benchmark commands.
+
 ## Downstream Evaluation
 
 ```bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 pythonpath = .
 testpaths = tests
+markers =
+    slow: deterministic tests excluded from the required core CI job due to runtime
+    external: tests requiring network access, external tools, or non-repository data
+    mps: tests requiring Apple Metal Performance Shaders hardware

--- a/scripts/benchmark_hybrid_critic.py
+++ b/scripts/benchmark_hybrid_critic.py
@@ -9,6 +9,7 @@ import time
 import os
 import sys
 import torch
+from torch import nn
 import numpy as np
 import pandas as pd
 from pathlib import Path

--- a/scripts/query_model.py
+++ b/scripts/query_model.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch

--- a/scripts/web_dashboard.py
+++ b/scripts/web_dashboard.py
@@ -2,6 +2,7 @@ import streamlit as st
 import os
 import sys
 import pandas as pd
+import torch
 from pathlib import Path
 
 # Add project root to sys.path to resolve 'src' when running directly with streamlit
@@ -939,7 +940,6 @@ def main():
                         opt_normalize = st.checkbox("Normalize Gradients", value=True)
 
                         if st.button("Optimize Sequence"):
-                            import torch
                             from src.protein_lm.ebm import ProteinLatentEBM
                             from src.protein_lm.sampler import latent_langevin_sample
                             from scripts.generative_design_loop import load_critic, score_with_critic

--- a/src/eval/inference_playground.py
+++ b/src/eval/inference_playground.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Optional, Tuple
 import torch
 
 from src.codonlm.model_tiny_gpt import TinyGPT
@@ -553,4 +553,3 @@ def get_attention_weights(
         # Restore SDPA settings
         for blk, val in zip(model.blocks, original_sdpa):
             blk.attn.use_sdpa = val
-


### PR DESCRIPTION
## Summary
- add separate fatal-error lint and stable core-test GitHub Actions checks
- run the supported Python 3.11 CPU suite with coverage summaries and uploaded XML
- register slow, external, and MPS markers and fail CI when tests dirty the checkout
- fix four undefined-name errors exposed by the new lint gate
- document the local CI-equivalent commands and MPS exclusion

## Validation
- `ruff check . --select E9,F63,F7,F82`
- `pytest -q -m "not slow and not external and not mps"`
- exact coverage-enabled CI command: 182 passed, 1 skipped, 1 xpassed; 22% baseline coverage
- workflow YAML parsed successfully

Closes #91