### PR TITLE
Add leakage-controlled CodonLM revalidation track

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -77,6 +77,10 @@ This file tracks all major tracks for the project. Each track has its own detail
 *Link: [./tracks/optimized_training_validation_20260717/](./tracks/optimized_training_validation_20260717/)*
 *Summary: Validate the measured MPS throughput winner with paired equal-token training runs, then compare 128-, 256-, and 512-token contexts using lossless chunking and token-budgeted updates before promoting new production defaults.*
 
+- [ ] **Track: Leakage-Controlled CodonLM Revalidation**
+*Link: [./tracks/leakage_controlled_revalidation_20260719/](./tracks/leakage_controlled_revalidation_20260719/)*
+*Summary: Correct tokenization, packing, leakage gates, trainer semantics, and evaluation provenance; freeze versioned genome/genus-held-out datasets; then retrain from scratch once and publish corrected intrinsic and downstream results separately from legacy Stage 2.6.*
+
 - [x] **Track: CodonLM Trainer Refactor**
 *Link: [./tracks/codonlm_trainer_refactor_20260622/](./tracks/codonlm_trainer_refactor_20260622/)*
 *Summary: Completed. Refactored the monolithic 1,200-line `train_codon_lm.py` script into a modular `src/codonlm/training/` subpackage (separating config, checkpoints, objectives, and training loop) while preserving CLI backwards compatibility and mid-epoch resume semantics. Updated all import locations across scripts and tests.*

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -1,0 +1,91 @@
+# Leakage-Controlled CodonLM Revalidation Plan
+
+## Status
+Planned. Full retraining is blocked until Phase 3 is complete.
+
+## Phase 1: Governance and CI
+- [x] Relabel legacy results and unsupported claims (#87).
+- [x] Make global grouped splitting the mandatory scientific default (#79).
+- [x] Require core CPU tests, fatal lint, coverage artifacts, and clean-checkout
+  verification in GitHub Actions (#91).
+- [ ] Keep this plan and issue #92 synchronized when a gate changes status.
+
+## Phase 2: Correct the Dataset Representation
+- [ ] Split CDS records at ambiguous codons without creating false adjacency; retain
+  source IDs and oriented codon coordinates; report fragment statistics (#80).
+- [ ] Replace suffix truncation with lossless chunks and expose record, chunk,
+  coordinate, boundary, and continuation metadata (#78).
+- [ ] Define and test a versioned dataset manifest schema covering sources, splits,
+  fragments, chunks, packing, vocabulary, seeds, and artifact hashes.
+
+Exit gate: fixtures prove that no transition crosses ambiguity, no source transition
+is lost or duplicated, and every derived fragment/chunk retains its source split.
+
+## Phase 3: Enforce Leakage and Training Correctness
+- [ ] Fail preparation on cross-split exact duplicates and disallowed protein
+  homology; record offending IDs, thresholds, commands, and tool versions (#77).
+- [ ] Abort and clear an accumulation group after any non-finite loss, preserving
+  correct optimizer/scheduler/resume counters (#83).
+- [ ] Apply configured attention dropout consistently in SDPA and manual paths (#81).
+- [ ] Resolve new-run vocabulary exclusively from the tokenizer artifact and fail on
+  dataset, config, or checkpoint mismatch (#84).
+- [ ] Run CPU integration tests and MPS smoke train/save/resume tests on the corrected
+  representation.
+
+Exit gate: all blocking data and trainer PRs are merged, CI is green, and an MPS
+preflight completes without OOM, non-finite updates, provenance gaps, or leakage.
+
+## Phase 4: Freeze Corrected Datasets
+- [ ] Pin the source snapshot and create immutable genome-held-out and genus-held-out
+  source-record manifests using seeds `1337` and `2027` where randomness applies.
+- [ ] Generate corrected fragment, chunk, packed, and vocabulary artifacts from the
+  same source inventory.
+- [ ] Run exact-duplicate and protein-homology gates before training.
+- [ ] Publish manifest hashes, group/record/fragment/chunk/token counts, achieved
+  split fractions, ambiguity statistics, and audit reports.
+- [ ] Tag the dataset schema and artifact generation as the pipeline freeze.
+
+Exit gate: a clean checkout can reproduce byte-identical manifests and all blocking
+audits pass. Any later semantic change creates a new dataset version.
+
+## Phase 5: Freeze Evaluation Instruments
+- [ ] Make perplexity baselines storage-format independent and vocabulary safe (#82).
+- [ ] Remove unsafe embedding fallbacks and record causal extraction provenance (#86).
+- [ ] Add gene/genome-grouped DNA-shape folds plus one-hot, random-model, 5-mer, and
+  7-mer controls (#88).
+- [ ] Add protein-cluster-held-out AMR splits, class reporting, stratified bootstrap,
+  and output isolation (#89).
+- [ ] Validate every evaluator on fixtures derived from the frozen manifest schema.
+
+Exit gate: all evaluators consume explicit frozen artifacts, reject incompatible
+inputs, preserve grouping, and emit machine-readable provenance.
+
+## Phase 6: Train Corrected Models
+- [ ] Select the MPS runtime policy through the equal-token quality gate in the
+  optimized training validation track; record the selected policy without changing
+  architecture or objectives.
+- [ ] Train genome-held-out models from random initialization at seeds `1337` and
+  `2027` with matched non-PAD token exposure.
+- [ ] Run a separately labeled genus-held-out training protocol.
+- [ ] Preserve configs, source/dataset hashes, checkpoints, logs, optimizer counters,
+  consumed-token counters, wall time, peak memory, and failure metrics.
+
+Exit gate: two genome-held-out seeds and the declared genus-held-out run finish with
+passing manifests, no invalid updates, and complete checkpoint/resume provenance.
+
+## Phase 7: Evaluate and Publish
+- [ ] Produce the uniform/unigram/bigram/trigram/CodonLM intrinsic table with loss,
+  perplexity, bits/codon, token count, and improvement over the best simple baseline.
+- [ ] Extract corrected causal embeddings and rerun EC, essentiality, AMR, and
+  DNA-shape evaluations under their controlled splits and shared controls.
+- [ ] Run nucleotide/protein nearest-neighbor and training-match coverage audits for
+  generated sequences before reporting memorization or novelty.
+- [ ] Publish a versioned report with exact commands, hashes, per-seed and aggregate
+  results, confidence intervals, limitations, and failed gates.
+- [ ] Update README and benchmark documents from the versioned report while retaining
+  a clearly separated legacy-versus-corrected table.
+
+## Deferred Follow-Ups
+- [ ] Separate raw, CDS-constrained, and guided generation protocols (#85).
+- [ ] Promote batch-aware memmap conversion only after an MPS benefit is measured
+  without a memory regression (#90).

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -1,0 +1,120 @@
+# Specification: Leakage-Controlled CodonLM Revalidation
+
+## Status
+Planned.
+
+## Objective
+Produce the first CodonLM result set trained and evaluated entirely under
+leakage-controlled, provenance-complete protocols. Legacy Stage 2.6 artifacts remain
+available for historical and engineering comparisons, but they cannot establish
+corrected held-out performance.
+
+This track is the execution plan for GitHub issue
+[#92](https://github.com/AvishaiBarnoy/genomics-lm/issues/92).
+
+## Why Retraining Is Deferred
+Issues in tokenization, fragmentation, long-gene chunking, packing, leakage audits,
+gradient accumulation, attention dropout, and vocabulary resolution all change the
+training stream or training semantics. Retraining after each fix would spend compute
+on artifacts that are immediately superseded. Each engineering PR therefore uses
+unit fixtures and short smoke runs; full training begins only after the pipeline
+freeze gate passes.
+
+## Artifact Generations
+
+### Legacy generation
+- Existing Stage 2.6 datasets, checkpoints, embeddings, probes, and benchmark tables.
+- May be used for historical comparison, debugging, and explicitly labeled transfer
+  experiments.
+- Must remain labeled `legacy protocol` and must not be promoted as corrected
+  genome- or genus-held-out evidence.
+
+### Corrected generation
+- Source records are globally split before fragmentation, chunking, or packing.
+- Dataset manifests capture source checksums, accession identities, split groups,
+  tokenizer and packing policies, seeds, vocabulary hash, software versions, and
+  audit results.
+- Models are trained from random initialization after the pipeline freeze.
+- Derived embeddings and probe results identify their dataset, checkpoint,
+  vocabulary, code SHA, and evaluation split artifacts.
+
+## Blocking Engineering Gates
+- [x] #79: mandatory global genome-aware splitting.
+- [x] #87: legacy scientific claims relabeled.
+- [x] #91: required core CI, fatal lint, coverage, and checkout-cleanliness checks.
+- [ ] #80: ambiguous-codon boundary preservation and fragment provenance.
+- [ ] #78: lossless long-gene chunking and explicit packing boundaries.
+- [ ] #77: preventive exact-duplicate and protein-homology leakage audits.
+- [ ] #83: abort and clear non-finite gradient-accumulation groups.
+- [ ] #81: correct attention-dropout behavior in all attention paths.
+- [ ] #84: tokenizer artifact as the vocabulary source of truth.
+- [ ] #86: causal embedding extraction provenance and unsafe-fallback removal.
+- [ ] #82: format-aware, vocabulary-safe perplexity baselines.
+- [ ] #88: grouped DNA-shape controls and local-sequence baselines.
+- [ ] #89: protein-cluster-held-out AMR evaluation and robust class reporting.
+
+Issues #85 and #90 are useful follow-ups but do not block the first corrected
+intrinsic and downstream result set.
+
+## Pipeline Freeze Gate
+Full retraining is prohibited until all blocking engineering issues are merged and
+the following artifacts pass a reproducible preflight command:
+
+- immutable source inventory and checksums;
+- genome-held-out and genus-held-out split assignments;
+- fragment and chunk provenance with source-record membership preserved;
+- tokenizer vocabulary and policy hashes;
+- packing configuration and deterministic seed;
+- exact-duplicate and protein-cluster leakage reports with zero blocking violations;
+- dataset token/count summaries and achieved split fractions;
+- successful CPU tests plus MPS smoke training, checkpoint, and resume tests.
+
+Any change to a frozen source, tokenizer, split, audit threshold, vocabulary, or
+packing policy creates a new dataset version and invalidates dependent training runs.
+
+## Retraining Protocol
+- Train corrected models from random initialization; do not initialize from a model
+  exposed to legacy holdout records.
+- Run genome-held-out training for at least seeds `1337` and `2027`.
+- Keep architecture, objectives, tokenizer, total non-PAD token exposure, and
+  evaluation commands fixed across seeds.
+- Report genus-held-out results separately; do not pool them with genome holdouts.
+- Use the MPS runtime configuration only after its equal-token quality gate passes.
+- Preserve configs, manifests, logs, checkpoints, consumed-token counters, wall time,
+  and peak-memory metrics for every run.
+
+## Corrected Evaluation Protocol
+1. Compare uniform, unigram, bigram, trigram, and CodonLM loss, perplexity, and
+   bits/codon on identical token streams.
+2. Extract embeddings causally from corrected checkpoints with complete provenance.
+3. Rerun EC, essentiality, AMR, and DNA-shape evaluations with controlled group or
+   protein-homology holdouts and shared folds for all controls.
+4. Report balanced accuracy, macro-F1, macro-AUPRC, AUROC where defined, and
+   class-aware confidence intervals.
+5. Audit generated sequences against training nucleotide and protein records before
+   making novelty or memorization claims.
+
+## Promotion Criteria
+Corrected results may replace legacy headlines only when:
+
+- every blocking issue and pipeline-freeze check passes;
+- two genome-held-out seeds complete without invalid updates or audit violations;
+- simple baselines and CodonLM use the same controlled test stream;
+- downstream results use corrected checkpoints and embeddings;
+- a versioned report contains commands, hashes, per-seed results, aggregate results,
+  limitations, and failed gates;
+- legacy and corrected protocols remain visibly separated.
+
+## Relationship to Other Tracks
+The [optimized training validation track](../optimized_training_validation_20260717/)
+may establish runtime and equal-token engineering behavior using legacy artifacts.
+Those results do not satisfy this track's scientific promotion criteria. Context
+ablation intended for corrected claims must use the frozen corrected datasets and
+the evaluation protocol defined here.
+
+## Non-Goals
+- Retrofitting corrected claims onto legacy checkpoints or embeddings.
+- Changing model size or adding objectives during the controlled revalidation.
+- Treating smoke runs, validation subsets, or CPU execution as final MPS evidence.
+- Requiring generation-protocol or memmap optimizations (#85 and #90) before the
+  first corrected intrinsic and probe report.


### PR DESCRIPTION
## Summary
- define legacy and corrected artifact generations for Stage 2.6-successor validation
- order the open data, trainer, audit, and evaluator issues behind explicit phase gates
- prohibit full retraining until the corrected pipeline and datasets are frozen
- define from-scratch retraining, evaluation, provenance, and result-promotion criteria
- relate the existing MPS optimization track to the corrected scientific protocol

## Validation
- `git diff --check`
- `pytest -q tests/test_scientific_claims_docs.py` (3 passed)

Tracks #92