### PR TITLE
Preserve ambiguous codon boundaries during preparation

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -11,7 +11,7 @@ Planned. Full retraining is blocked until Phase 3 is complete.
 - [ ] Keep this plan and issue #92 synchronized when a gate changes status.
 
 ## Phase 2: Correct the Dataset Representation
-- [ ] Split CDS records at ambiguous codons without creating false adjacency; retain
+- [x] Split CDS records at ambiguous codons without creating false adjacency; retain
   source IDs and oriented codon coordinates; report fragment statistics (#80).
 - [ ] Replace suffix truncation with lossless chunks and expose record, chunk,
   coordinate, boundary, and continuation metadata (#78).

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -42,7 +42,7 @@ freeze gate passes.
 - [x] #79: mandatory global genome-aware splitting.
 - [x] #87: legacy scientific claims relabeled.
 - [x] #91: required core CI, fatal lint, coverage, and checkout-cleanliness checks.
-- [ ] #80: ambiguous-codon boundary preservation and fragment provenance.
+- [x] #80: ambiguous-codon boundary preservation and fragment provenance.
 - [ ] #78: lossless long-gene chunking and explicit packing boundaries.
 - [ ] #77: preventive exact-duplicate and protein-homology leakage audits.
 - [ ] #83: abort and clear non-finite gradient-accumulation groups.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -51,6 +51,7 @@ You can configure training runs using YAML files under `configs/`. Complete temp
     *   `tie_embeddings`: Share weights between token and output embeddings.
 *   **Data Packing & Masking:**
     *   `pack_mode`: Dataset format, either `single` (one CDS per window) or `multi` (sequences packed).
+    *   `min_fragment_codons`: Minimum retained length for an unambiguous CDS fragment (default `10`). Global preparation splits each source CDS at any full codon containing an IUPAC ambiguous base, assigns every retained fragment the source record's existing split, and records oriented CDS coordinates plus retained/discarded counts in `cds_fragments.tsv` and `manifest.json`. Trailing partial codons are excluded and counted. The single-sequence `to_ids()` API rejects ambiguity instead of deleting it.
     *   `sep_mask_enabled`: Enable attention masking across `<SEP>` boundaries in packed mode.
 *   **Transfer Learning / Resumption / Freezing:**
     *   `transfer_from`: Path to pre-trained weights `.pt` file to initialize model parameters while discarding optimizer state.

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -29,7 +29,12 @@ import numpy as np
 import yaml
 from Bio import SeqIO
 
-from src.codonlm.codon_tokenize import to_ids, stoi, itos
+from src.codonlm.codon_tokenize import (
+    IUPAC_DNA_BASES,
+    itos,
+    stoi,
+    tokenize_cds_fragments,
+)
 from src.codonlm.extract_cds_from_genbank import reverse_complement, _first_qualifier, _join_qualifier
 
 
@@ -179,6 +184,9 @@ def main() -> None:
     pack_mode = cfg.get("pack_mode", "multi")
     windows_per_seq = int(float(cfg.get("windows_per_seq", 2)))
     min_len = int(cfg.get("min_len", 90))
+    min_fragment_codons = int(cfg.get("min_fragment_codons", 10))
+    if min_fragment_codons < 1:
+        raise SystemExit("[error] min_fragment_codons must be at least 1")
     requested_group_by = args.group_by or str(cfg.get("split_group_by", "genome"))
     if requested_group_by not in {"genome", "genus", "sequence"}:
         raise SystemExit(
@@ -233,7 +241,7 @@ def main() -> None:
             seq = str(rec.seq).upper()
             genus = extract_genus(rec)
             
-            for feat in rec.features:
+            for feature_index, feat in enumerate(rec.features):
                 if feat.type != "CDS":
                     continue
                 s, e = int(feat.location.start), int(feat.location.end)
@@ -242,9 +250,13 @@ def main() -> None:
                 if strand == -1:
                     cds_seq = reverse_complement(cds_seq)
                 
-                if len(cds_seq) >= dataset_min_len and set(cds_seq) <= set("ACGTN"):
+                if len(cds_seq) >= dataset_min_len and set(cds_seq) <= IUPAC_DNA_BASES:
+                    source_id = (
+                        f"{genome_id}:{rec.id}:cds:{s}-{e}:{strand}:{feature_index}"
+                    )
                     all_records.append({
                         "sequence": cds_seq,
+                        "source_id": source_id,
                         "genome": genome_id,
                         "genome_identity_source": identity_source,
                         "genus": genus,
@@ -330,10 +342,53 @@ def main() -> None:
 
     # 4. Tokenization phase
     print("[global-prep] Tokenizing sequences...")
+    fragment_records: List[dict] = []
     token_ids_list: List[List[int]] = []
-    for rec in all_records:
-        tids = to_ids(rec["sequence"])
-        token_ids_list.append(tids)
+    tokenization_counts = {
+        "ambiguous_codons": 0,
+        "source_records_with_ambiguity": 0,
+        "retained_fragments": 0,
+        "discarded_fragments": 0,
+        "partial_trailing_bases": 0,
+    }
+    per_split_counts = {
+        split: {key: 0 for key in tokenization_counts}
+        for split in ("train", "val", "test")
+    }
+    for source_line_idx, rec in enumerate(all_records):
+        result = tokenize_cds_fragments(
+            rec["sequence"],
+            source_id=rec["source_id"],
+            min_fragment_codons=min_fragment_codons,
+        )
+        split_counts = per_split_counts[rec["split"]]
+        tokenization_counts["ambiguous_codons"] += result.ambiguous_codons
+        split_counts["ambiguous_codons"] += result.ambiguous_codons
+        tokenization_counts["discarded_fragments"] += result.discarded_fragments
+        split_counts["discarded_fragments"] += result.discarded_fragments
+        tokenization_counts["partial_trailing_bases"] += result.partial_trailing_bases
+        split_counts["partial_trailing_bases"] += result.partial_trailing_bases
+        if result.source_had_ambiguity:
+            tokenization_counts["source_records_with_ambiguity"] += 1
+            split_counts["source_records_with_ambiguity"] += 1
+        for fragment in result.fragments:
+            token_ids_list.append(fragment.ids)
+            tokenization_counts["retained_fragments"] += 1
+            split_counts["retained_fragments"] += 1
+            fragment_records.append(
+                {
+                    "fragment_line_idx": len(fragment_records),
+                    "source_line_idx": source_line_idx,
+                    "source_id": rec["source_id"],
+                    "split": rec["split"],
+                    "fragment_index": fragment.fragment_index,
+                    "codon_start": fragment.codon_start,
+                    "codon_end": fragment.codon_end,
+                    "base_start": fragment.base_start,
+                    "base_end": fragment.base_end,
+                    "codon_count": fragment.codon_end - fragment.codon_start,
+                }
+            )
 
     # Save global codon ids
     ids_path = out_dir / "codon_ids.txt"
@@ -341,10 +396,28 @@ def main() -> None:
         for tids in token_ids_list:
             f.write(" ".join(str(i) for i in tids) + "\n")
 
+    fragments_path = out_dir / "cds_fragments.tsv"
+    fragment_fields = [
+        "fragment_line_idx",
+        "source_line_idx",
+        "source_id",
+        "split",
+        "fragment_index",
+        "codon_start",
+        "codon_end",
+        "base_start",
+        "base_end",
+        "codon_count",
+    ]
+    with open(fragments_path, "w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fragment_fields, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(fragment_records)
+
     # 5. Packing phase
     splits = {"train": [], "val": [], "test": []}
-    for idx, rec in enumerate(all_records):
-        splits[rec["split"]].append(token_ids_list[idx])
+    for fragment, token_ids in zip(fragment_records, token_ids_list):
+        splits[fragment["split"]].append(token_ids)
 
     def pack_multi(name: str, subset: List[List[int]]) -> Tuple[np.ndarray, np.ndarray]:
         SEP_ID = 3
@@ -495,6 +568,15 @@ def main() -> None:
             "groups_by_split": groups_by_split,
         },
         "genome_sources": genome_sources,
+        "tokenization": {
+            "fragment_metadata": str(fragments_path),
+            "ambiguous_codon_policy": {
+                "name": "split",
+                "min_fragment_codons": min_fragment_codons,
+                **tokenization_counts,
+                "per_split": per_split_counts,
+            },
+        },
         "packing": {
             "mode": pack_mode,
             "block_size": block_size,

--- a/src/codonlm/codon_tokenize.py
+++ b/src/codonlm/codon_tokenize.py
@@ -23,8 +23,11 @@ Outputs:
 
 from pathlib import Path
 import argparse
+import csv
+from dataclasses import dataclass
 
 CODONS = [a + b + c for a in "ACGT" for b in "ACGT" for c in "ACGT"]
+IUPAC_DNA_BASES = frozenset("ACGTRYSWKMBDHVN")
 STOP_CODONS = {"TAA", "TAG", "TGA"}
 SPECIALS = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>"]
 VOCAB = SPECIALS + CODONS
@@ -40,31 +43,147 @@ ALIASES = {
 for alias, canonical in ALIASES.items():
     stoi[alias] = stoi[canonical]
 
-def to_ids(dna: str, termination: str = "eos") -> list[int]:
-    """Converts a DNA sequence string into a list of token IDs, wrapping it in BOS and EOS/SEP tokens."""
-    dna = dna.strip().upper().replace("U", "T")
-    if len(dna) < 3:
-        return []
-    # trim to a multiple of 3, left-aligned (GenBank CDS already in-frame)
-    L = (len(dna) // 3) * 3
-    ids = [stoi["<BOS_CDS>"]]
-    for i in range(0, L, 3):
-        codon = dna[i : i + 3]
-        idx = stoi.get(codon)
-        if idx is None:
-            # Skip unknown codons (should not happen for ACGT)
-            continue
-        ids.append(idx)
-    # Ensure we terminate correctly even if sequence lacked a canonical stop
-    if len(ids) == 1:
-        return []
 
+class AmbiguousCodonError(ValueError):
+    """Raised when a single-sequence tokenization would erase an ambiguous codon."""
+
+
+@dataclass(frozen=True)
+class TokenizedCDSFragment:
+    """A retained contiguous run of unambiguous codons in oriented CDS coordinates."""
+
+    ids: list[int]
+    source_id: str | None
+    fragment_index: int
+    codon_start: int
+    codon_end: int
+    base_start: int
+    base_end: int
+
+
+@dataclass(frozen=True)
+class CDSTokenizationResult:
+    """Fragments and audit counts produced by ambiguity-aware CDS tokenization."""
+
+    fragments: list[TokenizedCDSFragment]
+    ambiguous_codons: int
+    discarded_fragments: int
+    partial_trailing_bases: int
+
+    @property
+    def source_had_ambiguity(self) -> bool:
+        return self.ambiguous_codons > 0
+
+
+def _normalize_dna(dna: str) -> str:
+    return dna.strip().upper().replace("U", "T")
+
+
+def _terminated_ids(codon_ids: list[int], termination: str) -> list[int]:
+    ids = [stoi["<BOS_CDS>"], *codon_ids]
     if termination == "eos":
         ids.append(stoi["<EOS_CDS>"])
     elif termination == "sep":
         ids.append(stoi["<SEP>"])
-    # "none" or other cases skip appending a special token here
+    elif termination != "none":
+        raise ValueError(f"Unsupported termination policy: {termination!r}")
     return ids
+
+
+def tokenize_cds_fragments(
+    dna: str,
+    *,
+    source_id: str | None = None,
+    min_fragment_codons: int = 1,
+    termination: str = "eos",
+) -> CDSTokenizationResult:
+    """Split a CDS at ambiguous codons without creating cross-gap adjacency.
+
+    Coordinates are zero-based, half-open offsets in the oriented CDS string. A
+    trailing partial codon is excluded and reported through ``partial_trailing_bases``.
+    Empty runs created by leading, trailing, or consecutive ambiguity are ignored.
+    """
+    if min_fragment_codons < 1:
+        raise ValueError("min_fragment_codons must be at least 1")
+
+    normalized = _normalize_dna(dna)
+    complete_length = (len(normalized) // 3) * 3
+    partial_trailing_bases = len(normalized) - complete_length
+    fragments: list[TokenizedCDSFragment] = []
+    ambiguous_codons = 0
+    discarded_fragments = 0
+    fragment_index = 0
+    run_start: int | None = None
+    run_ids: list[int] = []
+
+    def flush(end_codon: int) -> None:
+        nonlocal discarded_fragments, fragment_index, run_start, run_ids
+        if run_start is None:
+            return
+        if len(run_ids) >= min_fragment_codons:
+            fragments.append(
+                TokenizedCDSFragment(
+                    ids=_terminated_ids(run_ids, termination),
+                    source_id=source_id,
+                    fragment_index=fragment_index,
+                    codon_start=run_start,
+                    codon_end=end_codon,
+                    base_start=run_start * 3,
+                    base_end=end_codon * 3,
+                )
+            )
+        else:
+            discarded_fragments += 1
+        fragment_index += 1
+        run_start = None
+        run_ids = []
+
+    for codon_index in range(complete_length // 3):
+        codon = normalized[codon_index * 3 : codon_index * 3 + 3]
+        token_id = stoi.get(codon)
+        if token_id is None:
+            ambiguous_codons += 1
+            flush(codon_index)
+            continue
+        if run_start is None:
+            run_start = codon_index
+        run_ids.append(token_id)
+    flush(complete_length // 3)
+
+    return CDSTokenizationResult(
+        fragments=fragments,
+        ambiguous_codons=ambiguous_codons,
+        discarded_fragments=discarded_fragments,
+        partial_trailing_bases=partial_trailing_bases,
+    )
+
+def to_ids(dna: str, termination: str = "eos") -> list[int]:
+    """Converts a DNA sequence string into a list of token IDs, wrapping it in BOS and EOS/SEP tokens."""
+    dna = _normalize_dna(dna)
+    if len(dna) < 3:
+        return []
+    # trim to a multiple of 3, left-aligned (GenBank CDS already in-frame)
+    L = (len(dna) // 3) * 3
+    trailing = dna[L:]
+    if trailing and not set(trailing) <= set("ACGT"):
+        raise AmbiguousCodonError(
+            f"ambiguous partial codon {trailing!r} at codon index {L // 3}; "
+            "use tokenize_cds_fragments() for dataset preparation"
+        )
+    codon_ids = []
+    for i in range(0, L, 3):
+        codon = dna[i : i + 3]
+        idx = stoi.get(codon)
+        if idx is None:
+            raise AmbiguousCodonError(
+                f"ambiguous codon {codon!r} at codon index {i // 3}; "
+                "use tokenize_cds_fragments() for dataset preparation"
+            )
+        codon_ids.append(idx)
+    # Ensure we terminate correctly even if sequence lacked a canonical stop
+    if not codon_ids:
+        return []
+    return _terminated_ids(codon_ids, termination)
 
 
 def main():
@@ -74,20 +193,76 @@ def main():
     ap.add_argument("--out_ids", default="data/processed/codon_ids.txt")
     ap.add_argument("--out_vocab", default="data/processed/vocab_codon.txt")
     ap.add_argument("--out_itos", default="data/processed/itos_codon.txt")
+    ap.add_argument(
+        "--out_fragments",
+        default=None,
+        help="Fragment provenance TSV (default: <out_ids>.fragments.tsv).",
+    )
+    ap.add_argument("--min_fragment_codons", type=int, default=10)
     ap.add_argument("--termination", choices=["eos", "sep", "none"], default="eos",
                     help="Termination token: 'eos' (id 2, default), 'sep' (id 3, legacy default), or 'none'")
     args = ap.parse_args()
 
     ids_path = Path(args.out_ids)
     ids_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.inp) as fin, open(args.out_ids, "w") as fout:
-
-        n=0
-        for line in fin:
-            arr = to_ids(line, termination=args.termination)
-            if len(arr) > 2:
-                fout.write(" ".join(map(str, arr)) + "\n")
-                n += 1
+    fragments_path = Path(args.out_fragments or f"{args.out_ids}.fragments.tsv")
+    fragments_path.parent.mkdir(parents=True, exist_ok=True)
+    stats = {
+        "source_records": 0,
+        "source_records_with_ambiguity": 0,
+        "ambiguous_codons": 0,
+        "retained_fragments": 0,
+        "discarded_fragments": 0,
+        "partial_trailing_bases": 0,
+    }
+    with (
+        open(args.inp) as fin,
+        open(args.out_ids, "w") as fout,
+        open(fragments_path, "w", newline="") as fragment_handle,
+    ):
+        fields = [
+            "fragment_line_idx",
+            "source_line_idx",
+            "source_id",
+            "fragment_index",
+            "codon_start",
+            "codon_end",
+            "base_start",
+            "base_end",
+        ]
+        writer = csv.DictWriter(fragment_handle, fieldnames=fields, delimiter="\t")
+        writer.writeheader()
+        for source_line_idx, line in enumerate(fin):
+            source_id = f"line:{source_line_idx}"
+            result = tokenize_cds_fragments(
+                line,
+                source_id=source_id,
+                min_fragment_codons=args.min_fragment_codons,
+                termination=args.termination,
+            )
+            stats["source_records"] += 1
+            stats["source_records_with_ambiguity"] += int(
+                result.source_had_ambiguity
+            )
+            stats["ambiguous_codons"] += result.ambiguous_codons
+            stats["discarded_fragments"] += result.discarded_fragments
+            stats["partial_trailing_bases"] += result.partial_trailing_bases
+            for fragment in result.fragments:
+                fragment_line_idx = stats["retained_fragments"]
+                fout.write(" ".join(map(str, fragment.ids)) + "\n")
+                writer.writerow(
+                    {
+                        "fragment_line_idx": fragment_line_idx,
+                        "source_line_idx": source_line_idx,
+                        "source_id": source_id,
+                        "fragment_index": fragment.fragment_index,
+                        "codon_start": fragment.codon_start,
+                        "codon_end": fragment.codon_end,
+                        "base_start": fragment.base_start,
+                        "base_end": fragment.base_end,
+                    }
+                )
+                stats["retained_fragments"] += 1
     with open(args.out_vocab, "w") as f:
         for i, tok in enumerate(VOCAB):
             f.write(f"{i}\t{tok}\n")
@@ -95,10 +270,26 @@ def main():
         for tok in VOCAB:
             f.write(f"{tok}\n")
     print(
-        f"[tokenize] wrote {n} sequences → {ids_path} | vocab size {len(VOCAB)} | itos {args.out_itos}"
+        f"[tokenize] wrote {stats['retained_fragments']} fragments → {ids_path} "
+        f"| provenance {fragments_path} | stats {stats} | vocab size {len(VOCAB)} "
+        f"| itos {args.out_itos}"
     )
 
-__all__ = ["CODONS", "STOP_CODONS", "VOCAB", "stoi", "itos", "to_ids"]
+__all__ = [
+    "ALIASES",
+    "AmbiguousCodonError",
+    "CDSTokenizationResult",
+    "CODONS",
+    "IUPAC_DNA_BASES",
+    "SPECIALS",
+    "STOP_CODONS",
+    "TokenizedCDSFragment",
+    "VOCAB",
+    "itos",
+    "stoi",
+    "to_ids",
+    "tokenize_cds_fragments",
+]
 
 if __name__ == "__main__":
     main()

--- a/src/codonlm/extract_cds_from_genbank.py
+++ b/src/codonlm/extract_cds_from_genbank.py
@@ -9,9 +9,13 @@ from pathlib import Path
 import argparse
 from Bio import SeqIO
 
+from src.codonlm.codon_tokenize import IUPAC_DNA_BASES
+
 def reverse_complement(s):
     """Computes the reverse complement of a nucleotide sequence."""
-    comp = str.maketrans("ACGTacgtnN","TGCAtgcann")
+    upper = "ACGTRYSWKMBDHVN"
+    complement = "TGCAYRSWMKVHDBN"
+    comp = str.maketrans(upper + upper.lower(), complement + complement.lower())
     return s.translate(comp)[::-1]
 
 
@@ -60,7 +64,7 @@ def main():
                     cds = seq[s:e]
                     if strand == -1:
                         cds = reverse_complement(cds)
-                    if len(cds) >= args.min_len and set(cds) <= set("ACGTN"):
+                    if len(cds) >= args.min_len and set(cds) <= IUPAC_DNA_BASES:
                         ft.write(cds+"\n")
                         meta = [
                             str(idx),

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -14,6 +14,7 @@ from Bio.SeqFeature import FeatureLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from scripts.build_global_manifest import resolve_genome_identity
+from src.codonlm.extract_cds_from_genbank import reverse_complement
 
 
 def create_mock_genome(
@@ -23,16 +24,18 @@ def create_mock_genome(
     *,
     record_id: str | None = None,
     cds_count: int = 1,
+    cds_sequence: str | None = None,
 ):
     # Generates a mock genome with a coding sequence
-    seq = "A" * 60 + "ATG" + "GCT" * 40 + "TAA" + "C" * 80
+    cds_sequence = cds_sequence or ("ATG" + "GCT" * 40 + "TAA")
+    seq = "A" * 60 + cds_sequence + "C" * 80
     record = SeqRecord(
         Seq(seq), id=record_id or f"record_{genome_id}", name="test", description="mock"
     )
     record.annotations["molecule_type"] = "DNA"
     record.annotations["organism"] = organism
     cds_start = 60
-    cds_end = 60 + 3 + (40 * 3) + 3
+    cds_end = 60 + len(cds_sequence)
     for cds_idx in range(cds_count):
         record.features.append(
             SeqFeature(
@@ -97,6 +100,10 @@ def test_resolve_genome_identity_prefers_explicit_config(tmp_path):
 
     assert genome_id == "GCF_123456789.1"
     assert source == "config.genome_id"
+
+
+def test_reverse_complement_supports_iupac_ambiguity():
+    assert reverse_complement("ARYN") == "NRYT"
 
 
 def test_resolve_genome_identity_uses_parent_accession_for_generic_filename(tmp_path):
@@ -172,6 +179,58 @@ def test_global_packing_is_deterministic_for_same_seed(tmp_path):
     second_manifest = json.loads(Path(outputs[1]["combined_manifest"]).read_text())
     for key in ("seed", "split_policy", "genome_sources", "packing"):
         assert first_manifest[key] == second_manifest[key]
+
+
+def test_global_builder_fragments_ambiguity_after_source_split(tmp_path):
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(3)]
+    create_mock_genome(
+        genomes[0],
+        "0",
+        "Genus0 species",
+        cds_sequence="ATG" + "GCT" * 20 + "NNN" + "GAA" * 20 + "TAA",
+    )
+    for idx, genome in enumerate(genomes[1:], start=1):
+        create_mock_genome(genome, str(idx), f"Genus{idx} species")
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes, min_fragment_codons=2)
+    run_dir = tmp_path / "run"
+    output_dir = tmp_path / "processed"
+
+    result = _run_global_builder(config, run_dir, output_dir)
+
+    assert result.returncode == 0, result.stderr
+    manifest = json.loads((output_dir / "manifest.json").read_text())
+    policy = manifest["tokenization"]["ambiguous_codon_policy"]
+    assert policy["name"] == "split"
+    assert policy["min_fragment_codons"] == 2
+    assert policy["ambiguous_codons"] == 1
+    assert policy["source_records_with_ambiguity"] == 1
+    assert policy["retained_fragments"] == 4
+    assert policy["discarded_fragments"] == 0
+
+    source_splits = {}
+    with open(output_dir / "cds_meta.tsv") as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            source_splits[row["source_id"]] = row["split"]
+
+    with open(output_dir / "cds_fragments.tsv") as handle:
+        fragments = list(csv.DictReader(handle, delimiter="\t"))
+    assert len(fragments) == 4
+    assert all(row["split"] == source_splits[row["source_id"]] for row in fragments)
+    fragment_counts = {
+        source_id: sum(row["source_id"] == source_id for row in fragments)
+        for source_id in source_splits
+    }
+    ambiguous_source = next(
+        source_id for source_id, count in fragment_counts.items() if count == 2
+    )
+    ambiguous_fragments = [
+        row for row in fragments if row["source_id"] == ambiguous_source
+    ]
+    assert [(int(row["codon_start"]), int(row["codon_end"])) for row in ambiguous_fragments] == [
+        (0, 21),
+        (22, 43),
+    ]
 
 
 def test_global_builder_rejects_identity_collisions_across_files(tmp_path):

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,4 +1,7 @@
 from src.codonlm import codon_tokenize as ct
+import csv
+import subprocess
+import pytest
 
 
 def test_to_ids_basic():
@@ -11,3 +14,99 @@ def test_to_ids_basic():
     assert ct.VOCAB[ids[1]] == "ATG"
     assert ct.VOCAB[ids[2]] == "TTT"
 
+
+def _tokens(fragment):
+    return [ct.itos[token_id] for token_id in fragment.ids]
+
+
+def test_to_ids_rejects_ambiguous_codons():
+    with pytest.raises(ct.AmbiguousCodonError, match="codon index 1"):
+        ct.to_ids("ATGNNNGCT")
+    with pytest.raises(ct.AmbiguousCodonError, match="partial codon"):
+        ct.to_ids("ATGNN")
+
+
+def test_fragment_tokenizer_preserves_internal_ambiguity_boundary():
+    result = ct.tokenize_cds_fragments(
+        "ATGNNNGCTGAA", source_id="gene-1", min_fragment_codons=1
+    )
+
+    assert [_tokens(fragment) for fragment in result.fragments] == [
+        ["<BOS_CDS>", "ATG", "<EOS_CDS>"],
+        ["<BOS_CDS>", "GCT", "GAA", "<EOS_CDS>"],
+    ]
+    assert [
+        (fragment.fragment_index, fragment.codon_start, fragment.codon_end)
+        for fragment in result.fragments
+    ] == [(0, 0, 1), (1, 2, 4)]
+    assert all(fragment.source_id == "gene-1" for fragment in result.fragments)
+    assert result.ambiguous_codons == 1
+    assert result.source_had_ambiguity is True
+
+
+@pytest.mark.parametrize(
+    ("dna", "expected_ranges", "ambiguous_codons"),
+    [
+        ("NNNATGAAA", [(1, 3)], 1),
+        ("ATGAAANNN", [(0, 2)], 1),
+        ("ATGNNNNNNAAA", [(0, 1), (3, 4)], 2),
+    ],
+)
+def test_fragment_tokenizer_handles_boundary_and_consecutive_ambiguity(
+    dna, expected_ranges, ambiguous_codons
+):
+    result = ct.tokenize_cds_fragments(dna, min_fragment_codons=1)
+
+    assert [(f.codon_start, f.codon_end) for f in result.fragments] == expected_ranges
+    assert result.ambiguous_codons == ambiguous_codons
+
+
+def test_fragment_tokenizer_filters_short_fragments_and_counts_partial_tail():
+    result = ct.tokenize_cds_fragments(
+        "ATGNNNGCTGAANN", min_fragment_codons=2
+    )
+
+    assert [(f.fragment_index, f.codon_start, f.codon_end) for f in result.fragments] == [
+        (1, 2, 4)
+    ]
+    assert result.discarded_fragments == 1
+    assert result.partial_trailing_bases == 2
+
+
+def test_tokenizer_cli_writes_fragment_provenance(tmp_path):
+    input_path = tmp_path / "cds.txt"
+    ids_path = tmp_path / "ids.txt"
+    fragments_path = tmp_path / "fragments.tsv"
+    input_path.write_text("ATGNNNGCTGAA\nATGAAA\n")
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "src.codonlm.codon_tokenize",
+            "--inp",
+            str(input_path),
+            "--out_ids",
+            str(ids_path),
+            "--out_vocab",
+            str(tmp_path / "vocab.txt"),
+            "--out_itos",
+            str(tmp_path / "itos.txt"),
+            "--out_fragments",
+            str(fragments_path),
+            "--min_fragment_codons",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(ids_path.read_text().splitlines()) == 3
+    with open(fragments_path) as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert [(row["source_id"], row["codon_start"], row["codon_end"]) for row in rows] == [
+        ("line:0", "0", "1"),
+        ("line:0", "2", "4"),
+        ("line:1", "0", "2"),
+    ]


### PR DESCRIPTION
## Summary
- add ambiguity-aware CDS fragmentation with oriented codon/base coordinates and explicit provenance
- make single-sequence tokenization reject ambiguous full or partial codons instead of deleting them
- accept all IUPAC DNA ambiguity symbols during CDS extraction, including reverse complements
- split already-assigned source records into fragments in the global builder and preserve split membership
- emit fragment metadata plus global/per-split ambiguity, retention, discard, and partial-tail counts
- document the fixed split policy and configurable minimum fragment length
- mark #80 complete in the leakage-controlled revalidation track

## Validation
- red phase confirmed 7 expected failures before implementation
- focused tokenizer/global-builder suite: 22 passed
- required CI-equivalent suite with coverage: 191 passed, 1 skipped, 1 xpassed
- fatal Ruff gate and diff checks pass

Closes #80