### PR TITLE
Make exact-duplicate and protein-homology audits preventive

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -22,7 +22,7 @@ Exit gate: fixtures prove that no transition crosses ambiguity, no source transi
 is lost or duplicated, and every derived fragment/chunk retains its source split.
 
 ## Phase 3: Enforce Leakage and Training Correctness
-- [ ] Fail preparation on cross-split exact duplicates and disallowed protein
+- [x] Fail preparation on cross-split exact duplicates and disallowed protein
   homology; record offending IDs, thresholds, commands, and tool versions (#77).
 - [ ] Abort and clear an accumulation group after any non-finite loss, preserving
   correct optimizer/scheduler/resume counters (#83).

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -44,7 +44,7 @@ freeze gate passes.
 - [x] #91: required core CI, fatal lint, coverage, and checkout-cleanliness checks.
 - [x] #80: ambiguous-codon boundary preservation and fragment provenance.
 - [x] #78: lossless long-gene chunking and explicit packing boundaries.
-- [ ] #77: preventive exact-duplicate and protein-homology leakage audits.
+- [x] #77: preventive exact-duplicate and protein-homology leakage audits.
 - [ ] #83: abort and clear non-finite gradient-accumulation groups.
 - [ ] #81: correct attention-dropout behavior in all attention paths.
 - [ ] #84: tokenizer artifact as the vocabulary source of truth.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -291,8 +291,12 @@ python -m scripts.evaluate_test --run_dir runs/<RUN_ID>/checkpoints
 # Sanity KPIs (codon_corr, frameshift_delta, start/stop deltas, syn_gap)
 python -m scripts.sanity_kpis --run_dir runs/<RUN_ID>/checkpoints
 
-# Audit pretraining splits for duplicate sequence and L-mer cross-leakage (exact & near-duplicates)
+# Legacy post-packing diagnostic only; scientific preparation now blocks full-record
+# exact and MMseqs2 protein-cluster leakage before packing and writes leakage_audit.json.
 python -m scripts.audit_duplicates --train_npz data/processed/train_bs256.npz --test_npz data/processed/test_bs256.npz
+
+# Generated-sequence nucleotide/protein nearest neighbors and training-match coverage
+python -m scripts.audit_generated_sequences --train-fasta data/frozen/train_cds.fasta --generated-fasta runs/<RUN_ID>/generated.fasta --output runs/<RUN_ID>/scores/generated_leakage_audit.json
 
 # Calculate baseline perplexities (Uniform, Unigram, Bigram, Trigram Markov baselines)
 python -m scripts.eval_ppl_baselines --test_npz data/processed/test_bs256.npz --train_npz data/processed/train_bs256.npz

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -16,12 +16,40 @@ This guide establishes the mandatory scientific and engineering workflow for dev
    python -m scripts.build_global_manifest --config configs/tiny_mps.yaml --run-id <RUN_ID> --run-dir runs/<RUN_ID> --group-by genome
    ```
 
-   Scientific preparation fails when fewer than three groups are available.
+   Scientific preparation requires MMseqs2 on `PATH`. Before tokenization or
+   packing, the builder hashes normalized full CDS records, clusters translated
+   proteins, and searches validation/test records against training at both the
+   nucleotide and protein levels. It writes commands, the MMseqs2 version,
+   thresholds, identity summaries, and offending source IDs to
+   `leakage_audit.json`. Cross-split exact CDS duplicates or protein clusters are
+   fatal.
+
+   The default protein-cluster gate uses 30% sequence identity and 80% coverage.
+   Override those recorded thresholds with `max_cross_split_protein_identity` and
+   `min_homology_coverage` in the run config. `--skip-homology-audit` and
+   `--allow-cross-split-exact-duplicates` exist only for fixtures and legacy
+   reproduction; either marks the resulting manifest as non-scientific.
+
+   Scientific preparation also fails when fewer than three groups are available.
    `--allow-sequence-split` is an explicit development-only escape hatch and marks
    the resulting manifest as non-scientific. The older
    `scripts.pipeline_prepare` route is disabled unless
    `--allow-legacy-per-dataset-split` is supplied for historical reproduction.
 3. Verify that the output splits contain mutually exclusive genome sets by inspecting the generated `data/processed/global/<RUN_ID>/cds_meta.tsv`.
+
+Generated CDS claims require a separate novelty report against the frozen training
+source records:
+
+```bash
+python -m scripts.audit_generated_sequences \
+  --train-fasta data/frozen/train_cds.fasta \
+  --generated-fasta runs/<RUN_ID>/generated.fasta \
+  --output runs/<RUN_ID>/scores/generated_leakage_audit.json
+```
+
+This records the nearest nucleotide and protein training neighbor for every
+generated sequence and reports position coverage by exact 30-nt and 10-aa
+training substrings.
 
 ---
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pandas
   - numpy<2
   - biopython
+  - mmseqs2
   - scikit-learn
   - pyyaml
   - tqdm

--- a/scripts/audit_duplicates.py
+++ b/scripts/audit_duplicates.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import json
 from pathlib import Path
 import numpy as np
 
@@ -26,6 +27,12 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--train_npz", help="Path to train NPZ dataset")
     ap.add_argument("--test_npz", help="Path to test NPZ dataset")
+    ap.add_argument(
+        "--fail-on-exact",
+        action="store_true",
+        help="Exit nonzero when an exact packed-sequence duplicate is found.",
+    )
+    ap.add_argument("--report-json", help="Optional machine-readable output path.")
     args = ap.parse_args()
 
     # 1. Resolve Paths
@@ -84,6 +91,7 @@ def main():
     print("\n| Window Size (Codons / bp) | Unique Train L-mers | Shared Test Sequences | Leakage Percentage |")
     print("| :--- | :---: | :---: | :---: |")
 
+    overlaps = {}
     for L in window_sizes:
         bp = L * 3
         # Index all unique L-mers in the training set
@@ -99,7 +107,27 @@ def main():
                 shared_seqs += 1
 
         leak_pct = (shared_seqs / len(test_seqs)) * 100 if test_seqs else 0.0
+        overlaps[str(L)] = {
+            "unique_train_lmers": len(train_lmers),
+            "shared_test_sequences": shared_seqs,
+            "leakage_fraction": leak_pct / 100.0,
+        }
         print(f"| {L:2} codons ({bp:2} bp)       | {len(train_lmers):19,} | {shared_seqs:21,} | {leak_pct:17.2f}% |")
+
+    report = {
+        "schema_version": 1,
+        "scope": "legacy_post_packing_diagnostic",
+        "exact_duplicates": exact_duplicates,
+        "test_sequences": len(test_seqs),
+        "overlaps": overlaps,
+        "status": "failed" if args.fail_on_exact and exact_duplicates else "passed",
+    }
+    if args.report_json:
+        report_path = Path(args.report_json)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2) + "\n")
+    if args.fail_on_exact and exact_duplicates:
+        raise SystemExit(4)
 
 if __name__ == "__main__":
     main()

--- a/scripts/audit_generated_sequences.py
+++ b/scripts/audit_generated_sequences.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Audit generated CDS novelty against the training source-record corpus."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from Bio import SeqIO
+
+from src.codonlm.leakage_audit import audit_generated_sequences
+
+
+def _read_fasta(path: Path) -> list[dict[str, str]]:
+    return [
+        {"source_id": str(record.id), "sequence": str(record.seq)}
+        for record in SeqIO.parse(path, "fasta")
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--train-fasta", type=Path, required=True)
+    parser.add_argument("--generated-fasta", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--nucleotide-window", type=int, default=30)
+    parser.add_argument("--protein-window", type=int, default=10)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--mmseqs-executable", default="mmseqs")
+    args = parser.parse_args()
+
+    report = audit_generated_sequences(
+        _read_fasta(args.train_fasta),
+        _read_fasta(args.generated_fasta),
+        args.output,
+        nucleotide_window=args.nucleotide_window,
+        protein_window=args.protein_window,
+        threads=args.threads,
+        executable=args.mmseqs_executable,
+    )
+    print(
+        f"[generated-audit] wrote {report['generated_record_count']} records to {args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -24,7 +24,7 @@ import json
 import random
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List
 import numpy as np
 import yaml
 from Bio import SeqIO
@@ -44,6 +44,7 @@ from src.codonlm.lossless_packing import (
     packed_arrays,
     packing_metadata_rows,
 )
+from src.codonlm.leakage_audit import LeakageAuditError, audit_source_records
 
 
 ASSEMBLY_ACCESSION_RE = re.compile(
@@ -175,6 +176,22 @@ def main() -> None:
         help="Prepared dataset directory (default: data/processed/global/<run-id>).",
     )
     ap.add_argument("--seed", type=int, default=1337)
+    ap.add_argument(
+        "--skip-homology-audit",
+        action="store_true",
+        help="NON-SCIENTIFIC: skip the required MMseqs2 protein-homology audit.",
+    )
+    ap.add_argument(
+        "--allow-cross-split-exact-duplicates",
+        action="store_true",
+        help="NON-SCIENTIFIC: report but do not block cross-split exact CDS duplicates.",
+    )
+    ap.add_argument(
+        "--mmseqs-executable",
+        default="mmseqs",
+        help="MMseqs2 executable used for clustering and nearest-neighbor searches.",
+    )
+    ap.add_argument("--audit-threads", type=int, default=1)
     ap.add_argument("--force", action="store_true", help="Force rebuild")
     args = ap.parse_args()
 
@@ -193,8 +210,14 @@ def main() -> None:
     windows_per_seq = int(float(cfg.get("windows_per_seq", 1)))
     min_len = int(cfg.get("min_len", 90))
     min_fragment_codons = int(cfg.get("min_fragment_codons", 10))
+    min_protein_identity = float(cfg.get("max_cross_split_protein_identity", 0.3))
+    min_homology_coverage = float(cfg.get("min_homology_coverage", 0.8))
     if min_fragment_codons < 1:
         raise SystemExit("[error] min_fragment_codons must be at least 1")
+    if not (0.0 < min_protein_identity <= 1.0):
+        raise SystemExit("[error] max_cross_split_protein_identity must be in (0, 1]")
+    if not (0.0 < min_homology_coverage <= 1.0):
+        raise SystemExit("[error] min_homology_coverage must be in (0, 1]")
     requested_group_by = args.group_by or str(cfg.get("split_group_by", "genome"))
     if requested_group_by not in {"genome", "genus", "sequence"}:
         raise SystemExit(
@@ -323,6 +346,30 @@ def main() -> None:
         else Path("data/processed/global") / args.run_id
     )
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    audit_path = out_dir / "leakage_audit.json"
+    if args.skip_homology_audit:
+        print(
+            "[global-prep] NON-SCIENTIFIC: MMseqs2 protein-homology audit was explicitly skipped."
+        )
+    if args.allow_cross_split_exact_duplicates:
+        print(
+            "[global-prep] NON-SCIENTIFIC: cross-split exact CDS duplicates are allowed."
+        )
+    try:
+        leakage_report = audit_source_records(
+            all_records,
+            audit_path,
+            min_protein_identity=min_protein_identity,
+            min_coverage=min_homology_coverage,
+            threads=args.audit_threads,
+            executable=args.mmseqs_executable,
+            skip_homology=args.skip_homology_audit,
+            allow_exact_duplicates=args.allow_cross_split_exact_duplicates,
+        )
+    except LeakageAuditError as exc:
+        raise SystemExit(f"[error] {exc}; see {audit_path}") from exc
+    print(f"[global-prep] Leakage audit passed: {audit_path}")
     
     meta_path = out_dir / "cds_meta.tsv"
     dna_path = out_dir / "cds_dna.txt"
@@ -522,7 +569,11 @@ def main() -> None:
             "requested_group_by": requested_group_by,
             "effective_group_by": effective_group_by,
             "allow_sequence_split": bool(args.allow_sequence_split),
-            "scientific_valid": effective_group_by != "sequence",
+            "scientific_valid": (
+                effective_group_by != "sequence"
+                and not args.skip_homology_audit
+                and not args.allow_cross_split_exact_duplicates
+            ),
             "requested_fractions": {"val": val_frac, "test": test_frac},
             "achieved_record_fractions": achieved_fractions,
             "record_counts": counts,
@@ -530,6 +581,13 @@ def main() -> None:
             "groups_by_split": groups_by_split,
         },
         "genome_sources": genome_sources,
+        "leakage_audit": {
+            "report": str(audit_path),
+            "status": leakage_report["status"],
+            "homology_audit_skipped": args.skip_homology_audit,
+            "exact_duplicate_override": args.allow_cross_split_exact_duplicates,
+            "thresholds": leakage_report["thresholds"],
+        },
         "tokenization": {
             "fragment_metadata": str(fragments_path),
             "ambiguous_codon_policy": {

--- a/scripts/eval_generation_prefix.py
+++ b/scripts/eval_generation_prefix.py
@@ -347,6 +347,19 @@ def _ngram_repeat_ratio(tokens: List[str], n: int = 3) -> float:
     return 1.0 - (uniq / total) if total else 0.0
 
 
+def _training_match_coverage(
+    tokens: List[int], n: int, training_ngrams: set[tuple[int, ...]]
+) -> float:
+    """Fraction of generated token positions covered by an exact training n-gram."""
+    if len(tokens) < n or not training_ngrams:
+        return 0.0
+    covered = bytearray(len(tokens))
+    for start in range(len(tokens) - n + 1):
+        if tuple(tokens[start : start + n]) in training_ngrams:
+            covered[start : start + n] = b"\x01" * n
+    return sum(covered) / len(tokens)
+
+
 def _score_stop_behavior(
     gen_codons: List[str], truth_len_codons: int
 ) -> Tuple[float, bool, bool]:
@@ -955,13 +968,11 @@ def main() -> None:
                 if 10 in train_ngram_sets and train_ngram_sets[10]:
                     s10 = train_ngram_sets[10]
                     if len(full_gen_ids) >= 10:
-                        matches = sum(1 for idx in range(len(full_gen_ids) - 10 + 1) if tuple(full_gen_ids[idx : idx + 10]) in s10)
-                        overlap_10 = matches / (len(full_gen_ids) - 10 + 1)
+                        overlap_10 = _training_match_coverage(full_gen_ids, 10, s10)
                 if 20 in train_ngram_sets and train_ngram_sets[20]:
                     s20 = train_ngram_sets[20]
                     if len(full_gen_ids) >= 20:
-                        matches = sum(1 for idx in range(len(full_gen_ids) - 20 + 1) if tuple(full_gen_ids[idx : idx + 20]) in s20)
-                        overlap_20 = matches / (len(full_gen_ids) - 20 + 1)
+                        overlap_20 = _training_match_coverage(full_gen_ids, 20, s20)
 
                 rows.append(
                     SampleResult(

--- a/scripts/pipeline_prepare.py
+++ b/scripts/pipeline_prepare.py
@@ -453,8 +453,8 @@ def main() -> None:
             f"[integrity] ok: empty_windows train={empty_train} val={empty_val} test={empty_test}"
         )
 
-    # ---------- Run Split Duplication soft audit ----------
-    print("\n[prepare] Running split duplication soft audit...")
+    # ---------- Run legacy packed-data duplication gate ----------
+    print("\n[prepare] Running legacy packed-data duplication gate...")
     try:
         import sys
         import subprocess
@@ -466,13 +466,19 @@ def main() -> None:
             str(train_out),
             "--test_npz",
             str(test_out),
+            "--fail-on-exact",
+            "--report-json",
+            str(run_dir / "legacy_packed_leakage_audit.json"),
         ]
         res = subprocess.run(cmd, capture_output=True, text=True)
         print(res.stdout)
         if res.returncode != 0:
-            print(f"[warning] split duplication audit encountered an issue:\n{res.stderr}")
+            raise SystemExit(
+                "[integrity] legacy packed-data duplication gate failed:\n"
+                f"{res.stderr}"
+            )
     except Exception as exc:
-        print(f"[warning] failed to run split duplication audit: {exc}")
+        raise SystemExit(f"[integrity] failed to run duplication gate: {exc}") from exc
 
 
 if __name__ == "__main__":

--- a/src/codonlm/leakage_audit.py
+++ b/src/codonlm/leakage_audit.py
@@ -1,0 +1,471 @@
+"""Preventive source-record leakage audits for scientific dataset preparation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from statistics import median
+from typing import Any, Iterable, Mapping, Sequence
+
+from Bio.Seq import Seq
+
+
+SPLIT_ORDER = {"train": 0, "val": 1, "test": 2}
+
+
+class LeakageAuditError(RuntimeError):
+    """Raised when a blocking leakage audit cannot pass."""
+
+
+def normalize_cds(sequence: str) -> str:
+    """Return the canonical DNA representation used for exact hashing."""
+    return "".join(str(sequence).split()).upper().replace("U", "T")
+
+
+def translate_cds(sequence: str, table: int = 11) -> str:
+    """Translate a normalized CDS while retaining internal stop markers."""
+    normalized = normalize_cds(sequence)
+    usable = normalized[: len(normalized) - (len(normalized) % 3)]
+    if not usable:
+        return ""
+    protein = str(Seq(usable).translate(table=table))
+    if protein.endswith("*"):
+        protein = protein[:-1]
+    return protein.replace("*", "X")
+
+
+def exact_cross_split_duplicates(
+    records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return full-CDS hashes whose source records occur in multiple splits."""
+    by_hash: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        digest = hashlib.sha256(normalize_cds(record["sequence"]).encode("ascii")).hexdigest()
+        by_hash[digest].append(record)
+
+    violations = []
+    for digest, members in sorted(by_hash.items()):
+        splits = sorted({str(member["split"]) for member in members}, key=SPLIT_ORDER.get)
+        if len(splits) < 2:
+            continue
+        violations.append(
+            {
+                "sha256": digest,
+                "splits": splits,
+                "source_ids": sorted(str(member["source_id"]) for member in members),
+            }
+        )
+    return violations
+
+
+def cross_split_cluster_violations(
+    clusters: Mapping[str, Sequence[str]],
+    split_by_source: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    """Return protein clusters containing records from more than one split."""
+    violations = []
+    for representative, members in sorted(clusters.items()):
+        source_ids = sorted(set(members))
+        splits = sorted(
+            {split_by_source[source_id] for source_id in source_ids},
+            key=SPLIT_ORDER.get,
+        )
+        if len(splits) > 1:
+            violations.append(
+                {
+                    "representative": representative,
+                    "splits": splits,
+                    "source_ids": source_ids,
+                }
+            )
+    return violations
+
+
+def _write_fasta(path: Path, records: Iterable[tuple[str, str]]) -> None:
+    with path.open("w") as handle:
+        for source_id, sequence in records:
+            handle.write(f">{source_id}\n{sequence}\n")
+
+
+def _run(command: list[str], commands: list[list[str]]) -> subprocess.CompletedProcess[str]:
+    commands.append(command)
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def _parse_clusters(path: Path) -> dict[str, list[str]]:
+    clusters: dict[str, list[str]] = defaultdict(list)
+    with path.open() as handle:
+        for line in handle:
+            representative, member = line.rstrip("\n").split("\t")[:2]
+            clusters[representative].append(member)
+    return dict(clusters)
+
+
+def _parse_nearest(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    if not path.exists():
+        return rows
+    with path.open() as handle:
+        for line in handle:
+            query, target, pident, alnlen, qlen, tlen = line.rstrip("\n").split("\t")
+            rows.append(
+                {
+                    "query_id": query,
+                    "target_id": target,
+                    "identity": float(pident) / 100.0,
+                    "alignment_length": int(alnlen),
+                    "query_length": int(qlen),
+                    "target_length": int(tlen),
+                    "query_coverage": int(alnlen) / max(1, int(qlen)),
+                }
+            )
+    return rows
+
+
+def matching_substring_coverage(
+    sequence: str, training_sequences: Sequence[str], window_size: int
+) -> float:
+    """Return the fraction of query positions covered by exact training windows."""
+    if window_size < 1:
+        raise ValueError("window_size must be at least 1")
+    if len(sequence) < window_size:
+        return 0.0
+    training_windows = {
+        training[start : start + window_size]
+        for training in training_sequences
+        for start in range(max(0, len(training) - window_size + 1))
+    }
+    return _coverage_from_index(sequence, training_windows, window_size)
+
+
+def _coverage_from_index(
+    sequence: str, training_windows: set[str], window_size: int
+) -> float:
+    if len(sequence) < window_size or not training_windows:
+        return 0.0
+    covered = bytearray(len(sequence))
+    for start in range(len(sequence) - window_size + 1):
+        if sequence[start : start + window_size] in training_windows:
+            covered[start : start + window_size] = b"\x01" * window_size
+    return sum(covered) / len(sequence)
+
+
+def _identity_summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    identities = sorted(float(row["identity"]) for row in rows)
+    if not identities:
+        return {
+            "count": 0,
+            "min": None,
+            "median": None,
+            "p90": None,
+            "p95": None,
+            "max": None,
+        }
+
+    def percentile(fraction: float) -> float:
+        index = fraction * (len(identities) - 1)
+        lower = int(index)
+        upper = min(lower + 1, len(identities) - 1)
+        weight = index - lower
+        return identities[lower] * (1.0 - weight) + identities[upper] * weight
+
+    return {
+        "count": len(identities),
+        "min": identities[0],
+        "median": median(identities),
+        "p90": percentile(0.9),
+        "p95": percentile(0.95),
+        "max": identities[-1],
+    }
+
+
+def run_mmseqs_audit(
+    records: Sequence[Mapping[str, Any]],
+    work_dir: Path,
+    *,
+    min_protein_identity: float,
+    min_coverage: float,
+    threads: int = 1,
+    executable: str = "mmseqs",
+) -> dict[str, Any]:
+    """Cluster translated CDS records and find held-out nearest neighbors."""
+    resolved = shutil.which(executable)
+    if resolved is None:
+        raise LeakageAuditError(
+            f"MMseqs2 executable {executable!r} was not found; scientific preparation requires the protein-homology audit"
+        )
+    work_dir.mkdir(parents=True, exist_ok=True)
+    commands: list[list[str]] = []
+    version_result = _run([resolved, "version"], commands)
+    version = (version_result.stdout or version_result.stderr).strip()
+
+    proteins = [(str(record["source_id"]), translate_cds(record["sequence"])) for record in records]
+    proteins = [(source_id, sequence) for source_id, sequence in proteins if sequence]
+    protein_fasta = work_dir / "all_proteins.fasta"
+    _write_fasta(protein_fasta, proteins)
+    cluster_prefix = work_dir / "protein_clusters"
+    cluster_tmp = work_dir / "cluster_tmp"
+    _run(
+        [
+            resolved,
+            "easy-cluster",
+            str(protein_fasta),
+            str(cluster_prefix),
+            str(cluster_tmp),
+            "--min-seq-id",
+            str(min_protein_identity),
+            "-c",
+            str(min_coverage),
+            "--cov-mode",
+            "0",
+            "--cluster-mode",
+            "0",
+            "--threads",
+            str(threads),
+        ],
+        commands,
+    )
+    clusters = _parse_clusters(Path(f"{cluster_prefix}_cluster.tsv"))
+
+    train = [record for record in records if record["split"] == "train"]
+    held_out = [record for record in records if record["split"] in {"val", "test"}]
+    nearest: dict[str, Any] = {}
+    for sequence_type in ("nucleotide", "protein"):
+        if sequence_type == "protein":
+            convert = translate_cds
+        else:
+            convert = normalize_cds
+        train_fasta = work_dir / f"train_{sequence_type}.fasta"
+        query_fasta = work_dir / f"held_out_{sequence_type}.fasta"
+        _write_fasta(train_fasta, ((str(r["source_id"]), convert(r["sequence"])) for r in train))
+        _write_fasta(query_fasta, ((str(r["source_id"]), convert(r["sequence"])) for r in held_out))
+        output = work_dir / f"nearest_{sequence_type}.tsv"
+        search_tmp = work_dir / f"search_{sequence_type}_tmp"
+        _run(
+            [
+                resolved,
+                "easy-search",
+                str(query_fasta),
+                str(train_fasta),
+                str(output),
+                str(search_tmp),
+                "--format-output",
+                "query,target,pident,alnlen,qlen,tlen",
+                "--max-seqs",
+                "1",
+                "--threads",
+                str(threads),
+            ],
+            commands,
+        )
+        rows = _parse_nearest(output)
+        nearest[sequence_type] = {
+            "artifact": str(output),
+            "summary": _identity_summary(rows),
+        }
+
+    return {
+        "tool": {"name": "MMseqs2", "executable": resolved, "version": version},
+        "parameters": {
+            "min_protein_identity": min_protein_identity,
+            "min_coverage": min_coverage,
+            "cov_mode": 0,
+            "cluster_mode": 0,
+            "threads": threads,
+        },
+        "commands": commands,
+        "cluster_artifact": str(Path(f"{cluster_prefix}_cluster.tsv")),
+        "_clusters": clusters,
+        "nearest_neighbors": nearest,
+    }
+
+
+def audit_source_records(
+    records: Sequence[Mapping[str, Any]],
+    output_path: Path,
+    *,
+    min_protein_identity: float = 0.3,
+    min_coverage: float = 0.8,
+    threads: int = 1,
+    executable: str = "mmseqs",
+    skip_homology: bool = False,
+    allow_exact_duplicates: bool = False,
+) -> dict[str, Any]:
+    """Run blocking exact and protein-homology audits and always write JSON."""
+    exact = exact_cross_split_duplicates(records)
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "status": "pending",
+        "record_count": len(records),
+        "thresholds": {
+            "max_exact_cross_split_duplicates": 0,
+            "max_cross_split_protein_clusters": 0,
+            "min_protein_identity": min_protein_identity,
+            "min_coverage": min_coverage,
+        },
+        "exact_duplicates": {"count": len(exact), "violations": exact},
+        "homology_audit_skipped": skip_homology,
+        "exact_duplicate_override": allow_exact_duplicates,
+    }
+    blocking_reasons = []
+    if exact and not allow_exact_duplicates:
+        blocking_reasons.append("cross_split_exact_duplicates")
+
+    try:
+        if not skip_homology:
+            mmseqs = run_mmseqs_audit(
+                records,
+                output_path.parent / "leakage_audit_work",
+                min_protein_identity=min_protein_identity,
+                min_coverage=min_coverage,
+                threads=threads,
+                executable=executable,
+            )
+            split_by_source = {str(record["source_id"]): str(record["split"]) for record in records}
+            clusters = mmseqs.pop("_clusters")
+            protein_violations = cross_split_cluster_violations(clusters, split_by_source)
+            mmseqs["cluster_count"] = len(clusters)
+            mmseqs["cross_split_cluster_count"] = len(protein_violations)
+            mmseqs["cross_split_violations"] = protein_violations
+            report["protein_homology"] = mmseqs
+            if protein_violations:
+                blocking_reasons.append("cross_split_protein_clusters")
+        else:
+            report["protein_homology"] = None
+    except (LeakageAuditError, subprocess.CalledProcessError, OSError, ValueError) as exc:
+        report["status"] = "error"
+        report["error"] = str(exc)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2) + "\n")
+        raise LeakageAuditError(str(exc)) from exc
+
+    report["blocking_reasons"] = blocking_reasons
+    report["status"] = "failed" if blocking_reasons else "passed"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2) + "\n")
+    if blocking_reasons:
+        raise LeakageAuditError(
+            "Leakage audit failed: " + ", ".join(blocking_reasons)
+        )
+    return report
+
+
+def audit_generated_sequences(
+    training: Sequence[Mapping[str, Any]],
+    generated: Sequence[Mapping[str, Any]],
+    output_path: Path,
+    *,
+    nucleotide_window: int = 30,
+    protein_window: int = 10,
+    threads: int = 1,
+    executable: str = "mmseqs",
+) -> dict[str, Any]:
+    """Report nearest training identities and matching-substring coverage."""
+    resolved = shutil.which(executable)
+    if resolved is None:
+        raise LeakageAuditError(f"MMseqs2 executable {executable!r} was not found")
+    work_dir = output_path.parent / f"{output_path.stem}_work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    commands: list[list[str]] = []
+    version_result = _run([resolved, "version"], commands)
+    version = (version_result.stdout or version_result.stderr).strip()
+    nearest_by_type: dict[str, dict[str, dict[str, Any]]] = {}
+
+    converters = {"nucleotide": normalize_cds, "protein": translate_cds}
+    for sequence_type, convert in converters.items():
+        train_fasta = work_dir / f"train_{sequence_type}.fasta"
+        generated_fasta = work_dir / f"generated_{sequence_type}.fasta"
+        _write_fasta(
+            train_fasta,
+            ((str(record["source_id"]), convert(record["sequence"])) for record in training),
+        )
+        _write_fasta(
+            generated_fasta,
+            ((str(record["source_id"]), convert(record["sequence"])) for record in generated),
+        )
+        output = work_dir / f"nearest_{sequence_type}.tsv"
+        _run(
+            [
+                resolved,
+                "easy-search",
+                str(generated_fasta),
+                str(train_fasta),
+                str(output),
+                str(work_dir / f"search_{sequence_type}_tmp"),
+                "--format-output",
+                "query,target,pident,alnlen,qlen,tlen",
+                "--max-seqs",
+                "1",
+                "--threads",
+                str(threads),
+            ],
+            commands,
+        )
+        nearest_by_type[sequence_type] = {
+            row["query_id"]: row for row in _parse_nearest(output)
+        }
+
+    training_dna = [normalize_cds(record["sequence"]) for record in training]
+    training_proteins = [translate_cds(record["sequence"]) for record in training]
+    nucleotide_windows = {
+        sequence[start : start + nucleotide_window]
+        for sequence in training_dna
+        for start in range(max(0, len(sequence) - nucleotide_window + 1))
+    }
+    protein_windows = {
+        sequence[start : start + protein_window]
+        for sequence in training_proteins
+        for start in range(max(0, len(sequence) - protein_window + 1))
+    }
+    rows = []
+    for record in generated:
+        source_id = str(record["source_id"])
+        dna = normalize_cds(record["sequence"])
+        protein = translate_cds(record["sequence"])
+        rows.append(
+            {
+                "source_id": source_id,
+                "nucleotide_nearest": nearest_by_type["nucleotide"].get(source_id),
+                "protein_nearest": nearest_by_type["protein"].get(source_id),
+                "nucleotide_training_match_coverage": _coverage_from_index(
+                    dna, nucleotide_windows, nucleotide_window
+                ),
+                "protein_training_match_coverage": _coverage_from_index(
+                    protein, protein_windows, protein_window
+                ),
+            }
+        )
+
+    report = {
+        "schema_version": 1,
+        "tool": {"name": "MMseqs2", "executable": resolved, "version": version},
+        "parameters": {
+            "nucleotide_window": nucleotide_window,
+            "protein_window": protein_window,
+            "threads": threads,
+        },
+        "commands": commands,
+        "training_record_count": len(training),
+        "generated_record_count": len(generated),
+        "records": rows,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2) + "\n")
+    return report
+
+
+__all__ = [
+    "LeakageAuditError",
+    "audit_generated_sequences",
+    "audit_source_records",
+    "cross_split_cluster_violations",
+    "exact_cross_split_duplicates",
+    "normalize_cds",
+    "matching_substring_coverage",
+    "run_mmseqs_audit",
+    "translate_cds",
+]

--- a/tests/test_audit_duplicates.py
+++ b/tests/test_audit_duplicates.py
@@ -1,4 +1,5 @@
 import numpy as np
+import json
 import subprocess
 from pathlib import Path
 
@@ -49,3 +50,19 @@ def test_audit_duplicates_logic(tmp_path):
     # L=30: none should trigger overlap except maybe exact (which is len 12 < 30) so 0%
     assert "30 codons" in res.stdout
     assert "0.00%" in res.stdout
+
+    report_path = tmp_path / "audit.json"
+    blocked = subprocess.run(
+        [
+            *cmd,
+            "--fail-on-exact",
+            "--report-json",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert blocked.returncode == 4
+    report = json.loads(report_path.read_text())
+    assert report["status"] == "failed"
+    assert report["exact_duplicates"] == 1

--- a/tests/test_eval_generation_prefix.py
+++ b/tests/test_eval_generation_prefix.py
@@ -9,6 +9,7 @@ from scripts.eval_generation_prefix import (
     _ngram_repeat_ratio,
     _score_stop_behavior,
     _select_device,
+    _training_match_coverage,
 )
 
 
@@ -17,6 +18,13 @@ def test_ngram_repeat_ratio_simple():
     r = _ngram_repeat_ratio(seq, n=3)
     # two 3-grams repeated once each over 4 total grams: uniq=2, total=4 => repeat ratio=1-2/4=0.5
     assert abs(r - 0.5) < 1e-6
+
+
+def test_training_match_coverage_counts_covered_positions():
+    tokens = [1, 2, 3, 4, 5, 6]
+    training = {(1, 2, 3), (3, 4, 5)}
+
+    assert _training_match_coverage(tokens, 3, training) == 5 / 6
 
 
 def test_codon_to_aa_mapping():
@@ -197,4 +205,3 @@ def test_eval_generation_prefix_end_to_end(tmp_path):
     finally:
         if test_run_dir.exists():
             shutil.rmtree(test_run_dir)
-

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import json
 import os
 import subprocess
@@ -29,7 +30,13 @@ def create_mock_genome(
     cds_sequence: str | None = None,
 ):
     # Generates a mock genome with a coding sequence
-    cds_sequence = cds_sequence or ("ATG" + "GCT" * 40 + "TAA")
+    if cds_sequence is None:
+        digest = hashlib.sha256(genome_id.encode()).digest()
+        alanine_codons = ("GCT", "GCC", "GCA", "GCG")
+        cds_sequence = "ATG" + "".join(
+            alanine_codons[digest[index % len(digest)] % len(alanine_codons)]
+            for index in range(40)
+        ) + "TAA"
     seq = "A" * 60 + cds_sequence + "C" * 80
     record = SeqRecord(
         Seq(seq), id=record_id or f"record_{genome_id}", name="test", description="mock"
@@ -54,7 +61,9 @@ def _run_global_builder(
     run_dir: Path,
     output_dir: Path,
     *extra_args: str,
+    skip_homology: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    audit_args = ["--skip-homology-audit"] if skip_homology else []
     return subprocess.run(
         [
             "python",
@@ -70,6 +79,7 @@ def _run_global_builder(
             str(output_dir),
             "--group-by",
             "genome",
+            *audit_args,
             *extra_args,
         ],
         capture_output=True,
@@ -146,6 +156,7 @@ def test_sequence_fallback_requires_explicit_flag_and_is_marked_non_scientific(t
         run_dir,
         tmp_path / "processed",
         "--allow-sequence-split",
+        "--allow-cross-split-exact-duplicates",
     )
 
     assert result.returncode == 0, result.stderr
@@ -263,12 +274,19 @@ def test_global_dynamic_packing_keeps_starts_ends_and_all_transitions(tmp_path):
     result = _run_global_builder(config, run_dir, output_dir)
 
     assert result.returncode == 0, result.stderr
-    expected = to_ids("ATG" + "GCT" * 40 + "TAA")
+    sequences_by_split = {}
+    with open(output_dir / "cds_meta.tsv") as metadata, open(
+        output_dir / "cds_dna.txt"
+    ) as dna:
+        for row, sequence in zip(csv.DictReader(metadata, delimiter="\t"), dna):
+            sequences_by_split[row["split"]] = to_ids(sequence.strip())
     for split in ("train", "val", "test"):
         chunks = _dynamic_sequences(output_dir / f"{split}_bs8.npz")
         assert chunks[0][0] == stoi["<BOS_CDS>"]
         assert chunks[-1][-1] == stoi["<EOS_CDS>"]
-        assert _transition_counts(chunks) == _transition_counts([expected])
+        assert _transition_counts(chunks) == _transition_counts(
+            [sequences_by_split[split]]
+        )
         with open(output_dir / f"{split}_packing.tsv") as handle:
             spans = list(csv.DictReader(handle, delimiter="\t"))
         assert spans[0]["continues_from_previous"] == "0"
@@ -321,6 +339,65 @@ def test_global_builder_rejects_identity_collisions_across_files(tmp_path):
 
     assert result.returncode != 0
     assert "Genome identity collision" in (result.stderr + result.stdout)
+
+
+def test_global_builder_blocks_cross_split_exact_cds(tmp_path):
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(3)]
+    duplicate = "ATG" + "GCT" * 40 + "TAA"
+    create_mock_genome(genomes[0], "0", "Genus0 species", cds_sequence=duplicate)
+    create_mock_genome(genomes[1], "1", "Genus1 species", cds_sequence=duplicate)
+    create_mock_genome(
+        genomes[2],
+        "2",
+        "Genus2 species",
+        cds_sequence="ATG" + "AAA" * 40 + "TAA",
+    )
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes)
+    output_dir = tmp_path / "processed"
+
+    result = _run_global_builder(config, tmp_path / "run", output_dir)
+
+    assert result.returncode != 0
+    report = json.loads((output_dir / "leakage_audit.json").read_text())
+    assert report["status"] == "failed"
+    assert report["exact_duplicates"]["count"] == 1
+    assert report["blocking_reasons"] == ["cross_split_exact_duplicates"]
+
+
+def test_global_builder_blocks_cross_split_protein_clusters(tmp_path):
+    from tests.test_leakage_audit import _write_fake_mmseqs
+
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(3)]
+    create_mock_genome(
+        genomes[0], "0", "Genus0 species", cds_sequence="ATG" + "GCT" * 40 + "TAA"
+    )
+    create_mock_genome(
+        genomes[1], "1", "Genus1 species", cds_sequence="ATG" + "GCC" * 40 + "TAA"
+    )
+    create_mock_genome(
+        genomes[2], "2", "Genus2 species", cds_sequence="ATG" + "AAA" * 40 + "TAA"
+    )
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes)
+    executable = tmp_path / "mmseqs"
+    _write_fake_mmseqs(executable)
+    output_dir = tmp_path / "processed"
+
+    result = _run_global_builder(
+        config,
+        tmp_path / "run",
+        output_dir,
+        "--mmseqs-executable",
+        str(executable),
+        skip_homology=False,
+    )
+
+    assert result.returncode != 0
+    report = json.loads((output_dir / "leakage_audit.json").read_text())
+    assert report["status"] == "failed"
+    assert report["protein_homology"]["cross_split_cluster_count"] == 1
+    assert report["protein_homology"]["tool"]["version"] == "fake-mmseqs-1.0"
 
 def test_global_split_and_baselines_end_to_end(tmp_path):
     # Create 3 distinct genomes/gbff files

--- a/tests/test_leakage_audit.py
+++ b/tests/test_leakage_audit.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from src.codonlm.leakage_audit import (
+    LeakageAuditError,
+    audit_generated_sequences,
+    audit_source_records,
+    cross_split_cluster_violations,
+    exact_cross_split_duplicates,
+    matching_substring_coverage,
+    translate_cds,
+)
+
+
+def _record(source_id: str, split: str, sequence: str) -> dict[str, str]:
+    return {"source_id": source_id, "split": split, "sequence": sequence}
+
+
+def test_exact_duplicate_hashes_normalized_full_cds():
+    records = [
+        _record("train-a", "train", "atg gcc taa"),
+        _record("test-a", "test", "ATGGCCTAA"),
+        _record("val-unique", "val", "ATGGCTTAA"),
+    ]
+
+    violations = exact_cross_split_duplicates(records)
+
+    assert len(violations) == 1
+    assert violations[0]["splits"] == ["train", "test"]
+    assert violations[0]["source_ids"] == ["test-a", "train-a"]
+
+
+def test_translation_removes_terminal_stop_for_mmseqs():
+    assert translate_cds("ATGGCTTAA") == "MA"
+
+
+def test_matching_substring_coverage_marks_query_positions():
+    assert matching_substring_coverage("AAACCCGGG", ["TTTAAACCC"], 3) == 6 / 9
+
+
+def test_protein_cluster_threshold_behavior_is_cross_split_only():
+    clusters = {
+        "train-a": ["train-a", "train-b"],
+        "train-c": ["train-c", "test-a"],
+        "val-a": ["val-a"],
+    }
+    splits = {
+        "train-a": "train",
+        "train-b": "train",
+        "train-c": "train",
+        "test-a": "test",
+        "val-a": "val",
+    }
+
+    violations = cross_split_cluster_violations(clusters, splits)
+
+    assert violations == [
+        {
+            "representative": "train-c",
+            "splits": ["train", "test"],
+            "source_ids": ["test-a", "train-c"],
+        }
+    ]
+
+
+def test_exact_duplicate_blocks_even_when_homology_is_explicitly_skipped(tmp_path):
+    report_path = tmp_path / "leakage.json"
+    records = [
+        _record("train-a", "train", "ATGGCCTAA"),
+        _record("test-a", "test", "ATGGCCTAA"),
+    ]
+
+    with pytest.raises(LeakageAuditError, match="cross_split_exact_duplicates"):
+        audit_source_records(records, report_path, skip_homology=True)
+
+    report = json.loads(report_path.read_text())
+    assert report["status"] == "failed"
+    assert report["exact_duplicates"]["count"] == 1
+    assert report["blocking_reasons"] == ["cross_split_exact_duplicates"]
+
+
+def _write_fake_mmseqs(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+def fasta(path):
+    records = []
+    name = None
+    sequence = []
+    for line in Path(path).read_text().splitlines():
+        if line.startswith('>'):
+            if name is not None:
+                records.append((name, ''.join(sequence)))
+            name = line[1:]
+            sequence = []
+        else:
+            sequence.append(line.strip())
+    if name is not None:
+        records.append((name, ''.join(sequence)))
+    return records
+
+command = sys.argv[1]
+if command == 'version':
+    print('fake-mmseqs-1.0')
+elif command == 'easy-cluster':
+    groups = {}
+    for name, sequence in fasta(sys.argv[2]):
+        groups.setdefault(sequence, []).append(name)
+    output = Path(sys.argv[3] + '_cluster.tsv')
+    output.write_text(''.join(
+        f'{members[0]}\\t{member}\\n'
+        for members in groups.values()
+        for member in members
+    ))
+elif command == 'easy-search':
+    queries = fasta(sys.argv[2])
+    targets = fasta(sys.argv[3])
+    rows = []
+    for query_id, query in queries:
+        if not targets:
+            continue
+        target_id, target = max(
+            targets,
+            key=lambda item: sum(a == b for a, b in zip(query, item[1])),
+        )
+        length = min(len(query), len(target))
+        identity = 100.0 * sum(a == b for a, b in zip(query, target)) / max(1, length)
+        rows.append(f'{query_id}\\t{target_id}\\t{identity}\\t{length}\\t{len(query)}\\t{len(target)}\\n')
+    Path(sys.argv[4]).write_text(''.join(rows))
+else:
+    raise SystemExit(f'unsupported command: {command}')
+"""
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_mmseqs_protein_cluster_violation_blocks_and_records_provenance(tmp_path):
+    executable = tmp_path / "mmseqs"
+    _write_fake_mmseqs(executable)
+    report_path = tmp_path / "leakage.json"
+    records = [
+        _record("train-synonym", "train", "ATGGCTGCTTAA"),
+        _record("test-synonym", "test", "ATGGCCGCCTAA"),
+        _record("val-unique", "val", "ATGAAACAATAA"),
+    ]
+
+    with pytest.raises(LeakageAuditError, match="cross_split_protein_clusters"):
+        audit_source_records(
+            records,
+            report_path,
+            executable=str(executable),
+            min_protein_identity=0.3,
+            min_coverage=0.8,
+        )
+
+    report = json.loads(report_path.read_text())
+    homology = report["protein_homology"]
+    assert report["status"] == "failed"
+    assert homology["tool"]["version"] == "fake-mmseqs-1.0"
+    assert homology["parameters"]["min_protein_identity"] == 0.3
+    assert homology["cross_split_cluster_count"] == 1
+    assert homology["cross_split_violations"][0]["source_ids"] == [
+        "test-synonym",
+        "train-synonym",
+    ]
+    assert homology["nearest_neighbors"]["protein"]["summary"]["count"] == 2
+
+
+def test_generated_audit_reports_nearest_identity_and_match_coverage(tmp_path):
+    executable = tmp_path / "mmseqs"
+    _write_fake_mmseqs(executable)
+    output = tmp_path / "generated_audit.json"
+
+    report = audit_generated_sequences(
+        [_record("train-a", "train", "ATGGCTGCTGCTTAA")],
+        [_record("generated-a", "generated", "ATGGCTGCTAAATAA")],
+        output,
+        nucleotide_window=6,
+        protein_window=2,
+        executable=str(executable),
+    )
+
+    record = report["records"][0]
+    assert output.exists()
+    assert report["tool"]["version"] == "fake-mmseqs-1.0"
+    assert record["nucleotide_nearest"]["target_id"] == "train-a"
+    assert record["protein_nearest"]["target_id"] == "train-a"
+    assert 0.0 < record["nucleotide_training_match_coverage"] <= 1.0
+    assert 0.0 < record["protein_training_match_coverage"] <= 1.0


### PR DESCRIPTION
## Summary
- hash normalized full CDS records before tokenization and block cross-split exact duplicates
- require a reproducible MMseqs2 protein-cluster audit for scientific global preparation
- record thresholds, commands, tool version, offending source IDs, cluster counts, and held-out nearest-neighbor identity artifacts
- make legacy packed duplicate checks fatal when invoked by the legacy preparation path
- add generated-CDS nucleotide/protein nearest-neighbor and training-substring coverage reports
- mark every explicit audit override as non-scientific in the manifest

## Validation
- `pytest -q -m "not slow and not external and not mps"` (209 passed, 1 skipped, 1 xpassed)
- focused leakage/global/generation tests (32 passed)
- `ruff check . --select E9,F63,F7,F82`
- `git diff --check`

The MMseqs integration is exercised with a deterministic CLI fixture in CI; this machine did not have a real MMseqs2 binary installed before the environment dependency was added.

Closes #77