### PR TITLE
Abort and checkpoint nonfinite accumulation groups

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -24,7 +24,7 @@ is lost or duplicated, and every derived fragment/chunk retains its source split
 ## Phase 3: Enforce Leakage and Training Correctness
 - [x] Fail preparation on cross-split exact duplicates and disallowed protein
   homology; record offending IDs, thresholds, commands, and tool versions (#77).
-- [ ] Abort and clear an accumulation group after any non-finite loss, preserving
+- [x] Abort and clear an accumulation group after any non-finite loss, preserving
   correct optimizer/scheduler/resume counters (#83).
 - [ ] Apply configured attention dropout consistently in SDPA and manual paths (#81).
 - [ ] Resolve new-run vocabulary exclusively from the tokenizer artifact and fail on

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -45,7 +45,7 @@ freeze gate passes.
 - [x] #80: ambiguous-codon boundary preservation and fragment provenance.
 - [x] #78: lossless long-gene chunking and explicit packing boundaries.
 - [x] #77: preventive exact-duplicate and protein-homology leakage audits.
-- [ ] #83: abort and clear non-finite gradient-accumulation groups.
+- [x] #83: abort and clear non-finite gradient-accumulation groups.
 - [ ] #81: correct attention-dropout behavior in all attention paths.
 - [ ] #84: tokenizer artifact as the vocabulary source of truth.
 - [ ] #86: causal embedding extraction provenance and unsafe-fallback removal.

--- a/configs/codon_lm_example.yaml
+++ b/configs/codon_lm_example.yaml
@@ -65,6 +65,7 @@ warmup_steps: 100           # Number of linear warmup steps for the learning rat
 # ---------------------------------------------------------------------
 batch_size: 4               # Physical batch size per GPU/device step
 grad_accum_steps: 16        # Gradient accumulation steps (Simulates Batch Size = batch_size * grad_accum_steps)
+max_nonfinite_accumulation_groups: 3 # Abort corrupt groups; fail when more than this many have occurred (0 = immediate, -1 = unlimited)
 epochs: 10                  # Total training epochs
 early_stop_patience: 3      # Stop training if validation loss does not improve for this many epochs
 max_time_minutes: 360       # Bounded wall-time limit. Saves checkpoint and exits gracefully if limit is reached mid-epoch

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -67,6 +67,7 @@ You can configure training runs using YAML files under `configs/`. Complete temp
 *   **Training Loops:**
     *   `batch_size`: Physical batch size per device step.
     *   `grad_accum_steps`: Accumulate gradients over this many steps to simulate large batch sizes.
+    *   `max_nonfinite_accumulation_groups`: Maximum number of training accumulation groups that may be aborted after a non-finite loss (default `3`). `0` fails on the first group; `-1` explicitly disables the limit. An abort clears all active gradients, discards the incomplete group, does not advance optimizer or scheduler steps, and is recorded in checkpoints and run metrics.
     *   `early_stop_patience`: Stop training after this many epochs without validation loss improvements.
     *   `max_time_minutes`: Limit training run duration. Saves checkpoint and exits gracefully if exceeded.
     *   `batch_optimizer`: Optional section for benchmarking `batch_size` / `grad_accum_steps` candidates before a long run.

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -6,6 +6,7 @@ import csv
 import json
 import logging
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 import torch
 import torch.nn as nn
@@ -44,6 +45,65 @@ from src.codonlm.training.objectives import (
 
 RUN_ID_ENV = "RUN_ID"
 PAD_ID = 0
+
+
+class NonfiniteGroupLimitError(RuntimeError):
+    """Raised when aborted accumulation groups exceed the configured tolerance."""
+
+
+@dataclass
+class AccumulationHealth:
+    """Checkpointable counters for gradient-accumulation group integrity."""
+
+    active_microbatches: int = 0
+    nonfinite_microbatches: int = 0
+    aborted_groups: int = 0
+    discarded_finite_microbatches: int = 0
+
+    def record_finite_microbatch(self) -> None:
+        self.active_microbatches += 1
+
+    def complete_group(self) -> None:
+        if self.active_microbatches <= 0:
+            raise ValueError("cannot complete an empty accumulation group")
+        self.active_microbatches = 0
+
+    def abort_group(self, optimizer) -> int:
+        discarded = self.active_microbatches
+        optimizer.zero_grad(set_to_none=True)
+        self.nonfinite_microbatches += 1
+        self.aborted_groups += 1
+        self.discarded_finite_microbatches += discarded
+        self.active_microbatches = 0
+        return discarded
+
+    def exceeds_limit(self, max_aborted_groups: int) -> bool:
+        if max_aborted_groups < 0:
+            return False
+        return self.aborted_groups > max_aborted_groups
+
+    def state_dict(self) -> dict[str, int]:
+        state = self.metrics_dict()
+        # Gradients are not checkpointed; resume replays from the last resolved group.
+        state["active_microbatches"] = 0
+        return state
+
+    def metrics_dict(self) -> dict[str, int]:
+        return {
+            "active_microbatches": self.active_microbatches,
+            "nonfinite_microbatches": self.nonfinite_microbatches,
+            "aborted_groups": self.aborted_groups,
+            "discarded_finite_microbatches": self.discarded_finite_microbatches,
+        }
+
+    def load_state_dict(self, state: dict | None) -> None:
+        state = state or {}
+        self.active_microbatches = 0
+        self.nonfinite_microbatches = int(state.get("nonfinite_microbatches", 0))
+        self.aborted_groups = int(state.get("aborted_groups", 0))
+        self.discarded_finite_microbatches = int(
+            state.get("discarded_finite_microbatches", 0)
+        )
 
 
 def _average_accumulated_gradients(parameters, microbatch_count: int) -> None:
@@ -201,6 +261,7 @@ def run_training(cfg: dict, args) -> None:
     outdir = cfg["out_dir"]
     scores_base = cfg.get("scores_dir", "outputs/scores")
     ckpt_dir, scores_dir = _prepare_output_dirs(outdir, scores_base, run_id)
+    accumulation_health = AccumulationHealth()
 
     shutil.copy2(args.config, ckpt_dir / "config.yaml")
     run_logger = RunLogger(ckpt_dir.parent / "logs" / "train.log")
@@ -212,6 +273,7 @@ def run_training(cfg: dict, args) -> None:
             "status": "failed",
             "error_type": type(exc).__name__,
             "error": str(exc),
+            "accumulation_health": accumulation_health.metrics_dict(),
             "model_spec": {},
         }
         write_meta(ckpt_dir, meta)
@@ -477,6 +539,9 @@ def run_training(cfg: dict, args) -> None:
         scheduler_name = "cosine"
 
     gacc = cfg.get("grad_accum_steps", 16)
+    max_nonfinite_groups = int(cfg.get("max_nonfinite_accumulation_groups", 3))
+    if max_nonfinite_groups < -1:
+        raise ValueError("max_nonfinite_accumulation_groups must be -1 or greater")
     warmup_steps = int(cfg.get("warmup_steps", 200))
     min_lr = float(cfg.get("min_lr", 1e-5))
     base_lr = float(cfg["lr"])
@@ -581,6 +646,9 @@ def run_training(cfg: dict, args) -> None:
             best_epoch = ckpt_resume.get("best_epoch", best_epoch)
             no_improve = int(ckpt_resume.get("no_improve", no_improve))
             resume_microbatch_idx = int(ckpt_resume.get("epoch_microbatch_idx", 0) or 0)
+            accumulation_health.load_state_dict(
+                ckpt_resume.get("accumulation_health")
+            )
             checkpoint_batch_size = ckpt_resume.get("batch_size")
             checkpoint_grad_accum = ckpt_resume.get("grad_accum_steps")
             if checkpoint_batch_size is not None and int(checkpoint_batch_size) != int(cfg["batch_size"]):
@@ -644,6 +712,8 @@ def run_training(cfg: dict, args) -> None:
                 "grad_accum_steps": int(gacc),
                 "train_examples": int(len(train_ds)),
                 "train_batches": int(len(train_loader)),
+                "accumulation_health": accumulation_health.state_dict(),
+                "max_nonfinite_accumulation_groups": max_nonfinite_groups,
             }
             if use_shape_guidance and encoder is not None:
                 payload["encoder"] = encoder.state_dict()
@@ -666,8 +736,8 @@ def run_training(cfg: dict, args) -> None:
             offset_totals = {offset: 0.0 for offset in multi_offset_weights}
             offset_counts = {offset: 0 for offset in multi_offset_weights}
             optim.zero_grad(set_to_none=True)
-            accumulated_microbatches = 0
             skipped = 0
+            health_before = accumulation_health.state_dict()
             start_time = time.perf_counter()
             if split == "train" and skip_microbatches > 0:
                 print(f"[resume] skipping {skip_microbatches}/{len(loader)} already-applied train microbatches")
@@ -761,6 +831,7 @@ def run_training(cfg: dict, args) -> None:
                             pg["lr"] = base_lr * scale
                     optim.step()
                     optim.zero_grad(set_to_none=True)
+                    accumulation_health.complete_group()
                     step += 1
                     current_resume_microbatch_idx = batch_idx + 1
                     if use_cosine:
@@ -781,13 +852,25 @@ def run_training(cfg: dict, args) -> None:
                     loss, next_loss, offset_losses, term_loss, replay_loss = fwd()
                 if not torch.isfinite(loss):
                     skipped += 1
+                    if split == "train":
+                        discarded = accumulation_health.abort_group(optim)
+                        current_resume_microbatch_idx = batch_idx + 1
+                        print(
+                            "[train] aborted nonfinite accumulation group "
+                            f"at microbatch={batch_idx + 1}; discarded_finite_microbatches={discarded} "
+                            f"aborted_groups={accumulation_health.aborted_groups}"
+                        )
+                        if accumulation_health.exceeds_limit(max_nonfinite_groups):
+                            raise NonfiniteGroupLimitError(
+                                "nonfinite accumulation groups exceeded configured maximum "
+                                f"{max_nonfinite_groups}: {accumulation_health.aborted_groups}"
+                            )
                     continue
                 if split=="train":
                     loss.backward()
-                    accumulated_microbatches += 1
-                    if accumulated_microbatches == gacc:
-                        step_optimizer(accumulated_microbatches)
-                        accumulated_microbatches = 0
+                    accumulation_health.record_finite_microbatch()
+                    if accumulation_health.active_microbatches == gacc:
+                        step_optimizer(accumulation_health.active_microbatches)
                         if split == "train" and periodic_ckpt.should_save(step):
                             save_last_checkpoint(epoch_idx, reason="periodic")
                 total += loss.item()
@@ -804,12 +887,17 @@ def run_training(cfg: dict, args) -> None:
                 n += 1
                 wall_timer.check()
             
-            if split == "train" and accumulated_microbatches:
-                step_optimizer(accumulated_microbatches)
+            if split == "train" and accumulation_health.active_microbatches:
+                step_optimizer(accumulation_health.active_microbatches)
 
             offset_avgs = {
                 offset: (offset_totals[offset] / max(offset_counts[offset], 1))
                 for offset in offset_totals
+            }
+            health_after = accumulation_health.state_dict()
+            health_delta = {
+                key: health_after[key] - health_before[key]
+                for key in health_after
             }
             return (
                 total / max(n, 1),
@@ -818,6 +906,7 @@ def run_training(cfg: dict, args) -> None:
                 (replay_total / max(replay_count, 1)) if replay_loss_enabled and split == "train" else None,
                 skipped,
                 offset_avgs,
+                health_delta,
             )
 
         history = []
@@ -856,14 +945,14 @@ def run_training(cfg: dict, args) -> None:
             epoch_idx = epoch + 1
             skip_for_epoch = resume_microbatch_idx if epoch == start_epoch else 0
             resume_microbatch_idx = 0
-            train_loss, train_next_loss, train_term_loss, train_replay_term_loss, train_skips, train_offsets = one_pass(
+            train_loss, train_next_loss, train_term_loss, train_replay_term_loss, train_skips, train_offsets, train_health = one_pass(
                 "train",
                 train_loader,
                 epoch_idx,
                 skip_microbatches=skip_for_epoch,
             )
             with torch.no_grad():
-                val_loss, val_next_loss, val_term_loss, _, val_skips, val_offsets = one_pass("val", val_loader, epoch_idx)
+                val_loss, val_next_loss, val_term_loss, _, val_skips, val_offsets, _ = one_pass("val", val_loader, epoch_idx)
             ppl = math.exp(min(20.0, val_next_loss))
             if not use_cosine:
                 scheduler.step(val_loss)
@@ -874,6 +963,12 @@ def run_training(cfg: dict, args) -> None:
             )
             if train_skips or val_skips:
                 msg += f" | skips train={train_skips} val={val_skips}"
+            if train_health["aborted_groups"]:
+                msg += (
+                    " | aborted_groups="
+                    f"{train_health['aborted_groups']} discarded_finite_microbatches="
+                    f"{train_health['discarded_finite_microbatches']}"
+                )
             if multi_offset_weights:
                 offset_msg = " ".join(
                     f"o{offset}:train={train_offsets.get(offset, 0.0):.3f}/val={val_offsets.get(offset, 0.0):.3f}"
@@ -946,6 +1041,11 @@ def run_training(cfg: dict, args) -> None:
                 "train_replay_term_loss": train_replay_term_loss,
                 "perplexity": ppl,
                 "lr": lr_now,
+                "nonfinite_microbatches": train_health["nonfinite_microbatches"],
+                "aborted_accumulation_groups": train_health["aborted_groups"],
+                "discarded_finite_microbatches": train_health[
+                    "discarded_finite_microbatches"
+                ],
             })
 
             if improved:
@@ -953,6 +1053,15 @@ def run_training(cfg: dict, args) -> None:
             elif no_improve >= int(cfg.get("early_stop_patience", 5)):
                 print("[early-stopping] no improvement; stopping.")
                 break
+    except NonfiniteGroupLimitError as exc:
+        ckpt_payload = make_checkpoint_payload(current_epoch_idx or (start_epoch + 1))
+        ckpt_payload["checkpoint_reason"] = "nonfinite_group_limit"
+        save_checkpoint_atomic(ckpt_payload, ckpt_dir / "last.pt")
+        print(
+            f"[checkpoint] saved {ckpt_dir / 'last.pt'} after nonfinite-group limit"
+        )
+        write_failure_meta(exc)
+        raise
     except WallTimeLimitException:
         print(f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.")
         ckpt_payload = make_checkpoint_payload(current_epoch_idx or (start_epoch + 1))
@@ -971,6 +1080,7 @@ def run_training(cfg: dict, args) -> None:
             "best_epoch": best_epoch,
             "best_val_loss": float(best) if best != float("inf") else None,
             "status": "stopped",
+            "accumulation_health": accumulation_health.state_dict(),
             "model_spec": model.to_dict() if hasattr(model, "to_dict") else {}
         }
 
@@ -1049,6 +1159,7 @@ def run_training(cfg: dict, args) -> None:
         "best_epoch": best_epoch,
         "best_val_loss": float(best) if best != float("inf") else None,
         "status": "completed",
+        "accumulation_health": accumulation_health.state_dict(),
         "model_spec": model.to_dict() if hasattr(model, "to_dict") else {}
     }
 

--- a/tests/test_nonfinite_accumulation.py
+++ b/tests/test_nonfinite_accumulation.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import yaml
+
+from src.codonlm.model_tiny_gpt import TinyGPT
+from src.codonlm.training.loop import NonfiniteGroupLimitError, run_training
+
+
+def _config(tmp_path, *, max_nonfinite_groups: int) -> dict:
+    return {
+        "vocab_size": 69,
+        "block_size": 4,
+        "n_layer": 1,
+        "n_head": 1,
+        "n_embd": 8,
+        "dropout": 0.0,
+        "batch_size": 1,
+        "grad_accum_steps": 2,
+        "max_nonfinite_accumulation_groups": max_nonfinite_groups,
+        "lr": 0.001,
+        "min_lr": 0.0001,
+        "weight_decay": 0.0,
+        "warmup_steps": 0,
+        "epochs": 1,
+        "optimizer": "adamw",
+        "amp": False,
+        "use_checkpoint": False,
+        "scheduler": "cosine",
+        "early_stop_patience": 2,
+        "out_dir": str(tmp_path / "unused-checkpoints"),
+        "scores_dir": str(tmp_path / "unused-scores"),
+        "seed": 42,
+        "num_workers": 0,
+    }
+
+
+def _write_inputs(tmp_path, config: dict):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+    x_train = np.ones((5, 4), dtype=np.int32)
+    y_train = np.full((5, 4), 2, dtype=np.int32)
+    x_val = np.ones((2, 4), dtype=np.int32)
+    y_val = np.full((2, 4), 2, dtype=np.int32)
+    paths = {}
+    for name, x, y in (
+        ("train", x_train, y_train),
+        ("val", x_val, y_val),
+        ("test", x_val, y_val),
+    ):
+        path = tmp_path / f"{name}.npz"
+        np.savez_compressed(path, X=x, Y=y)
+        paths[name] = path
+    return config_path, paths
+
+
+def _args(config_path, paths, *, run_id: str, resume=None):
+    return SimpleNamespace(
+        config=str(config_path),
+        run_id=run_id,
+        resume=resume,
+        transfer_from=None,
+        train_npz=[str(paths["train"])],
+        val_npz=[str(paths["val"])],
+        test_npz=[str(paths["test"])],
+    )
+
+
+def test_nonfinite_abort_checkpoint_and_resume_preserve_step_counters(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config = _config(tmp_path, max_nonfinite_groups=0)
+    config_path, paths = _write_inputs(tmp_path, config)
+    original_forward = TinyGPT.forward
+    train_calls = 0
+
+    def fail_second_train_microbatch(self, *args, **kwargs):
+        nonlocal train_calls
+        result = original_forward(self, *args, **kwargs)
+        if self.training:
+            train_calls += 1
+            if train_calls == 2:
+                logits, loss = result
+                return logits, loss * torch.tensor(float("nan"), device=loss.device)
+        return result
+
+    monkeypatch.setattr(TinyGPT, "forward", fail_second_train_microbatch)
+    args = _args(config_path, paths, run_id="nonfinite-resume")
+
+    with pytest.raises(NonfiniteGroupLimitError):
+        run_training(dict(config), args)
+
+    checkpoint_path = tmp_path / "runs/nonfinite-resume/checkpoints/last.pt"
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    assert checkpoint["step"] == 0
+    assert checkpoint["scheduler"]["last_epoch"] == 0
+    assert checkpoint["epoch_microbatch_idx"] == 2
+    assert checkpoint["accumulation_health"] == {
+        "active_microbatches": 0,
+        "nonfinite_microbatches": 1,
+        "aborted_groups": 1,
+        "discarded_finite_microbatches": 1,
+    }
+
+    monkeypatch.setattr(TinyGPT, "forward", original_forward)
+    resume_args = _args(
+        config_path,
+        paths,
+        run_id="nonfinite-resume",
+        resume=str(checkpoint_path),
+    )
+    run_training(dict(config), resume_args)
+
+    resumed = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    assert resumed["step"] == 2
+    assert resumed["scheduler"]["last_epoch"] == 2
+    assert resumed["epoch_microbatch_idx"] == 0
+    assert resumed["accumulation_health"]["aborted_groups"] == 1
+    assert resumed["accumulation_health"]["discarded_finite_microbatches"] == 1

--- a/tests/test_trainer_utils.py
+++ b/tests/test_trainer_utils.py
@@ -1,11 +1,16 @@
 import inspect
 
 import numpy as np
+import pytest
 import torch
 
 from src.codonlm.data_loading import PackedDataset
 from src.codonlm.training.config import _ensure_path_list
-from src.codonlm.training.loop import _average_accumulated_gradients, run_training
+from src.codonlm.training.loop import (
+    AccumulationHealth,
+    _average_accumulated_gradients,
+    run_training,
+)
 
 
 def test_ensure_path_list_from_string():
@@ -85,3 +90,70 @@ def test_average_accumulated_gradients_matches_mean_loss():
 
 def test_training_loop_does_not_clear_mps_cache_on_happy_path():
     assert "empty_cache" not in inspect.getsource(run_training)
+
+
+@pytest.mark.parametrize(
+    ("group_size", "nonfinite_position", "discarded"),
+    [
+        pytest.param(4, 0, 0, id="full-first"),
+        pytest.param(4, 2, 2, id="full-middle"),
+        pytest.param(4, 3, 3, id="full-final"),
+        pytest.param(2, 0, 0, id="remainder-first"),
+        pytest.param(2, 1, 1, id="remainder-final"),
+    ],
+)
+def test_nonfinite_position_aborts_entire_group(
+    group_size, nonfinite_position, discarded
+):
+    parameter = torch.nn.Parameter(torch.tensor(1.0))
+    optimizer = torch.optim.SGD([parameter], lr=1.0)
+    health = AccumulationHealth()
+
+    for _ in range(nonfinite_position):
+        parameter.backward()
+        health.record_finite_microbatch()
+
+    assert health.abort_group(optimizer) == discarded
+    assert parameter.grad is None
+    assert health.active_microbatches == 0
+    assert health.aborted_groups == 1
+    assert health.nonfinite_microbatches == 1
+    assert health.discarded_finite_microbatches == discarded
+
+    # A later complete group must contain only its own gradients.
+    for _ in range(group_size):
+        parameter.backward()
+        health.record_finite_microbatch()
+    _average_accumulated_gradients([parameter], group_size)
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+    health.complete_group()
+    assert parameter.item() == pytest.approx(0.0)
+
+
+def test_accumulation_health_resume_preserves_counters_but_not_active_gradients():
+    parameter = torch.nn.Parameter(torch.tensor(1.0))
+    optimizer = torch.optim.SGD([parameter], lr=0.1)
+    health = AccumulationHealth()
+    parameter.backward()
+    health.record_finite_microbatch()
+    health.abort_group(optimizer)
+
+    resumed = AccumulationHealth()
+    resumed.load_state_dict(health.state_dict())
+
+    assert resumed.active_microbatches == 0
+    assert resumed.nonfinite_microbatches == 1
+    assert resumed.aborted_groups == 1
+    assert resumed.discarded_finite_microbatches == 1
+    assert parameter.grad is None
+
+
+def test_nonfinite_group_limit_counts_only_aborted_groups():
+    health = AccumulationHealth(aborted_groups=2)
+
+    assert not health.exceeds_limit(2)
+    health.aborted_groups += 1
+    assert health.exceeds_limit(2)
+    assert health.exceeds_limit(0)
+    assert not health.exceeds_limit(-1)


### PR DESCRIPTION
## Summary
- clear all active gradients and reset accumulation state when a training loss is non-finite
- advance resume position past resolved aborted groups without advancing optimizer, scheduler, warmup, or successful-step counters
- checkpoint cumulative non-finite microbatch, aborted-group, and discarded-finite-microbatch metrics
- stop after a configurable number of aborted groups and save `last.pt` before failing
- preserve counters and correct group replay semantics across checkpoint/resume

## Threshold semantics
- `max_nonfinite_accumulation_groups: 0`: fail on the first aborted group
- positive value: tolerate that many aborted groups, fail on the next
- `-1`: explicitly disable the failure limit

## Validation
- `pytest -q -m "not slow and not external and not mps"` (217 passed, 1 skipped, 1 xpassed)
- position tests cover first/middle/final failures in full and remainder groups
- trainer integration test verifies abort checkpoint step/scheduler counters and resume cursor
- `ruff check . --select E9,F63,F7,F82`
- `git diff --check`

Closes #83