### PR TITLE
Apply configured attention dropout consistently

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -26,7 +26,7 @@ is lost or duplicated, and every derived fragment/chunk retains its source split
   homology; record offending IDs, thresholds, commands, and tool versions (#77).
 - [x] Abort and clear an accumulation group after any non-finite loss, preserving
   correct optimizer/scheduler/resume counters (#83).
-- [ ] Apply configured attention dropout consistently in SDPA and manual paths (#81).
+- [x] Apply configured attention dropout consistently in SDPA and manual paths (#81).
 - [ ] Resolve new-run vocabulary exclusively from the tokenizer artifact and fail on
   dataset, config, or checkpoint mismatch (#84).
 - [ ] Run CPU integration tests and MPS smoke train/save/resume tests on the corrected

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -46,7 +46,7 @@ freeze gate passes.
 - [x] #78: lossless long-gene chunking and explicit packing boundaries.
 - [x] #77: preventive exact-duplicate and protein-homology leakage audits.
 - [x] #83: abort and clear non-finite gradient-accumulation groups.
-- [ ] #81: correct attention-dropout behavior in all attention paths.
+- [x] #81: correct attention-dropout behavior in all attention paths.
 - [ ] #84: tokenizer artifact as the vocabulary source of truth.
 - [ ] #86: causal embedding extraction provenance and unsafe-fallback removal.
 - [ ] #82: format-aware, vocabulary-safe perplexity baselines.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -43,7 +43,7 @@ You can configure training runs using YAML files under `configs/`. Complete temp
     *   `n_layer`: Number of transformer blocks (e.g., 6 or 10).
     *   `n_head`: Number of self-attention heads (must divide `n_embd`).
     *   `n_embd`: Hidden state embedding dimension size (e.g., 256).
-    *   `dropout`: Dropout probability applied to projections and embeddings.
+    *   `dropout`: Dropout probability applied to projections, embeddings, MLP layers, and attention probabilities during training. Attention dropout is disabled automatically in evaluation mode and is applied consistently by SDPA and manual attention. Runs created before the #81 correction did not apply attention-probability dropout even when this value was nonzero, so enabling the corrected behavior changes new-run training semantics without changing checkpoint keys.
     *   `label_smoothing`: Epsilon smoothing factor for CrossEntropyLoss.
     *   `use_checkpoint`: Enable activation gradient checkpointing (saves GPU RAM).
     *   `use_sdpa`: Use PyTorch's native Scaled Dot Product Attention for speedups.

--- a/src/codonlm/model_tiny_gpt.py
+++ b/src/codonlm/model_tiny_gpt.py
@@ -101,22 +101,32 @@ class CausalSelfAttention(nn.Module):
 
         base = self.mask[:,:,:T,:T]
         if self.use_sdpa and hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+            attention_dropout = self.dropout.p if self.training else 0.0
             if attn_mask is not None:
                 attn_mask_bool = (attn_mask > 0)
+                if attn_mask_bool.ndim == 2:
+                    attn_mask_bool = attn_mask_bool.unsqueeze(0).unsqueeze(0)
+                elif attn_mask_bool.ndim == 3:
+                    attn_mask_bool = attn_mask_bool.unsqueeze(1)
                 mask = attn_mask_bool.expand(B, self.n_head, T, T)
-                y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)
+                y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=attention_dropout, is_causal=False)
             else:
-                y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=None, dropout_p=0.0, is_causal=True)
+                y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=None, dropout_p=attention_dropout, is_causal=True)
             y = y.transpose(1,2).contiguous().view(B, T, C)
         else:
             att = (q @ k.transpose(-2,-1)) / math.sqrt(k.size(-1))
             if attn_mask is not None:
                 attn_mask_bool = (attn_mask > 0)
+                if attn_mask_bool.ndim == 2:
+                    attn_mask_bool = attn_mask_bool.unsqueeze(0).unsqueeze(0)
+                elif attn_mask_bool.ndim == 3:
+                    attn_mask_bool = attn_mask_bool.unsqueeze(1)
                 att = att.masked_fill(~attn_mask_bool, float('-inf'))
             else:
                 att = att.masked_fill(base==0, float('-inf'))
             att = torch.softmax(att, dim=-1)
             self.last_attn = att.detach()
+            att = self.dropout(att)
             y = att @ v
             y = y.transpose(1,2).contiguous().view(B, T, C)
         return self.proj(y)

--- a/tests/test_attention_dropout.py
+++ b/tests/test_attention_dropout.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.codonlm.model_tiny_gpt import CausalSelfAttention
+
+
+def _attention(*, use_sdpa: bool, dropout: float = 0.4) -> CausalSelfAttention:
+    return CausalSelfAttention(
+        n_embd=8,
+        n_head=2,
+        dropout=dropout,
+        block_size=6,
+        use_sdpa=use_sdpa,
+    )
+
+
+@pytest.mark.parametrize("explicit_mask", [False, True])
+def test_sdpa_uses_configured_dropout_only_during_training(
+    monkeypatch, explicit_mask
+):
+    original = torch.nn.functional.scaled_dot_product_attention
+    observed = []
+
+    def capture(*args, **kwargs):
+        observed.append((kwargs["dropout_p"], kwargs["is_causal"]))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(torch.nn.functional, "scaled_dot_product_attention", capture)
+    attention = _attention(use_sdpa=True)
+    x = torch.randn(1, 6, 8)
+    mask = torch.tril(torch.ones(1, 6, 6, dtype=torch.bool)) if explicit_mask else None
+
+    attention.train()
+    attention(x, attn_mask=mask)
+    attention.eval()
+    attention(x, attn_mask=mask)
+
+    assert observed == [(0.4, not explicit_mask), (0.0, not explicit_mask)]
+
+
+@pytest.mark.parametrize("explicit_mask", [False, True])
+def test_manual_and_sdpa_attention_are_equivalent_in_eval(explicit_mask):
+    manual = _attention(use_sdpa=False)
+    sdpa = _attention(use_sdpa=True)
+    sdpa.load_state_dict(manual.state_dict())
+    manual.eval()
+    sdpa.eval()
+    x = torch.randn(1, 6, 8)
+    mask = None
+    if explicit_mask:
+        mask = torch.tril(torch.ones(1, 6, 6, dtype=torch.bool))
+        mask[:, 4:, :3] = False
+
+    manual_output = manual(x, attn_mask=mask)
+    sdpa_output = sdpa(x, attn_mask=mask)
+
+    assert torch.allclose(manual_output, sdpa_output, atol=1e-6, rtol=1e-5)
+
+
+@pytest.mark.parametrize("use_sdpa", [False, True])
+@pytest.mark.parametrize("explicit_mask", [False, True])
+def test_attention_dropout_is_seeded_in_train_mode(use_sdpa, explicit_mask):
+    attention = _attention(use_sdpa=use_sdpa)
+    attention.train()
+    x = torch.randn(1, 6, 8)
+    mask = torch.tril(torch.ones(1, 6, 6, dtype=torch.bool)) if explicit_mask else None
+
+    torch.manual_seed(123)
+    first = attention(x, attn_mask=mask)
+    torch.manual_seed(123)
+    repeated = attention(x, attn_mask=mask)
+    torch.manual_seed(456)
+    different = attention(x, attn_mask=mask)
+
+    assert torch.equal(first, repeated)
+    assert not torch.equal(first, different)
+
+
+def test_attention_dropout_adds_no_checkpoint_state():
+    no_dropout = _attention(use_sdpa=False, dropout=0.0)
+    with_dropout = _attention(use_sdpa=False, dropout=0.4)
+
+    assert no_dropout.state_dict().keys() == with_dropout.state_dict().keys()


### PR DESCRIPTION
## Summary
- pass configured attention dropout to SDPA in training and force zero dropout in evaluation
- apply the same probability dropout to manual attention weights during training
- preserve pre-dropout `last_attn` values for interpretation
- normalize 2D/3D explicit masks before head broadcasting, avoiding batch/head shape coupling
- document that corrected nonzero attention dropout changes new-run training semantics without changing checkpoint keys

## Validation
- `pytest -q -m "not slow and not external and not mps"` (226 passed, 1 skipped, 1 xpassed)
- deterministic tests cover SDPA/manual, train/eval, causal-only, and explicit segment masks
- state-dict compatibility test confirms no new checkpoint keys
- `ruff check . --select E9,F63,F7,F82`
- `git diff --check`

Closes #81