### PR TITLE
Make tokenizer vocabulary authoritative for training

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -27,7 +27,7 @@ is lost or duplicated, and every derived fragment/chunk retains its source split
 - [x] Abort and clear an accumulation group after any non-finite loss, preserving
   correct optimizer/scheduler/resume counters (#83).
 - [x] Apply configured attention dropout consistently in SDPA and manual paths (#81).
-- [ ] Resolve new-run vocabulary exclusively from the tokenizer artifact and fail on
+- [x] Resolve new-run vocabulary exclusively from the tokenizer artifact and fail on
   dataset, config, or checkpoint mismatch (#84).
 - [ ] Run CPU integration tests and MPS smoke train/save/resume tests on the corrected
   representation.

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -47,7 +47,7 @@ freeze gate passes.
 - [x] #77: preventive exact-duplicate and protein-homology leakage audits.
 - [x] #83: abort and clear non-finite gradient-accumulation groups.
 - [x] #81: correct attention-dropout behavior in all attention paths.
-- [ ] #84: tokenizer artifact as the vocabulary source of truth.
+- [x] #84: tokenizer artifact as the vocabulary source of truth.
 - [ ] #86: causal embedding extraction provenance and unsafe-fallback removal.
 - [ ] #82: format-aware, vocabulary-safe perplexity baselines.
 - [ ] #88: grouped DNA-shape controls and local-sequence baselines.

--- a/configs/bench_b4_gqa4.yaml
+++ b/configs/bench_b4_gqa4.yaml
@@ -20,6 +20,6 @@ train_npz: data/processed/stage2.6_large_master_pack/train_bs512.npz
 use_checkpoint: true
 use_sdpa: true
 val_npz: data/processed/stage2.6_large_master_pack/val_bs512.npz
-vocab_size: 69
+vocab_size: 68
 warmup_steps: 100
 weight_decay: 0.05

--- a/configs/bench_b8_all.yaml
+++ b/configs/bench_b8_all.yaml
@@ -21,6 +21,6 @@ use_checkpoint: true
 use_mmap: true
 use_sdpa: true
 val_npz: data/processed/stage2.6_large_master_pack/val_bs512.npz
-vocab_size: 69
+vocab_size: 68
 warmup_steps: 100
 weight_decay: 0.05

--- a/configs/bench_b8_baseline.yaml
+++ b/configs/bench_b8_baseline.yaml
@@ -19,6 +19,6 @@ train_npz: data/processed/stage2.6_large_master_pack/train_bs512.npz
 use_checkpoint: true
 use_sdpa: true
 val_npz: data/processed/stage2.6_large_master_pack/val_bs512.npz
-vocab_size: 69
+vocab_size: 68
 warmup_steps: 100
 weight_decay: 0.05

--- a/configs/bench_b8_gqa2.yaml
+++ b/configs/bench_b8_gqa2.yaml
@@ -20,6 +20,6 @@ train_npz: data/processed/stage2.6_large_master_pack/train_bs512.npz
 use_checkpoint: true
 use_sdpa: true
 val_npz: data/processed/stage2.6_large_master_pack/val_bs512.npz
-vocab_size: 69
+vocab_size: 68
 warmup_steps: 100
 weight_decay: 0.05

--- a/configs/bench_b8_gqa4.yaml
+++ b/configs/bench_b8_gqa4.yaml
@@ -20,6 +20,6 @@ train_npz: data/processed/stage2.6_large_master_pack/train_bs512.npz
 use_checkpoint: true
 use_sdpa: true
 val_npz: data/processed/stage2.6_large_master_pack/val_bs512.npz
-vocab_size: 69
+vocab_size: 68
 warmup_steps: 100
 weight_decay: 0.05

--- a/configs/bench_b8_sep_off.yaml
+++ b/configs/bench_b8_sep_off.yaml
@@ -19,6 +19,6 @@ train_npz: data/processed/stage2.6_large_master_pack/train_bs512.npz
 use_checkpoint: true
 use_sdpa: true
 val_npz: data/processed/stage2.6_large_master_pack/val_bs512.npz
-vocab_size: 69
+vocab_size: 68
 warmup_steps: 100
 weight_decay: 0.05

--- a/configs/bench_gqa_only.yaml
+++ b/configs/bench_gqa_only.yaml
@@ -1,5 +1,5 @@
 # Isolate: only GQA (n_kv_head=2), all else same as baseline
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/bench_mmap_only.yaml
+++ b/configs/bench_mmap_only.yaml
@@ -1,5 +1,5 @@
 # Isolate: only mmap dataset, all else same as baseline
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/bench_sep_only.yaml
+++ b/configs/bench_sep_only.yaml
@@ -1,5 +1,5 @@
 # Isolate: only disable SEP mask (fused causal SDPA path)
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/codon_lm_example.yaml
+++ b/configs/codon_lm_example.yaml
@@ -7,7 +7,7 @@
 # ---------------------------------------------------------------------
 # Model Architecture Configuration
 # ---------------------------------------------------------------------
-vocab_size: 69              # Vocabulary size (64 codons + 5 special tokens: PAD, BOS, EOS, SEP, etc.)
+vocab_size: 68              # Must match itos_path: 64 codons + PAD, BOS, EOS, and SEP
 block_size: 512             # Context window receptive field length (number of codons)
 n_layer: 10                 # Number of transformer decoder blocks/layers
 n_head: 8                   # Number of self-attention heads (must divide n_embd)

--- a/configs/compare_m2_upgrade.yaml
+++ b/configs/compare_m2_upgrade.yaml
@@ -1,4 +1,4 @@
-vocab_size: 69
+vocab_size: 68
 
 block_size: 320 
 n_layer: 16 

--- a/configs/long_range_offsets_smoke.yaml
+++ b/configs/long_range_offsets_smoke.yaml
@@ -2,7 +2,7 @@
 # Uses the existing Stage 2.6 dynamic master pack and a small d384-compatible
 # run shape. For full runs, start from the latest backed-up Stage 2.6 checkpoint.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/m2_depth_upgrade.yaml
+++ b/configs/m2_depth_upgrade.yaml
@@ -1,4 +1,5 @@
 vocab_size: 68
+itos_path: "data/processed/itos_codon.txt"
 
 # Model depth/width
 n_layer: 16
@@ -41,4 +42,3 @@ out_dir: outputs/checkpoints
 scores_dir: outputs/scores
 log_csv: curves.csv
 seed: 1337
-

--- a/configs/m2_max_10L8H.yaml
+++ b/configs/m2_max_10L8H.yaml
@@ -3,7 +3,7 @@
 # To be deployed ONLY if Stage 2.5 Master fails the Termination Benchmark.
 
 # Model Architecture (Scale-up)
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10       # Increased from 6
 n_head: 8         # Increased from 4

--- a/configs/m4_high_capacity_spec.yaml
+++ b/configs/m4_high_capacity_spec.yaml
@@ -2,7 +2,8 @@
 # Optimized for 16GB Unified Memory (e.g. M4 Chip)
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
+itos_path: "data/processed/itos_codon.txt"
 block_size: 2048  # 4x increase; captures full operons + promoters
 n_layer: 12       # 2x depth
 n_head: 8         # 2x attention heads

--- a/configs/mps.yaml
+++ b/configs/mps.yaml
@@ -1,4 +1,4 @@
-vocab_size: 69
+vocab_size: 68
 
 block_size: 512 
 n_layer: 16 

--- a/configs/noprop_toy.yaml
+++ b/configs/noprop_toy.yaml
@@ -2,7 +2,8 @@
 # Minimal toy config for NoProp CPU verification
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
+itos_path: "data/processed/itos_codon.txt"
 block_size: 512
 n_layer: 2
 n_head: 2

--- a/configs/separate_heads_full.yaml
+++ b/configs/separate_heads_full.yaml
@@ -1,7 +1,7 @@
 # Configuration for the Full Separate Heads Multi-Offset CodonLM run.
 # Transfers from the Stage 2.6 checkpoint and trains the projection heads over 2 epochs.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/separate_heads_mlp_frozen.yaml
+++ b/configs/separate_heads_mlp_frozen.yaml
@@ -1,7 +1,7 @@
 # Configuration for the Non-Linear Offset MLP Heads with Backbone Freezing.
 # Freezes the pre-trained transformer layers and next-token head, and trains 2-layer MLP projections.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/separate_heads_mlp_replay.yaml
+++ b/configs/separate_heads_mlp_replay.yaml
@@ -1,7 +1,7 @@
 # Generated-prefix replay correction for the 69-token MLP priors model.
 # Trains from the dated termination pre-trained checkpoint.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/separate_heads_mlp_replay_d512.yaml
+++ b/configs/separate_heads_mlp_replay_d512.yaml
@@ -1,6 +1,6 @@
 # Generated-prefix replay correction for the 69-token MLP priors model (d512 upscaled).
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/separate_heads_mlp_termination.yaml
+++ b/configs/separate_heads_mlp_termination.yaml
@@ -1,7 +1,7 @@
 # Training configuration to pre-train the termination head on the 69-token codon-only model.
 # Transfers weights from our best MLP prior checkpoint and trains the new termination auxiliary head.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/separate_heads_v2.yaml
+++ b/configs/separate_heads_v2.yaml
@@ -1,7 +1,7 @@
 # Configuration for the x=[2, 8, 16, 32] Separate Heads run.
 # Transfers from the 2-epoch separate heads run checkpoint and introduces the x=2 strand target.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage2.5_10L8H_d384_transfer.yaml
+++ b/configs/stage2.5_10L8H_d384_transfer.yaml
@@ -2,7 +2,7 @@
 # Transfers weights from 6L4H_d384_e5 to scale up depth and heads while preserving biological features
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage2.5_6L4H_d384_transfer.yaml
+++ b/configs/stage2.5_6L4H_d384_transfer.yaml
@@ -2,7 +2,7 @@
 # Transfers weights from 4L2H_d384 to preserve learned biological features (e.g. positive synonymous gap)
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 6
 n_head: 4

--- a/configs/stage2.5_6L4H_dynamic.yaml
+++ b/configs/stage2.5_6L4H_dynamic.yaml
@@ -3,7 +3,7 @@
 # Can be used as a transfer learning source for 8L4H_d256 later.
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 6
 n_head: 4

--- a/configs/stage2.5_d384_dynamic.yaml
+++ b/configs/stage2.5_d384_dynamic.yaml
@@ -2,7 +2,7 @@
 # Designed to verify stop codon / termination learning at larger embedding dimension
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 4
 n_head: 2

--- a/configs/stage2.5_extended.yaml
+++ b/configs/stage2.5_extended.yaml
@@ -1,7 +1,7 @@
 # Stage 2.5: Extended Master Genomic Architect
 # Deep Polishing: Lower LR, Extended Patience
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 6
 n_head: 4

--- a/configs/stage2.5_master.yaml
+++ b/configs/stage2.5_master.yaml
@@ -2,7 +2,7 @@
 # Optimized for M2/8GB RAM (Turbo Attention enabled)
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 6
 n_head: 4

--- a/configs/stage2.5_resume30.yaml
+++ b/configs/stage2.5_resume30.yaml
@@ -1,7 +1,7 @@
 # Stage 2.5: Resume to 30 Epochs (10 + 12 + 8)
 # Deep Polishing: Lower LR, Extended Patience, Epoch Checkpoints Enabled
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 6
 n_head: 4

--- a/configs/stage2.5_small_control.yaml
+++ b/configs/stage2.5_small_control.yaml
@@ -1,5 +1,5 @@
 # Config for Small CodonLM control training (absolute position embeddings + standard GELU FFN)
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 4
 n_head: 2

--- a/configs/stage2.5_small_dynamic.yaml
+++ b/configs/stage2.5_small_dynamic.yaml
@@ -2,7 +2,7 @@
 # Designed to verify stop codon / termination learning from scratch
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 4
 n_head: 2

--- a/configs/stage2.5_small_rope.yaml
+++ b/configs/stage2.5_small_rope.yaml
@@ -1,5 +1,5 @@
 # Config for Small CodonLM rope + standard GELU FFN training
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 4
 n_head: 2

--- a/configs/stage2.5_small_rope_swiglu.yaml
+++ b/configs/stage2.5_small_rope_swiglu.yaml
@@ -1,5 +1,5 @@
 # Config for Small CodonLM rope + swiglu training
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 4
 n_head: 2

--- a/configs/stage2.5_small_swiglu.yaml
+++ b/configs/stage2.5_small_swiglu.yaml
@@ -1,5 +1,5 @@
 # Config for Small CodonLM absolute position + swiglu training
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 4
 n_head: 2

--- a/configs/stage2.5_transfer_10L8H.yaml
+++ b/configs/stage2.5_transfer_10L8H.yaml
@@ -3,7 +3,7 @@
 # Uses n_embd=256 to allow direct parameter alignment for transfer learning from 6L4H_d256.
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage2.6_large_scaling.yaml
+++ b/configs/stage2.6_large_scaling.yaml
@@ -2,7 +2,7 @@
 # Transfers weights from 6L4H_d384_e5 to scale up depth and heads while preserving biological features
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage2.6_mps_optimized.yaml
+++ b/configs/stage2.6_mps_optimized.yaml
@@ -14,7 +14,7 @@
 # DO NOT use sep_mask_enabled=false on MPS (Metal is_causal kernel is slower).
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage2.6_optimized.yaml
+++ b/configs/stage2.6_optimized.yaml
@@ -3,7 +3,7 @@
 # Based on: configs/stage2.6_large_scaling.yaml
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage2_deep.yaml
+++ b/configs/stage2_deep.yaml
@@ -2,7 +2,7 @@
 # 6 Layers for higher capacity on diverse bacterial taxa
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 256
 n_layer: 6       # Increased from 4
 n_head: 4        # Increased from 2

--- a/configs/stage2_diverse.yaml
+++ b/configs/stage2_diverse.yaml
@@ -2,7 +2,7 @@
 # Fine-tuning from Enterobacteriaceae pre-trained weights
 
 # Model Architecture (must match pre-trained weights)
-vocab_size: 69
+vocab_size: 68
 block_size: 256
 n_layer: 4
 n_head: 2

--- a/configs/stage2_long_context.yaml
+++ b/configs/stage2_long_context.yaml
@@ -2,7 +2,7 @@
 # 512 Codons to capture entire genes and improve termination logic
 
 # Model Architecture
-vocab_size: 69
+vocab_size: 68
 block_size: 512  # Doubled from 256
 n_layer: 6
 n_head: 4

--- a/configs/stage3_structured_pdb_finetune.yaml
+++ b/configs/stage3_structured_pdb_finetune.yaml
@@ -5,7 +5,7 @@
 # the subset first with scripts/filter_cds_by_pdb.py, then tokenize/pack it with
 # the existing codon_tokenize.py and build_dataset.py utilities.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/stage3_structured_pdb_replay_finetune.yaml
+++ b/configs/stage3_structured_pdb_replay_finetune.yaml
@@ -1,7 +1,7 @@
 # Stage 3 — PDB-Filtered Structural Fine-Tuning with MLP Prior + Replay.
 # Fine-tunes the latest best 69-token model on the high-confidence bacteria structural subset.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/termination_aux_smoke.yaml
+++ b/configs/termination_aux_smoke.yaml
@@ -2,7 +2,7 @@
 # Starts from the latest backed-up Stage 2.6 checkpoint and adds a supervised
 # distance-to-stop signal while keeping the main CodonLM objective intact.
 
-vocab_size: 69
+vocab_size: 68
 block_size: 512
 n_layer: 10
 n_head: 8

--- a/configs/tiny_mps.yaml
+++ b/configs/tiny_mps.yaml
@@ -1,4 +1,4 @@
-vocab_size: 69
+vocab_size: 68
 
 block_size: 512 
 n_layer: 8 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -38,7 +38,8 @@ A compact codon‑level GPT‑style LM with a reproducible training + analysis p
 You can configure training runs using YAML files under `configs/`. Complete template configurations are available at [codon_lm_example.yaml](file:///Users/User/github/genomics-lm/configs/codon_lm_example.yaml) and [protein_lm_example.yaml](file:///Users/User/github/genomics-lm/configs/protein_lm_example.yaml). Supported keys include:
 
 *   **Model Architecture:**
-    *   `vocab_size`: Size of vocabulary (usually 69 for CodonLM, containing 64 codons and 5 specials).
+    *   `vocab_size`: Declared vocabulary size. It must match the tokenizer artifact exactly; the base CodonLM vocabulary has 68 entries (64 codons plus PAD, BOS, EOS, and SEP).
+    *   `itos_path`: Tokenizer vocabulary artifact for legacy/non-global datasets. Global datasets use their adjacent `itos.txt` as the primary source. Fresh training validates unique contiguous entries, config size, fixed/dynamic dataset token bounds, and strict resume-checkpoint dimensions before model construction. Each run snapshots `itos.txt` and records its SHA-256 contract in `vocabulary.json` and checkpoints. Vocabulary changes require `transfer_from`; strict `resume` rejects them.
     *   `block_size`: Maximum sequence length receptive window (e.g., 512).
     *   `n_layer`: Number of transformer blocks (e.g., 6 or 10).
     *   `n_head`: Number of self-attention heads (must divide `n_embd`).
@@ -56,7 +57,7 @@ You can configure training runs using YAML files under `configs/`. Complete temp
     *   Packing provenance: every split NPZ includes aligned integer `segment_ids`, `source_positions`, and `chunk_ids`. `<SEP>` and padding positions use `-1`. `<split>_packing.tsv` maps windows and spans to source records, fragments, oriented codon coordinates, chunk indices, gene boundaries, and continuation flags. The global manifest records the packing schema version and sidecar filenames.
     *   `sep_mask_enabled`: Enable attention masking across `<SEP>` boundaries in packed mode.
 *   **Transfer Learning / Resumption / Freezing:**
-    *   `transfer_from`: Path to pre-trained weights `.pt` file to initialize model parameters while discarding optimizer state.
+    *   `transfer_from`: Path to pre-trained weights `.pt` file to initialize model parameters while discarding optimizer state. Legacy vocabulary rows are mapped by token name when artifacts are available; discarded/new rows and source/target sizes are recorded as an explicit legacy adaptation.
     *   `freeze_backbone`: Set to `true` to freeze all transformer layers and standard prediction heads, training only the auxiliary projection heads.
 *   **Optimizer & Scheduler:**
     *   `optimizer`: Select `"adamw"` or `"adafactor"` (reduces memory footprint).

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -62,7 +62,7 @@ training substrings.
 For every test evaluation, calculate and compare model performance against Uniform and Markov baselines:
 1. Run [`eval_ppl_baselines.py`](file:///Users/User/github/genomics-lm/scripts/eval_ppl_baselines.py) using the train and test splits:
    ```bash
-   python -m scripts.eval_ppl_baselines --train_npz data/processed/global/<RUN_ID>/train_bs256.npz --test_npz data/processed/global/<RUN_ID>/test_bs256.npz --vocab_size 69
+   python -m scripts.eval_ppl_baselines --train_npz data/processed/global/<RUN_ID>/train_bs256.npz --test_npz data/processed/global/<RUN_ID>/test_bs256.npz --vocab_size 68
    ```
 2. Report the **excess bits per codon** ($\Delta H$) and the perplexity drop over the 2nd-order Markov (Trigram) baseline.
 

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import random
 import re
@@ -581,6 +582,13 @@ def main() -> None:
             "groups_by_split": groups_by_split,
         },
         "genome_sources": genome_sources,
+        "vocabulary": {
+            "schema_version": 1,
+            "itos_path": str(itos_path),
+            "sha256": hashlib.sha256(itos_path.read_bytes()).hexdigest(),
+            "size": len(itos),
+            "token_ids_contiguous": sorted(itos) == list(range(len(itos))),
+        },
         "leakage_audit": {
             "report": str(audit_path),
             "status": leakage_report["status"],
@@ -624,6 +632,7 @@ def main() -> None:
         "test_npz": str(out_paths["test"]),
         "primary_dna": str(dna_path),
         "combined_manifest": str(manifest_json_path),
+        "itos_path": str(itos_path),
     }
     
     result_path = run_dir / "pipeline_prepare.json"

--- a/src/codonlm/checkpoints.py
+++ b/src/codonlm/checkpoints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Mapping
+import hashlib
 
 import torch
 
@@ -61,15 +62,47 @@ def load_codon_model(
     ckpt_name: str = "best.pt",
 ) -> tuple[TinyGPT, dict, Path]:
     state_dict, cfg, ckpt_path = load_codon_checkpoint(run_dir, ckpt_name=ckpt_name)
-    # Dynamically resolve vocabulary size to prevent configuration mismatches
+    configured_size = cfg.get("vocab_size")
+    itos_path = Path(run_dir) / "itos.txt"
+    artifact_tokens = (
+        [line.strip() for line in itos_path.read_text().splitlines()]
+        if itos_path.exists()
+        else []
+    )
+    artifact_size = len(artifact_tokens) if artifact_tokens else None
+    embedding_rows = None
     if "tok_emb.weight" in state_dict:
-        cfg["vocab_size"] = state_dict["tok_emb.weight"].shape[0]
-    else:
-        itos_path = Path(run_dir) / "itos.txt"
-        if itos_path.exists():
-            tokens = [line.strip() for line in itos_path.read_text().splitlines() if line.strip()]
-            if tokens:
-                cfg["vocab_size"] = len(tokens)
+        embedding_rows = int(state_dict["tok_emb.weight"].shape[0])
+        cfg["vocab_size"] = embedding_rows
+    elif artifact_size is not None:
+        cfg["vocab_size"] = artifact_size
+    output_rows = (
+        int(state_dict["head.weight"].shape[0])
+        if "head.weight" in state_dict
+        else None
+    )
+    if embedding_rows is not None and output_rows is not None and embedding_rows != output_rows:
+        raise RuntimeError(
+            f"Legacy checkpoint has incompatible embedding rows={embedding_rows} "
+            f"and output rows={output_rows}: {ckpt_path}"
+        )
+    cfg["vocabulary_compatibility"] = {
+        "mode": "legacy_checkpoint_inference",
+        "configured_size": configured_size,
+        "embedding_rows": embedding_rows,
+        "output_rows": output_rows,
+        "artifact_path": str(itos_path) if itos_path.exists() else None,
+        "artifact_size": artifact_size,
+        "artifact_sha256": (
+            hashlib.sha256(itos_path.read_bytes()).hexdigest()
+            if itos_path.exists()
+            else None
+        ),
+        "legacy_adaptation": any(
+            value is not None and value != cfg["vocab_size"]
+            for value in (configured_size, artifact_size)
+        ),
+    }
     model = build_codon_model_from_cfg(cfg)
     model.load_state_dict(state_dict, strict=False)
     model.to(device)

--- a/src/codonlm/train_noprop.py
+++ b/src/codonlm/train_noprop.py
@@ -19,6 +19,11 @@ from .model_tiny_gpt import NoPropTinyGPT
 from .data_loading import PackedDataset, dynamic_lm_collate_fn
 from .train_codon_lm import _ensure_path_list, _normalize_run_id, _auto_run_id, _prepare_output_dirs
 from src.training.runtime import save_checkpoint_atomic
+from .training.vocabulary import (
+    resolve_vocabulary_contract,
+    snapshot_vocabulary,
+    write_vocabulary_manifest,
+)
 
 def main():
     ap = argparse.ArgumentParser()
@@ -46,6 +51,18 @@ def main():
     # Load datasets
     train_paths = _ensure_path_list(None, cfg.get("train_npz"), "train_npz")
     val_paths = _ensure_path_list(None, cfg.get("val_npz"), "val_npz")
+    contract = resolve_vocabulary_contract(
+        [*train_paths, *val_paths],
+        configured_path=cfg.get("itos_path"),
+        configured_size=cfg.get("vocab_size"),
+    )
+    cfg["vocab_size"] = contract.size
+    vocabulary_snapshot = snapshot_vocabulary(contract, ckpt_root.parent / "itos.txt")
+    cfg["itos_path"] = str(vocabulary_snapshot)
+    cfg["vocabulary"] = contract.provenance(vocabulary_snapshot)
+    write_vocabulary_manifest(
+        cfg["vocabulary"], ckpt_root.parent / "vocabulary.json"
+    )
     train_ds = PackedDataset(train_paths)
     val_ds = PackedDataset(val_paths)
 

--- a/src/codonlm/training/checkpoint.py
+++ b/src/codonlm/training/checkpoint.py
@@ -29,13 +29,20 @@ def _load_transfer_state_dict(
 
     source_index = {tok: i for i, tok in enumerate(source_itos or [])}
     target_index = {tok: i for i, tok in enumerate(target_itos or [])}
+    vocab_row_names = {"tok_emb.weight", "head.weight", "loss_weights"}
 
     for name, target_tensor in target_state.items():
         source_tensor = source_state.get(name)
         if source_tensor is None:
             skipped.append(name)
             continue
-        if tuple(source_tensor.shape) == tuple(target_tensor.shape):
+        requires_token_remap = (
+            name in vocab_row_names
+            and source_index
+            and target_index
+            and list(source_itos or []) != list(target_itos or [])
+        )
+        if tuple(source_tensor.shape) == tuple(target_tensor.shape) and not requires_token_remap:
             adapted[name] = source_tensor
             loaded_exact.append(name)
             continue
@@ -43,7 +50,10 @@ def _load_transfer_state_dict(
             source_tensor.ndim >= 1
             and target_tensor.ndim >= 1
             and tuple(source_tensor.shape[1:]) == tuple(target_tensor.shape[1:])
-            and source_tensor.shape[0] != target_tensor.shape[0]
+            and (
+                source_tensor.shape[0] != target_tensor.shape[0]
+                or requires_token_remap
+            )
         ):
             merged = target_tensor.detach().clone()
             copied = 0

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -42,6 +42,12 @@ from src.codonlm.training.objectives import (
     termination_distance_bucket_labels,
     termination_aux_loss,
 )
+from src.codonlm.training.vocabulary import (
+    resolve_vocabulary_contract,
+    snapshot_vocabulary,
+    validate_resume_checkpoint,
+    write_vocabulary_manifest,
+)
 
 RUN_ID_ENV = "RUN_ID"
 PAD_ID = 0
@@ -139,8 +145,18 @@ def run_training(cfg: dict, args) -> None:
     cfg["val_npz"] = val_paths
     cfg["test_npz"] = test_paths
 
+    configured_vocab_size = cfg.get("vocab_size")
+    vocabulary_contract = resolve_vocabulary_contract(
+        [*train_paths, *val_paths, *test_paths],
+        configured_path=cfg.get("itos_path"),
+        configured_size=configured_vocab_size,
+    )
+    cfg["vocab_size"] = vocabulary_contract.size
+
     if resume_path and not os.path.isfile(resume_path):
         raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
+    if resume_path:
+        validate_resume_checkpoint(resume_path, vocabulary_contract)
 
     transfer_path = None if resume_path else (args.transfer_from or cfg.pop("transfer_from", None))
     if transfer_path and not os.path.isfile(transfer_path):
@@ -263,6 +279,16 @@ def run_training(cfg: dict, args) -> None:
     ckpt_dir, scores_dir = _prepare_output_dirs(outdir, scores_base, run_id)
     accumulation_health = AccumulationHealth()
 
+    vocabulary_snapshot = snapshot_vocabulary(
+        vocabulary_contract, ckpt_dir.parent / "itos.txt"
+    )
+    vocabulary_provenance = vocabulary_contract.provenance(vocabulary_snapshot)
+    cfg["itos_path"] = str(vocabulary_snapshot)
+    cfg["vocabulary"] = vocabulary_provenance
+    write_vocabulary_manifest(
+        vocabulary_provenance, ckpt_dir.parent / "vocabulary.json"
+    )
+
     shutil.copy2(args.config, ckpt_dir / "config.yaml")
     run_logger = RunLogger(ckpt_dir.parent / "logs" / "train.log")
     run_logger.__enter__()
@@ -384,6 +410,10 @@ def run_training(cfg: dict, args) -> None:
         use_rope=bool(cfg.get("use_rope", False)),
         use_shape_guidance=use_shape_guidance,
     ).to(device)
+    if model.tok_emb.num_embeddings != vocabulary_contract.size:
+        raise RuntimeError("model token embedding rows do not match resolved vocabulary")
+    if model.head.out_features != vocabulary_contract.size:
+        raise RuntimeError("model output rows do not match resolved vocabulary")
 
     replay_loader = None
     replay_iter = None
@@ -602,12 +632,43 @@ def run_training(cfg: dict, args) -> None:
             sd = ckpt_transfer["model"] if isinstance(ckpt_transfer, dict) and "model" in ckpt_transfer else ckpt_transfer
             transfer_cfg = ckpt_transfer.get("cfg", {}) if isinstance(ckpt_transfer, dict) else {}
             source_itos = _read_itos(transfer_cfg.get("itos_path"), Path.cwd())
-            target_itos = _read_itos(cfg.get("itos_path"), Path.cwd())
+            if source_itos is None:
+                transfer_checkpoint_path = Path(transfer_path).resolve()
+                for candidate in (
+                    transfer_checkpoint_path.parent / "itos.txt",
+                    transfer_checkpoint_path.parent.parent / "itos.txt",
+                ):
+                    source_itos = _read_itos(str(candidate))
+                    if source_itos is not None:
+                        break
             transfer_report = _load_transfer_state_dict(
                 model,
                 sd,
                 source_itos=source_itos,
-                target_itos=target_itos,
+                target_itos=list(vocabulary_contract.tokens),
+            )
+            source_embedding_rows = (
+                int(sd["tok_emb.weight"].shape[0])
+                if "tok_emb.weight" in sd
+                else None
+            )
+            vocabulary_provenance["legacy_adaptation"] = bool(
+                source_embedding_rows != vocabulary_contract.size
+                or transfer_report["loaded_rows"]
+            )
+            vocabulary_provenance["transfer"] = {
+                "checkpoint": str(transfer_path),
+                "source_embedding_rows": source_embedding_rows,
+                "source_tokenizer_entries": (
+                    len(source_itos) if source_itos is not None else None
+                ),
+                "target_vocab_size": vocabulary_contract.size,
+                "loaded_rows": transfer_report["loaded_rows"],
+                "skipped": transfer_report["skipped"],
+            }
+            cfg["vocabulary"] = vocabulary_provenance
+            write_vocabulary_manifest(
+                vocabulary_provenance, ckpt_dir.parent / "vocabulary.json"
             )
             print(
                 "[transfer] loaded_exact="

--- a/src/codonlm/training/vocabulary.py
+++ b/src/codonlm/training/vocabulary.py
@@ -1,0 +1,238 @@
+"""Vocabulary contracts for reproducible CodonLM training."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+import torch
+
+
+class VocabularyContractError(ValueError):
+    """Raised when tokenizer, dataset, config, and model token spaces disagree."""
+
+
+@dataclass(frozen=True)
+class DatasetTokenBounds:
+    path: str
+    minimum: int | None
+    maximum: int | None
+    arrays: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class VocabularyContract:
+    source_path: Path
+    tokens: tuple[str, ...]
+    sha256: str
+    configured_size: int | None
+    dataset_bounds: tuple[DatasetTokenBounds, ...]
+
+    @property
+    def size(self) -> int:
+        return len(self.tokens)
+
+    def provenance(self, resolved_path: Path | None = None) -> dict:
+        return {
+            "schema_version": 1,
+            "source_path": str(self.source_path),
+            "resolved_path": str(resolved_path or self.source_path),
+            "sha256": self.sha256,
+            "size": self.size,
+            "configured_size": self.configured_size,
+            "token_ids_contiguous": True,
+            "dataset_bounds": [
+                {
+                    "path": bound.path,
+                    "minimum": bound.minimum,
+                    "maximum": bound.maximum,
+                    "arrays": list(bound.arrays),
+                }
+                for bound in self.dataset_bounds
+            ],
+            "legacy_adaptation": False,
+        }
+
+
+def load_itos(path: Path) -> tuple[str, ...]:
+    if not path.exists():
+        raise VocabularyContractError(f"Tokenizer vocabulary not found: {path}")
+    raw_lines = path.read_text().splitlines()
+    if not raw_lines:
+        raise VocabularyContractError(f"Tokenizer vocabulary is empty: {path}")
+    tokens = tuple(line.strip() for line in raw_lines)
+    empty_ids = [index for index, token in enumerate(tokens) if not token]
+    if empty_ids:
+        raise VocabularyContractError(
+            f"Tokenizer vocabulary contains empty token IDs {empty_ids}: {path}"
+        )
+    duplicates = sorted({token for token in tokens if tokens.count(token) > 1})
+    if duplicates:
+        raise VocabularyContractError(
+            f"Tokenizer vocabulary contains duplicate tokens {duplicates}: {path}"
+        )
+    return tokens
+
+
+def resolve_itos_path(
+    dataset_paths: Sequence[str | Path], configured_path: str | Path | None
+) -> Path:
+    adjacent = {
+        Path(path).expanduser().resolve().parent / "itos.txt" for path in dataset_paths
+    }
+    existing_adjacent = sorted(path for path in adjacent if path.exists())
+    if existing_adjacent:
+        if len(existing_adjacent) != 1 or any(path != existing_adjacent[0] for path in adjacent):
+            raise VocabularyContractError(
+                "Dataset shards do not resolve to one shared adjacent itos.txt: "
+                + ", ".join(str(path) for path in sorted(adjacent))
+            )
+        resolved = existing_adjacent[0]
+        if configured_path is not None:
+            configured = Path(configured_path).expanduser().resolve()
+            if configured.exists() and configured.read_bytes() != resolved.read_bytes():
+                raise VocabularyContractError(
+                    f"Configured tokenizer {configured} differs from dataset tokenizer {resolved}"
+                )
+        return resolved
+    if configured_path is None:
+        raise VocabularyContractError(
+            "No dataset-adjacent itos.txt or explicit itos_path was found"
+        )
+    return Path(configured_path).expanduser().resolve()
+
+
+def _bounds(arrays: Iterable[tuple[str, np.ndarray]]) -> tuple[int | None, int | None, tuple[str, ...]]:
+    minimum = None
+    maximum = None
+    names = []
+    for name, array in arrays:
+        names.append(name)
+        if array.size == 0:
+            continue
+        array_min = int(np.min(array))
+        array_max = int(np.max(array))
+        minimum = array_min if minimum is None else min(minimum, array_min)
+        maximum = array_max if maximum is None else max(maximum, array_max)
+    return minimum, maximum, tuple(names)
+
+
+def dataset_token_bounds(path_value: str | Path) -> DatasetTokenBounds:
+    path = Path(path_value).expanduser().resolve()
+    x_sidecar = path.with_name(f"{path.stem}_X.npy")
+    y_sidecar = path.with_name(f"{path.stem}_Y.npy")
+    if x_sidecar.exists():
+        arrays = [("X", np.load(x_sidecar, mmap_mode="r"))]
+        if y_sidecar.exists():
+            arrays.append(("Y", np.load(y_sidecar, mmap_mode="r")))
+        minimum, maximum, names = _bounds(arrays)
+    else:
+        if not path.exists():
+            raise VocabularyContractError(f"Dataset shard not found: {path}")
+        with np.load(path, allow_pickle=False) as data:
+            names = tuple(name for name in ("X", "Y") if name in data)
+            if "X" not in names:
+                raise VocabularyContractError(f"Dataset shard has no X array: {path}")
+            minimum, maximum, names = _bounds((name, data[name]) for name in names)
+    return DatasetTokenBounds(str(path), minimum, maximum, names)
+
+
+def resolve_vocabulary_contract(
+    dataset_paths: Sequence[str | Path],
+    *,
+    configured_path: str | Path | None,
+    configured_size: int | None,
+) -> VocabularyContract:
+    source_path = resolve_itos_path(dataset_paths, configured_path)
+    tokens = load_itos(source_path)
+    if configured_size is not None and int(configured_size) != len(tokens):
+        raise VocabularyContractError(
+            f"Configured vocab_size={configured_size} does not match tokenizer vocabulary "
+            f"size={len(tokens)} from {source_path}"
+        )
+    bounds = tuple(dataset_token_bounds(path) for path in dataset_paths)
+    for bound in bounds:
+        if bound.minimum is not None and bound.minimum < 0:
+            raise VocabularyContractError(
+                f"Dataset {bound.path} contains negative token ID {bound.minimum}"
+            )
+        if bound.maximum is not None and bound.maximum >= len(tokens):
+            raise VocabularyContractError(
+                f"Dataset {bound.path} contains token ID {bound.maximum}, but tokenizer "
+                f"{source_path} defines valid IDs 0..{len(tokens) - 1}"
+            )
+    return VocabularyContract(
+        source_path=source_path,
+        tokens=tokens,
+        sha256=hashlib.sha256(source_path.read_bytes()).hexdigest(),
+        configured_size=(int(configured_size) if configured_size is not None else None),
+        dataset_bounds=bounds,
+    )
+
+
+def snapshot_vocabulary(contract: VocabularyContract, destination: Path) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if contract.source_path != destination.resolve():
+        shutil.copy2(contract.source_path, destination)
+    if hashlib.sha256(destination.read_bytes()).hexdigest() != contract.sha256:
+        raise VocabularyContractError(f"Vocabulary snapshot hash mismatch: {destination}")
+    return destination.resolve()
+
+
+def checkpoint_embedding_rows(checkpoint: dict) -> tuple[int | None, int | None]:
+    state = checkpoint.get("model", checkpoint)
+    embedding = state.get("tok_emb.weight")
+    output = state.get("head.weight")
+    return (
+        int(embedding.shape[0]) if embedding is not None else None,
+        int(output.shape[0]) if output is not None else None,
+    )
+
+
+def validate_resume_checkpoint(checkpoint_path: str | Path, contract: VocabularyContract) -> None:
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    embedding_rows, output_rows = checkpoint_embedding_rows(checkpoint)
+    checkpoint_cfg = checkpoint.get("cfg", {}) if isinstance(checkpoint, dict) else {}
+    checkpoint_size = checkpoint_cfg.get("vocab_size")
+    mismatches = []
+    if embedding_rows != contract.size:
+        mismatches.append(f"embedding rows={embedding_rows}")
+    if output_rows != contract.size:
+        mismatches.append(f"output rows={output_rows}")
+    if checkpoint_size is not None and int(checkpoint_size) != contract.size:
+        mismatches.append(f"checkpoint cfg vocab_size={checkpoint_size}")
+    checkpoint_vocab = checkpoint_cfg.get("vocabulary", {})
+    checkpoint_hash = checkpoint_vocab.get("sha256") if isinstance(checkpoint_vocab, dict) else None
+    if checkpoint_hash is not None and checkpoint_hash != contract.sha256:
+        mismatches.append(f"checkpoint vocabulary sha256={checkpoint_hash}")
+    if mismatches:
+        raise VocabularyContractError(
+            f"Resume checkpoint {checkpoint_path} is incompatible with tokenizer "
+            f"{contract.source_path} (size={contract.size}, sha256={contract.sha256}): "
+            + ", ".join(mismatches)
+            + ". Use transfer_from only for explicit legacy vocabulary adaptation."
+        )
+
+
+def write_vocabulary_manifest(provenance: dict, path: Path) -> None:
+    path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n")
+
+
+__all__ = [
+    "DatasetTokenBounds",
+    "VocabularyContract",
+    "VocabularyContractError",
+    "checkpoint_embedding_rows",
+    "dataset_token_bounds",
+    "load_itos",
+    "resolve_itos_path",
+    "resolve_vocabulary_contract",
+    "snapshot_vocabulary",
+    "validate_resume_checkpoint",
+    "write_vocabulary_manifest",
+]

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -16,7 +16,7 @@ from Bio.SeqFeature import FeatureLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from scripts.build_global_manifest import resolve_genome_identity
-from src.codonlm.codon_tokenize import stoi, to_ids
+from src.codonlm.codon_tokenize import itos, stoi, to_ids
 from src.codonlm.extract_cds_from_genbank import reverse_complement
 
 
@@ -428,10 +428,14 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
     train_npz = Path(pipeline_data["train_npz"])
     val_npz = Path(pipeline_data["val_npz"])
     test_npz = Path(pipeline_data["test_npz"])
+    assert Path(pipeline_data["itos_path"]) == output_dir / "itos.txt"
     
     assert train_npz.exists()
     assert val_npz.exists()
     assert test_npz.exists()
+    manifest = json.loads((output_dir / "manifest.json").read_text())
+    assert manifest["vocabulary"]["size"] == len(itos)
+    assert manifest["vocabulary"]["token_ids_contiguous"] is True
     
     # Verify metadata and ensure zero genomic leakage (each split must have mutually exclusive genomes)
     meta_tsv = output_dir / "cds_meta.tsv"

--- a/tests/test_nonfinite_accumulation.py
+++ b/tests/test_nonfinite_accumulation.py
@@ -40,6 +40,9 @@ def _config(tmp_path, *, max_nonfinite_groups: int) -> dict:
 
 
 def _write_inputs(tmp_path, config: dict):
+    itos_path = tmp_path / "itos.txt"
+    itos_path.write_text("\n".join(f"token_{index}" for index in range(69)) + "\n")
+    config["itos_path"] = str(itos_path)
     config_path = tmp_path / "config.yaml"
     config_path.write_text(yaml.safe_dump(config))
     x_train = np.ones((5, 4), dtype=np.int32)
@@ -106,6 +109,10 @@ def test_nonfinite_abort_checkpoint_and_resume_preserve_step_counters(
         "aborted_groups": 1,
         "discarded_finite_microbatches": 1,
     }
+    assert checkpoint["cfg"]["vocabulary"]["size"] == 69
+    assert checkpoint["cfg"]["vocabulary"]["legacy_adaptation"] is False
+    assert (tmp_path / "runs/nonfinite-resume/itos.txt").exists()
+    assert (tmp_path / "runs/nonfinite-resume/vocabulary.json").exists()
 
     monkeypatch.setattr(TinyGPT, "forward", original_forward)
     resume_args = _args(

--- a/tests/test_shared_resolve_run.py
+++ b/tests/test_shared_resolve_run.py
@@ -107,11 +107,18 @@ def test_load_codon_model_dynamic_vocab(tmp_path):
         "cfg": cfg
     }
     torch.save(state, run_dir / "best.pt")
+    (run_dir / "itos.txt").write_text(
+        "\n".join(f"token_{index}" for index in range(7)) + "\n"
+    )
     
     from src.codonlm.checkpoints import load_codon_model
     loaded_model, loaded_cfg, _ = load_codon_model(run_dir, device="cpu")
     assert loaded_model is not None
     assert loaded_cfg["vocab_size"] == 8
-
+    compatibility = loaded_cfg["vocabulary_compatibility"]
+    assert compatibility["legacy_adaptation"] is True
+    assert compatibility["configured_size"] == 15
+    assert compatibility["embedding_rows"] == 8
+    assert compatibility["artifact_size"] == 7
 
 

--- a/tests/test_transfer_learning.py
+++ b/tests/test_transfer_learning.py
@@ -51,3 +51,24 @@ def test_transfer_state_dict_expands_vocab_by_token_name():
     assert torch.allclose(target.head.weight[4], torch.full((8,), 23.0))
     assert torch.allclose(target.tok_emb.weight[2], torch.full((8,), -1.0))
     assert torch.allclose(target.tok_emb.weight[5], torch.full((8,), -1.0))
+
+
+def test_transfer_state_dict_remaps_equal_size_reordered_vocab():
+    source_itos = ["<PAD>", "AAA", "TAA"]
+    target_itos = ["<PAD>", "TAA", "AAA"]
+    source = TinyGPT(3, 4, n_layer=1, n_head=1, n_embd=4, dropout=0.0)
+    target = TinyGPT(3, 4, n_layer=1, n_head=1, n_embd=4, dropout=0.0)
+    with torch.no_grad():
+        source.tok_emb.weight[1].fill_(11.0)
+        source.tok_emb.weight[2].fill_(22.0)
+
+    report = _load_transfer_state_dict(
+        target,
+        source.state_dict(),
+        source_itos=source_itos,
+        target_itos=target_itos,
+    )
+
+    assert "tok_emb.weight:3" in report["loaded_rows"]
+    assert torch.allclose(target.tok_emb.weight[1], torch.full((4,), 22.0))
+    assert torch.allclose(target.tok_emb.weight[2], torch.full((4,), 11.0))

--- a/tests/test_vocabulary_contract.py
+++ b/tests/test_vocabulary_contract.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+import torch
+
+from src.codonlm.model_tiny_gpt import TinyGPT
+from src.codonlm.training.vocabulary import (
+    VocabularyContractError,
+    load_itos,
+    resolve_vocabulary_contract,
+    snapshot_vocabulary,
+    validate_resume_checkpoint,
+)
+
+
+TOKENS = ("<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>", "AAA")
+
+
+def _write_vocab(path, tokens=TOKENS):
+    path.write_text("\n".join(tokens) + "\n")
+    return path
+
+
+def test_matching_fixed_dataset_contract_and_snapshot(tmp_path):
+    vocab = _write_vocab(tmp_path / "itos.txt")
+    dataset = tmp_path / "train.npz"
+    np.savez_compressed(
+        dataset,
+        X=np.array([[1, 4, 0]], dtype=np.int32),
+        Y=np.array([[4, 2, 0]], dtype=np.int32),
+    )
+
+    contract = resolve_vocabulary_contract(
+        [dataset], configured_path=vocab, configured_size=len(TOKENS)
+    )
+    snapshot = snapshot_vocabulary(contract, tmp_path / "run" / "itos.txt")
+
+    assert contract.tokens == TOKENS
+    assert contract.size == 5
+    assert contract.dataset_bounds[0].minimum == 0
+    assert contract.dataset_bounds[0].maximum == 4
+    assert contract.sha256 == hashlib.sha256(vocab.read_bytes()).hexdigest()
+    assert snapshot.read_text() == vocab.read_text()
+
+
+def test_dynamic_and_npy_sidecar_bounds_are_supported(tmp_path):
+    _write_vocab(tmp_path / "itos.txt")
+    dynamic = tmp_path / "dynamic.npz"
+    np.savez_compressed(
+        dynamic,
+        X=np.array([1, 4, 2], dtype=np.int32),
+        lengths=np.array([3], dtype=np.int32),
+    )
+    sidecar = tmp_path / "sidecar.npz"
+    np.savez_compressed(sidecar, X=np.array([[99]], dtype=np.int32))
+    np.save(tmp_path / "sidecar_X.npy", np.array([[1, 4]], dtype=np.int32))
+    np.save(tmp_path / "sidecar_Y.npy", np.array([[4, 2]], dtype=np.int32))
+
+    contract = resolve_vocabulary_contract(
+        [dynamic, sidecar], configured_path=None, configured_size=5
+    )
+
+    assert [bound.maximum for bound in contract.dataset_bounds] == [4, 4]
+
+
+@pytest.mark.parametrize(
+    ("configured_size", "data", "message"),
+    [
+        pytest.param(6, [1, 4], "Configured vocab_size=6", id="stale-config"),
+        pytest.param(5, [1, 5], "contains token ID 5", id="out-of-range"),
+        pytest.param(5, [-1, 2], "negative token ID -1", id="negative"),
+    ],
+)
+def test_contract_rejects_mismatches(tmp_path, configured_size, data, message):
+    _write_vocab(tmp_path / "itos.txt")
+    dataset = tmp_path / "train.npz"
+    values = np.asarray([data], dtype=np.int32)
+    np.savez_compressed(dataset, X=values, Y=values)
+
+    with pytest.raises(VocabularyContractError, match=message):
+        resolve_vocabulary_contract(
+            [dataset], configured_path=None, configured_size=configured_size
+        )
+
+
+def test_vocab_rejects_duplicates_and_empty_ids(tmp_path):
+    duplicate = _write_vocab(tmp_path / "duplicate.txt", ("A", "B", "A"))
+    empty = _write_vocab(tmp_path / "empty.txt", ("A", "", "B"))
+
+    with pytest.raises(VocabularyContractError, match="duplicate"):
+        load_itos(duplicate)
+    with pytest.raises(VocabularyContractError, match="empty token IDs"):
+        load_itos(empty)
+
+
+def test_resume_requires_exact_embedding_output_and_checkpoint_vocab(tmp_path):
+    vocab = _write_vocab(tmp_path / "itos.txt")
+    dataset = tmp_path / "train.npz"
+    np.savez_compressed(dataset, X=np.array([[1, 4]]), Y=np.array([[4, 2]]))
+    contract = resolve_vocabulary_contract(
+        [dataset], configured_path=vocab, configured_size=5
+    )
+    model = TinyGPT(5, 4, n_layer=1, n_head=1, n_embd=4, dropout=0.0)
+    checkpoint = tmp_path / "matching.pt"
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "cfg": {
+                "vocab_size": 5,
+                "vocabulary": {"sha256": contract.sha256},
+            },
+        },
+        checkpoint,
+    )
+
+    validate_resume_checkpoint(checkpoint, contract)
+
+    legacy = TinyGPT(6, 4, n_layer=1, n_head=1, n_embd=4, dropout=0.0)
+    legacy_checkpoint = tmp_path / "legacy.pt"
+    torch.save(
+        {"model": legacy.state_dict(), "cfg": {"vocab_size": 6}},
+        legacy_checkpoint,
+    )
+    with pytest.raises(VocabularyContractError, match="Use transfer_from"):
+        validate_resume_checkpoint(legacy_checkpoint, contract)

--- a/tests/test_wall_time.py
+++ b/tests/test_wall_time.py
@@ -34,6 +34,9 @@ def test_train_codon_lm_wall_time_limit(tmp_path):
     }
     
     config_file = tmp_path / "config.yaml"
+    itos_path = tmp_path / "itos.txt"
+    itos_path.write_text("\n".join(f"token_{index}" for index in range(69)) + "\n")
+    config_data["itos_path"] = str(itos_path)
     with open(config_file, "w") as f:
         yaml.safe_dump(config_data, f)
         


### PR DESCRIPTION
## Summary
- resolve fresh-training vocabulary from dataset-adjacent or explicitly configured `itos` artifacts before model construction
- reject malformed/duplicate entries, stale config sizes, negative or out-of-range fixed/dynamic/mmap dataset tokens, and incompatible resume checkpoints
- snapshot `itos.txt` into each run and record path, SHA-256, size, bounds, and compatibility status in `vocabulary.json` and checkpoint config
- keep legacy checkpoint inference and `transfer_from` adaptation explicit, including token-name row remapping for reordered equal-size vocabularies
- add the same contract to the NoProp trainer and vocabulary identity to global dataset manifests
- correct base-codon configs from the historical 69 classes to the canonical 68; leave hybrid 74-token configs unchanged

## Validation
- `pytest -q -m "not slow and not external and not mps"` (234 passed, 1 skipped, 1 xpassed)
- tests cover matching fixed/dynamic/mmap inputs, stale config, negative/out-of-range IDs, malformed artifacts, strict resume, legacy inference, and transfer row mapping
- `ruff check . --select E9,F63,F7,F82`
- `git diff --check`

Closes #84