### PR TITLE
Harden causal embedding extraction provenance

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -50,7 +50,7 @@ audits pass. Any later semantic change creates a new dataset version.
 
 ## Phase 5: Freeze Evaluation Instruments
 - [x] Make perplexity baselines storage-format independent and vocabulary safe (#82).
-- [ ] Remove unsafe embedding fallbacks and record causal extraction provenance (#86).
+- [x] Remove unsafe embedding fallbacks and record causal extraction provenance (#86).
 - [ ] Add gene/genome-grouped DNA-shape folds plus one-hot, random-model, 5-mer, and
   7-mer controls (#88).
 - [ ] Add protein-cluster-held-out AMR splits, class reporting, stratified bootstrap,

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -48,7 +48,7 @@ freeze gate passes.
 - [x] #83: abort and clear non-finite gradient-accumulation groups.
 - [x] #81: correct attention-dropout behavior in all attention paths.
 - [x] #84: tokenizer artifact as the vocabulary source of truth.
-- [ ] #86: causal embedding extraction provenance and unsafe-fallback removal.
+- [x] #86: causal embedding extraction provenance and unsafe-fallback removal.
 - [x] #82: format-aware, vocabulary-safe perplexity baselines.
 - [ ] #88: grouped DNA-shape controls and local-sequence baselines.
 - [ ] #89: protein-cluster-held-out AMR evaluation and robust class reporting.

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -101,6 +101,22 @@ For every test evaluation, calculate and compare model performance against Unifo
 **Always control for token-identity decodability in shape and classification probes.**
 
 ### Mandatory Workflow
+Regenerate embeddings from the corrected checkpoint before running any probe:
+
+```bash
+python -m scripts.extract_embeddings \
+  --run_dir runs/<RUN_ID> \
+  --fasta data/frozen/test_cds.fasta \
+  --out runs/<RUN_ID>/embeddings/test_causal.npz
+```
+
+Extraction requires the canonical causal `forward_hidden()` model API and the
+run-resolved vocabulary. Shape-guided checkpoints must contain their trained
+shape encoder. The adjacent `.npz.metadata.json` sidecar records checkpoint,
+vocabulary, input, masking, pooling, truncation, and code provenance. Embedding
+files without this sidecar are legacy/unverified and must not be used for
+corrected headline results.
+
 When training linear probes (e.g. for DNA-shape or EC level classification), compare your pretrained embeddings against:
 1. **One-Hot Codon Identity vectors** (proves learning beyond local codon lookup).
 2. **Randomly Initialized Model Embeddings** (proves that the pretraining phase, and not just the neural architecture, is responsible for the representation quality).

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -17,6 +17,10 @@ Example:
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
 
@@ -24,6 +28,8 @@ import numpy as np
 import torch
 
 from . import query_model as Q
+from src.codonlm.checkpoints import load_codon_checkpoint
+from src.codonlm.training.vocabulary import load_itos
 
 
 def _read_fasta(path: Path) -> List[Tuple[str, str]]:
@@ -56,52 +62,85 @@ def _dna_to_codon_tokens(dna: str) -> List[str]:
 
 
 def _pool_hidden(
-    model: torch.nn.Module, idx: torch.Tensor, nonpad_mask: torch.Tensor
+    model: torch.nn.Module,
+    idx: torch.Tensor,
+    nonpad_mask: torch.Tensor,
+    *,
+    shape_embeddings: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    # Reconstruct/retrieve hidden states up to ln_f; then mean-pool over non-pad tokens
+    """Mean-pool canonical causal hidden states over non-PAD positions."""
+    forward_hidden = getattr(model, "forward_hidden", None)
+    if not callable(forward_hidden):
+        raise TypeError(
+            f"{type(model).__name__} does not expose the verified forward_hidden API"
+        )
+    if getattr(model, "use_shape_guidance", False) and shape_embeddings is None:
+        raise RuntimeError(
+            "shape-guided extraction requires embeddings from the checkpoint's shape encoder"
+        )
     with torch.no_grad():
-        if hasattr(model, "forward_hidden"):
-            shape_embeddings = None
-            if getattr(model, "use_shape_guidance", False):
-                try:
-                    from src.codonlm.biophysics import NucleotideEncoder
-                    from scripts.train_biophysics_fusion import build_one_hot_lookup
-                    from pathlib import Path
-                    encoder = NucleotideEncoder(d_shape=3).to(idx.device).eval()
-                    enc_ckpt = Path("runs/biophysics_encoder.pt")
-                    if enc_ckpt.exists():
-                        encoder.load_state_dict(torch.load(enc_ckpt, map_location=idx.device))
-                    itos_file = Path("itos.txt")
-                    if itos_file.exists():
-                        itos = [line.strip() for line in itos_file.read_text().splitlines() if line.strip()]
-                    else:
-                        from src.codonlm.generate import CODON_ITOS
-                        itos = CODON_ITOS
-                    lookup_table = build_one_hot_lookup(itos, idx.device)
-                    one_hots = lookup_table[idx]
-                    one_hots = one_hots.view(idx.size(0), 3 * idx.size(1), 4)
-                    shape_embeddings = encoder(one_hots)
-                except Exception as e:
-                    print(f"[warn] Failed to generate shape embeddings for extraction: {e}")
-            x = model.forward_hidden(idx, shape_embeddings=shape_embeddings)
-        else:
-            pos = torch.arange(0, idx.shape[1], device=idx.device).unsqueeze(0)
-            x = model.tok_emb(idx) + model.pos_emb(pos)
-            x = model.drop(x)
-            attn_mask = None
-            if getattr(model, "sep_id", None) is not None:
-                sep = idx == int(model.sep_id)
-                seg = torch.cumsum(sep, dim=1)
-                attn_mask = (seg.unsqueeze(-1) == seg.unsqueeze(-2)).unsqueeze(1)
-            for blk in model.blocks:
-                x = blk(x, attn_mask=attn_mask)
-            x = model.ln_f(x)
-        # Pool
+        x = forward_hidden(idx, shape_embeddings=shape_embeddings)
         mask = nonpad_mask.to(x.dtype).unsqueeze(-1)  # (B,T,1)
         summed = (x * mask).sum(dim=1)
         counts = mask.sum(dim=1).clamp_min(1.0)
         pooled = summed / counts
         return pooled  # (B, D)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git_sha() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _validate_vocabulary(itos: tuple[str, ...], state: dict, cfg: dict, path: Path) -> None:
+    rows = int(state["tok_emb.weight"].shape[0])
+    if rows != len(itos):
+        raise RuntimeError(
+            f"checkpoint embedding rows={rows} do not match vocabulary size={len(itos)}"
+        )
+    output_rows = int(state["head.weight"].shape[0])
+    if output_rows != len(itos):
+        raise RuntimeError(
+            f"checkpoint output rows={output_rows} do not match vocabulary size={len(itos)}"
+        )
+    configured = cfg.get("vocab_size")
+    if configured is not None and int(configured) != len(itos):
+        raise RuntimeError(
+            f"checkpoint vocab_size={configured} does not match vocabulary size={len(itos)}"
+        )
+    vocabulary_metadata = cfg.get("vocabulary") or {}
+    if not isinstance(vocabulary_metadata, dict):
+        raise RuntimeError("checkpoint vocabulary metadata must be a mapping")
+    expected_hash = vocabulary_metadata.get("sha256")
+    if expected_hash and expected_hash != _sha256(path):
+        raise RuntimeError("checkpoint vocabulary hash does not match run itos.txt")
+
+
+def _shape_runtime(checkpoint_path: Path, itos: tuple[str, ...], device: torch.device):
+    from scripts.train_biophysics_fusion import build_one_hot_lookup
+    from src.codonlm.biophysics import NucleotideEncoder
+
+    payload = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if not isinstance(payload, dict) or "encoder" not in payload:
+        raise RuntimeError(
+            f"shape-guided checkpoint does not contain its trained encoder: {checkpoint_path}"
+        )
+    encoder = NucleotideEncoder(d_shape=3).to(device)
+    encoder.load_state_dict(payload["encoder"])
+    encoder.eval()
+    return encoder, build_one_hot_lookup(list(itos), device)
 
 
 def main() -> None:
@@ -120,11 +159,19 @@ def main() -> None:
         rd = Path(args.run_dir)
     else:
         rd = Path(__file__).resolve().parents[1] / "runs" / args.run_id
-    itos, stoi = Q._load_vocab(rd)
-    state_dict, cfg = Q._load_checkpoint(rd)
-    model = Q.build_model_from_state(state_dict, cfg)
+    itos_path = rd / "itos.txt"
+    itos = load_itos(itos_path)
+    stoi = {token: index for index, token in enumerate(itos)}
+    state_dict, cfg, checkpoint_path = load_codon_checkpoint(rd)
+    _validate_vocabulary(itos, state_dict, cfg, itos_path)
+    model = Q.build_model_from_state(
+        state_dict, cfg, setup_shape_runtime=False
+    )
     device = Q.dev()
     model.to(device).eval()
+    encoder = lookup = None
+    if getattr(model, "use_shape_guidance", False):
+        encoder, lookup = _shape_runtime(checkpoint_path, itos, device)
 
     # Load sequences
     seqs: List[Tuple[str, str]] = []
@@ -166,7 +213,13 @@ def main() -> None:
                 toks[:max_T], dtype=torch.long, device=device
             ).unsqueeze(0)
             nonpad = ids_tensor.ne(pad)
-            pooled = _pool_hidden(model, ids_tensor, nonpad)
+            shapes = None
+            if encoder is not None:
+                one_hots = lookup[ids_tensor].view(1, 3 * ids_tensor.size(1), 4)
+                shapes = encoder(one_hots)
+            pooled = _pool_hidden(
+                model, ids_tensor, nonpad, shape_embeddings=shapes
+            )
             out_vecs.append(pooled.squeeze(0).cpu().numpy())
             ids.append(sid)
 
@@ -176,6 +229,28 @@ def main() -> None:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     np.savez_compressed(out_path, X=X, ids=np.array(ids, dtype=object))
+    input_paths = [Path(path) for path in (args.fasta, args.csv) if path]
+    metadata = {
+        "schema_version": 1,
+        "validation_status": "causal_verified",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "checkpoint": {"path": str(checkpoint_path.resolve()), "sha256": _sha256(checkpoint_path)},
+        "vocabulary": {"path": str(itos_path.resolve()), "size": len(itos), "sha256": _sha256(itos_path)},
+        "inputs": [{"path": str(path.resolve()), "sha256": _sha256(path)} for path in input_paths],
+        "mask_mode": (
+            "canonical_causal_segment"
+            if getattr(model, "sep_id", None) is not None
+            else "canonical_causal"
+        ),
+        "pooling_mode": "mean_nonpad_including_special_tokens",
+        "shape_guidance": bool(getattr(model, "use_shape_guidance", False)),
+        "block_size": max_T,
+        "truncation_policy": "right_truncate",
+        "code_git_sha": _git_sha(),
+    }
+    out_path.with_suffix(out_path.suffix + ".metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+    )
     print(f"[extract] wrote {args.out} with X.shape={X.shape}")
 
 

--- a/scripts/query_model.py
+++ b/scripts/query_model.py
@@ -108,12 +108,18 @@ def ids_to_codons(ids: List[int], itos: List[str]) -> List[str]:
     return [itos[i] if 0 <= i < len(itos) else f"<{i}>" for i in ids]
 
 
-def build_model_from_state(state_dict: Dict, cfg: Dict, checkpoint: Optional[Dict] = None) -> TinyGPT:
+def build_model_from_state(
+    state_dict: Dict,
+    cfg: Dict,
+    checkpoint: Optional[Dict] = None,
+    *,
+    setup_shape_runtime: bool = True,
+) -> TinyGPT:
     model = build_codon_model_from_cfg(cfg)
     model.load_state_dict(state_dict, strict=False)
     model.eval()
     
-    if getattr(model, "use_shape_guidance", False):
+    if getattr(model, "use_shape_guidance", False) and setup_shape_runtime:
         from src.codonlm.biophysics import NucleotideEncoder
         from scripts.train_biophysics_fusion import build_one_hot_lookup
         

--- a/tests/test_embedding_extraction_contract.py
+++ b/tests/test_embedding_extraction_contract.py
@@ -1,0 +1,120 @@
+import json
+
+import numpy as np
+import pytest
+import torch
+
+from scripts import extract_embeddings
+from scripts.extract_embeddings import _pool_hidden, _validate_vocabulary
+from src.codonlm.model_tiny_gpt import TinyGPT
+
+
+def _model(*, sep_id=3):
+    torch.manual_seed(7)
+    return TinyGPT(
+        vocab_size=12,
+        block_size=8,
+        n_layer=2,
+        n_head=2,
+        n_embd=16,
+        dropout=0.0,
+        use_checkpoint=False,
+        sep_id=sep_id,
+        use_sdpa=True,
+    ).eval()
+
+
+def test_future_tokens_cannot_change_prefix_hidden_states():
+    model = _model()
+    first = torch.tensor([[1, 4, 5, 6, 7]])
+    second = torch.tensor([[1, 4, 5, 8, 9]])
+    with torch.no_grad():
+        first_hidden = model.forward_hidden(first)
+        second_hidden = model.forward_hidden(second)
+    torch.testing.assert_close(first_hidden[:, :3], second_hidden[:, :3])
+
+
+def test_previous_segment_cannot_change_later_segment_hidden_states():
+    model = _model()
+    first = torch.tensor([[1, 4, 3, 6, 7]])
+    second = torch.tensor([[1, 9, 3, 6, 7]])
+    with torch.no_grad():
+        first_hidden = model.forward_hidden(first)
+        second_hidden = model.forward_hidden(second)
+    torch.testing.assert_close(first_hidden[:, 2:], second_hidden[:, 2:])
+
+
+def test_pooling_rejects_unverified_model_api():
+    class Unsupported(torch.nn.Module):
+        pass
+
+    ids = torch.tensor([[1, 2]])
+    with pytest.raises(TypeError, match="verified forward_hidden"):
+        _pool_hidden(Unsupported(), ids, ids.ne(0))
+
+
+def test_shape_guided_pooling_requires_explicit_shapes():
+    model = _model()
+    model.use_shape_guidance = True
+    ids = torch.tensor([[1, 2]])
+    with pytest.raises(RuntimeError, match="shape-guided extraction requires"):
+        _pool_hidden(model, ids, ids.ne(0))
+
+
+def test_checkpoint_vocabulary_rows_must_match(tmp_path):
+    vocabulary = tmp_path / "itos.txt"
+    vocabulary.write_text("<PAD>\nA\nB\n")
+    state = {
+        "tok_emb.weight": torch.zeros(3, 4),
+        "head.weight": torch.zeros(4, 4),
+    }
+    with pytest.raises(RuntimeError, match="output rows=4"):
+        _validate_vocabulary(tuple(vocabulary.read_text().splitlines()), state, {}, vocabulary)
+
+
+def test_cli_writes_verified_provenance_sidecar(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run"
+    (run_dir / "checkpoints").mkdir(parents=True)
+    tokens = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>", "ATG"] + [
+        f"T{i}" for i in range(7)
+    ]
+    (run_dir / "itos.txt").write_text("\n".join(tokens) + "\n")
+    model = _model()
+    cfg = {
+        "vocab_size": 12,
+        "block_size": 8,
+        "n_layer": 2,
+        "n_head": 2,
+        "n_embd": 16,
+        "dropout": 0.0,
+        "use_sdpa": True,
+    }
+    torch.save(
+        {"model": model.state_dict(), "cfg": cfg},
+        run_dir / "checkpoints" / "best.pt",
+    )
+    fasta = tmp_path / "input.fasta"
+    fasta.write_text(">gene-1\nATG\n")
+    output = tmp_path / "embeddings.npz"
+    monkeypatch.setattr(extract_embeddings.Q, "dev", lambda: torch.device("cpu"))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "extract_embeddings",
+            "--run_dir",
+            str(run_dir),
+            "--fasta",
+            str(fasta),
+            "--out",
+            str(output),
+        ],
+    )
+    extract_embeddings.main()
+
+    with np.load(output, allow_pickle=True) as data:
+        assert data["X"].shape == (1, 16)
+    metadata = json.loads(output.with_suffix(".npz.metadata.json").read_text())
+    assert metadata["validation_status"] == "causal_verified"
+    assert metadata["mask_mode"] == "canonical_causal_segment"
+    assert metadata["vocabulary"]["size"] == 12
+    assert metadata["inputs"][0]["path"] == str(fasta.resolve())


### PR DESCRIPTION
## Summary
- require the canonical causal hidden-state API and remove the manual noncausal reconstruction fallback
- resolve and validate the run vocabulary against checkpoint embedding/output rows and recorded hashes
- require shape-guided checkpoints to provide their trained encoder instead of using working-directory or random fallbacks
- write checkpoint, vocabulary, input, mask, pooling, truncation, and code provenance beside every embedding artifact
- identify embeddings without the provenance sidecar as legacy/unverified in the workflow

Closes #86

## Testing
- pytest -q (243 passed, 1 skipped, 1 xpassed)
- pytest -q tests/test_embedding_extraction_contract.py (6 passed)
- ruff check scripts/extract_embeddings.py scripts/query_model.py tests/test_embedding_extraction_contract.py
- git diff --check