### PR TITLE
Add versioned content-addressed dataset manifests

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -15,7 +15,7 @@ Planned. Full retraining is blocked until Phase 3 is complete.
   source IDs and oriented codon coordinates; report fragment statistics (#80).
 - [x] Replace suffix truncation with lossless chunks and expose record, chunk,
   coordinate, boundary, and continuation metadata (#78).
-- [ ] Define and test a versioned dataset manifest schema covering sources, splits,
+- [x] Define and test a versioned dataset manifest schema covering sources, splits,
   fragments, chunks, packing, vocabulary, seeds, and artifact hashes.
 
 Exit gate: fixtures prove that no transition crosses ambiguity, no source transition

--- a/docs/DATASET_MANIFEST.md
+++ b/docs/DATASET_MANIFEST.md
@@ -1,0 +1,37 @@
+# Versioned Dataset Manifest
+
+Corrected CodonLM datasets use the `codonlm_dataset_manifest` schema. Version 1
+binds source snapshots, split policy, ambiguity handling, lossless chunking,
+packing, vocabulary, leakage gates, seeds, and derived artifacts into one
+content-addressed dataset identity.
+
+Validate a prepared dataset before training or evaluation:
+
+```bash
+python -m scripts.validate_dataset_manifest \
+  data/processed/global/<DATASET_ID>/manifest.json
+```
+
+Validation fails on unsupported schema versions, inconsistent scientific-validity
+claims, overlapping split groups, count mismatches, missing or modified sources,
+missing or modified artifacts, untracked NPY sidecars, invalid special-token IDs,
+or dataset tokens outside the declared vocabulary.
+
+## Dataset Identity
+
+`dataset.id` is the SHA-256 digest of deterministic JSON containing scientific
+policies and content hashes. Storage paths and legacy compatibility fields are
+excluded, so moving byte-identical sources and artifacts does not change the ID.
+Changing a source, split, vocabulary, transformation policy, audit result, seed,
+or derived artifact changes the ID.
+
+## Compatibility
+
+The global builder writes the authoritative manifest beside the dataset and an
+absolute-path compatibility copy under the run directory. Both have the same
+dataset ID. Training auto-discovers one shared adjacent manifest or accepts an
+explicit `dataset_manifest` configuration value. Missing manifests are recorded
+as `legacy_unverified`; an explicit or discovered invalid manifest is fatal.
+
+Evaluators record the validated dataset ID when `--manifest` is supplied. Results
+without it remain legacy/unverified and cannot support corrected headline claims.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -595,5 +595,58 @@ These ratios are descriptive arithmetic only. Because the numerator metrics and 
 *   **Run Cleanup Script (`cleanup_runs.py`)**: Created a command-line cleanup utility supporting dry-run auditing, intermediate checkpoint purging (keeping only protected files like `best.pt`), and directory removal for runs older than N days.
 *   **Unit Testing**: Added a test suite `tests/test_cleanup_runs.py` verifying correct targeted item removal and preservation rules.
 
+## 29. Stage 29: Leakage-Controlled Revalidation Infrastructure
+**Goal:** Correct the data, training, and evaluation defects identified in the
+Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks.
+
+*   **Legacy Claims and Governance (issues #87, #91, epic #92):**
+    *   Relabeled historical Stage 2.6 results as legacy/preliminary and removed
+        unsupported validation language in PR #94.
+    *   Made core CPU tests, fatal scoped lint, coverage artifacts, and clean-checkout
+        verification required CI gates in PR #96.
+    *   Added the dependency-ordered leakage-controlled revalidation conductor track
+        in PR #97. The track explicitly blocks retraining until its engineering and
+        dataset-freeze gates pass.
+*   **Global Splitting and Dataset Semantics (issues #79, #80, #78):**
+    *   Made global genome/genus grouping the default scientific preparation route,
+        removed implicit sequence-level fallback, and hardened genome accession
+        resolution in PR #95.
+    *   Replaced silent ambiguous-codon deletion with explicit fragment boundaries and
+        oriented source coordinates in PR #98. This prevents fabricated adjacency
+        across ambiguous regions.
+    *   Replaced suffix-only truncation and implicit mid-CDS continuation with lossless,
+        overlap-aware chunks and explicit packing spans in PR #99. Every retained
+        next-token transition is represented exactly once.
+*   **Preventive Leakage and Trainer Correctness (issues #77, #83, #81, #84):**
+    *   Added fatal exact-CDS duplicate and MMseqs2 protein-homology gates, generated
+        sequence nearest-neighbor audits, thresholds, commands, and tool provenance in
+        PR #100.
+    *   Corrected incomplete accumulation-group scaling, aborts and clears groups after
+        non-finite losses, and preserves optimizer/scheduler/resume counters in PR #101.
+    *   Applied configured attention dropout consistently in SDPA and manual attention
+        paths in PR #102.
+    *   Made the ordered tokenizer artifact the vocabulary source of truth, validated
+        dataset/checkpoint token spaces, and retained explicit legacy transfer mapping
+        in PR #103.
+*   **Controlled Evaluation Instruments (issues #82, #86, #88, #89):**
+    *   Rebuilt perplexity baselines for fixed NPZ, dynamic NPZ, and NPY memmap storage;
+        added vocabulary validation, bits/codon, best-simple-baseline comparison, hashes,
+        JSON, and Markdown outputs in PR #104.
+    *   Removed noncausal hidden-state reconstruction and working-directory vocabulary
+        fallbacks; required trained shape encoders and wrote causal embedding provenance
+        sidecars in PR #105.
+    *   Replaced position-level DNA-shape K-fold leakage with deterministic window,
+        gene, or genome grouping; separated packed CDS spans; and added random-model,
+        codon one-hot, centered 5-mer, and centered 7-mer controls in PR #106.
+    *   Separated CARD annotation-family and MMseqs2 protein-cluster AMR protocols,
+        reported achieved class/group balance, added class-stratified bootstrap, and
+        isolated all outputs and tests from research data in PR #107.
+*   **Validation Status:** These PRs build and validate the corrected instruments; they
+    do not retroactively validate Stage 2.6. No corrected headline perplexity, AMR, EC,
+    essentiality, or DNA-shape values have been published yet. The next blocking work is
+    the versioned dataset-manifest contract, CPU/MPS train-save-resume preflight, and
+    immutable genome/genus-held-out dataset freeze. Only then should models be retrained
+    from random initialization and the controlled evaluations rerun.
+
 ---
 *End of Log*

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -310,7 +310,7 @@ python -m scripts.generate_synonymous_controls --test_npz data/processed/test_bs
 python -m scripts.eval_shape_baselines \
   --run_dir runs/<RUN_ID> --ckpt best.pt \
   --test_npz data/processed/global/<DATASET_ID>/test_bs256.npz \
-  --packing-metadata data/processed/global/<DATASET_ID>/test_packing_metadata.tsv \
+  --packing-metadata data/processed/global/<DATASET_ID>/test_packing.tsv \
   --cds-metadata data/processed/global/<DATASET_ID>/cds_meta.tsv \
   --group-by genome --output-prefix runs/<RUN_ID>/scores/shape_genome_grouped
 

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -37,6 +37,15 @@ This guide establishes the mandatory scientific and engineering workflow for dev
    `--allow-legacy-per-dataset-split` is supplied for historical reproduction.
 3. Verify that the output splits contain mutually exclusive genome sets by inspecting the generated `data/processed/global/<RUN_ID>/cds_meta.tsv`.
 
+4. Validate the content-addressed dataset contract before any scientific run:
+   ```bash
+   python -m scripts.validate_dataset_manifest \
+     data/processed/global/<RUN_ID>/manifest.json
+   ```
+   See [`DATASET_MANIFEST.md`](DATASET_MANIFEST.md) for schema and compatibility
+   rules. A missing manifest is legacy/unverified; a present but invalid manifest
+   is fatal.
+
 Generated CDS claims require a separate novelty report against the frozen training
 source records:
 
@@ -128,7 +137,8 @@ folds, and centered local-sequence controls:
 python -m scripts.eval_shape_baselines \
   --run_dir runs/<RUN_ID> --ckpt best.pt \
   --test_npz data/processed/global/<DATASET_ID>/test_bs256.npz \
-  --packing-metadata data/processed/global/<DATASET_ID>/test_packing_metadata.tsv \
+  --manifest data/processed/global/<DATASET_ID>/manifest.json \
+  --packing-metadata data/processed/global/<DATASET_ID>/test_packing.tsv \
   --cds-metadata data/processed/global/<DATASET_ID>/cds_meta.tsv \
   --group-by genome --output-prefix runs/<RUN_ID>/scores/shape_genome_grouped
 ```

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -45,6 +45,14 @@ from src.codonlm.lossless_packing import (
     packed_arrays,
     packing_metadata_rows,
 )
+from src.codonlm.dataset_manifest import (
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    artifact_entry,
+    file_sha256,
+    finalize_manifest,
+    validate_dataset_manifest,
+)
 from src.codonlm.leakage_audit import LeakageAuditError, audit_source_records
 
 
@@ -262,7 +270,12 @@ def main() -> None:
                 )
             genome_sources.setdefault(
                 genome_id,
-                {"gbff": resolved_path, "identity_source": identity_source},
+                {
+                    "gbff": resolved_path,
+                    "identity_source": identity_source,
+                    "sha256": file_sha256(gbff_path),
+                    "bytes": gbff_path.stat().st_size,
+                },
             )
             if genome_id not in announced_genomes:
                 print(
@@ -560,7 +573,35 @@ def main() -> None:
             split: len(groups) for split, groups in split_groups.items()
         }
 
+    scientific_valid = (
+        effective_group_by != "sequence"
+        and not args.skip_homology_audit
+        and not args.allow_cross_split_exact_duplicates
+    )
+    artifacts = {
+        "train_tokens": artifact_entry(out_paths["train"], out_dir, "train_tokens"),
+        "val_tokens": artifact_entry(out_paths["val"], out_dir, "val_tokens"),
+        "test_tokens": artifact_entry(out_paths["test"], out_dir, "test_tokens"),
+        "vocabulary": artifact_entry(itos_path, out_dir, "vocabulary"),
+        "vocabulary_map": artifact_entry(vocab_path, out_dir, "vocabulary_map"),
+        "source_metadata": artifact_entry(meta_path, out_dir, "source_metadata"),
+        "source_dna": artifact_entry(dna_path, out_dir, "source_dna"),
+        "token_ids": artifact_entry(ids_path, out_dir, "token_ids"),
+        "fragment_metadata": artifact_entry(fragments_path, out_dir, "fragment_metadata"),
+        "leakage_audit": artifact_entry(audit_path, out_dir, "leakage_audit"),
+    }
+    for split in ("train", "val", "test"):
+        artifacts[f"{split}_packing_metadata"] = artifact_entry(
+            out_dir / packing_metadata_paths[split], out_dir, f"{split}_packing_metadata"
+        )
+
     manifest = {
+        "schema": {"name": SCHEMA_NAME, "version": SCHEMA_VERSION},
+        "dataset": {
+            "id": "pending",
+            "scientific_valid": scientific_valid,
+            "source_record_count": total_seqs,
+        },
         "train": str(out_paths["train"]),
         "val": str(out_paths["val"]),
         "test": str(out_paths["test"]),
@@ -582,22 +623,35 @@ def main() -> None:
             "groups_by_split": groups_by_split,
         },
         "genome_sources": genome_sources,
+        "sources": {
+            genome: {
+                "path": source["gbff"],
+                "sha256": source["sha256"],
+                "bytes": source["bytes"],
+                "identity_source": source["identity_source"],
+            }
+            for genome, source in sorted(genome_sources.items())
+        },
         "vocabulary": {
             "schema_version": 1,
             "itos_path": str(itos_path),
             "sha256": hashlib.sha256(itos_path.read_bytes()).hexdigest(),
             "size": len(itos),
             "token_ids_contiguous": sorted(itos) == list(range(len(itos))),
+            "special_tokens": {
+                token: stoi[token]
+                for token in ("<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>")
+            },
         },
         "leakage_audit": {
-            "report": str(audit_path),
+            "artifact": "leakage_audit",
             "status": leakage_report["status"],
             "homology_audit_skipped": args.skip_homology_audit,
             "exact_duplicate_override": args.allow_cross_split_exact_duplicates,
             "thresholds": leakage_report["thresholds"],
         },
         "tokenization": {
-            "fragment_metadata": str(fragments_path),
+            "fragment_metadata_artifact": "fragment_metadata",
             "ambiguous_codon_policy": {
                 "name": "split",
                 "min_fragment_codons": min_fragment_codons,
@@ -614,17 +668,31 @@ def main() -> None:
             "transition_policy": "exactly_once",
             "legacy_windows_per_seq_ignored": windows_per_seq,
             "seed": args.seed,
-            "metadata": packing_metadata_paths,
+            "metadata": {
+                split: f"{split}_packing_metadata" for split in ("train", "val", "test")
+            },
             "window_counts": packed_window_counts,
             "chunk_counts": packed_chunk_counts,
         },
+        "artifacts": artifacts,
+        "reproducibility": {
+            "split_seed": args.seed,
+            "packing_seed": args.seed,
+            "deterministic_packing": True,
+        },
     }
-    
+    manifest = finalize_manifest(manifest)
     manifest_json_path = out_dir / "manifest.json"
+    validate_dataset_manifest(manifest, manifest_json_path, verify_artifacts=True)
     manifest_json_path.write_text(json.dumps(manifest, indent=2, sort_keys=True))
-    (run_dir / "combined_manifest.json").write_text(
-        json.dumps(manifest, indent=2, sort_keys=True)
-    )
+    run_manifest = json.loads(json.dumps(manifest))
+    for entry in run_manifest["artifacts"].values():
+        artifact_path = Path(entry["path"])
+        if not artifact_path.is_absolute():
+            entry["path"] = str((out_dir / artifact_path).resolve())
+    run_manifest_path = run_dir / "combined_manifest.json"
+    validate_dataset_manifest(run_manifest, run_manifest_path, verify_artifacts=True)
+    run_manifest_path.write_text(json.dumps(run_manifest, indent=2, sort_keys=True))
     
     pipeline_prepare_json = {
         "train_npz": str(out_paths["train"]),
@@ -633,6 +701,8 @@ def main() -> None:
         "primary_dna": str(dna_path),
         "combined_manifest": str(manifest_json_path),
         "itos_path": str(itos_path),
+        "dataset_id": manifest["dataset"]["id"],
+        "dataset_schema": manifest["schema"],
     }
     
     result_path = run_dir / "pipeline_prepare.json"

--- a/scripts/eval_ppl_baselines.py
+++ b/scripts/eval_ppl_baselines.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import numpy as np
 
 from src.codonlm.data_loading import MmapPackedDataset
+from src.codonlm.dataset_manifest import load_dataset_manifest, manifest_artifact_path
 from src.codonlm.training.vocabulary import resolve_vocabulary_contract
 
 PAD_ID = 0
@@ -140,6 +141,23 @@ def main() -> None:
     parser.add_argument("--output-prefix", type=Path)
     args = parser.parse_args()
     train, test = Path(args.train), Path(args.test)
+    manifest_provenance = {"status": "legacy_unverified"}
+    if args.manifest is not None:
+        manifest = load_dataset_manifest(args.manifest)
+        for split, selected in (("train", train), ("test", test)):
+            declared = manifest_artifact_path(
+                manifest, args.manifest.resolve(), f"{split}_tokens"
+            ).resolve()
+            if selected.resolve() != declared:
+                raise ValueError(
+                    f"{split} dataset {selected.resolve()} does not match manifest artifact {declared}"
+                )
+        manifest_provenance = {
+            "path": str(args.manifest.resolve()),
+            "dataset_id": manifest["dataset"]["id"],
+            "scientific_valid": manifest["dataset"]["scientific_valid"],
+            "schema": manifest["schema"],
+        }
     contract = resolve_vocabulary_contract(
         [train, test], configured_path=args.itos, configured_size=None
     )
@@ -155,6 +173,7 @@ def main() -> None:
             for name, path in (("manifest", args.manifest), ("config", args.config))
             if path is not None
         },
+        "dataset_manifest": manifest_provenance,
         "vocabulary": contract.provenance(),
         "smoothing": {"method": "additive", "alpha": args.alpha},
         "evaluated_tokens": tokens,

--- a/scripts/eval_shape_baselines.py
+++ b/scripts/eval_shape_baselines.py
@@ -19,6 +19,7 @@ from sklearn.metrics import r2_score
 
 from scripts._shared import build_model, load_model, load_token_list, resolve_run
 from scripts.probe_structural_awareness import get_theoretical_shape
+from src.codonlm.dataset_manifest import load_dataset_manifest, manifest_artifact_path
 
 PROPERTIES = (
     "MGW", "Roll", "EP", "ProT", "HelT", "Slide", "Rise", "Shift", "Tilt",
@@ -200,6 +201,7 @@ def main():
     parser.add_argument("--run_dir")
     parser.add_argument("--ckpt", default="best.pt")
     parser.add_argument("--test_npz", required=True)
+    parser.add_argument("--manifest", type=Path)
     parser.add_argument("--packing-metadata", required=True, type=Path)
     parser.add_argument("--cds-metadata", type=Path)
     parser.add_argument("--group-by", choices=("window", "gene", "genome"), default="gene")
@@ -211,6 +213,29 @@ def main():
     if args.group_by == "genome" and args.cds_metadata is None:
         parser.error("--cds-metadata is required for --group-by genome")
     run_id, run_dir = resolve_run(args.run_id, args.run_dir)
+    manifest_provenance = {"status": "legacy_unverified"}
+    if args.manifest is not None:
+        manifest = load_dataset_manifest(args.manifest)
+        expected = {
+            "test_tokens": Path(args.test_npz),
+            "test_packing_metadata": args.packing_metadata,
+        }
+        if args.cds_metadata is not None:
+            expected["source_metadata"] = args.cds_metadata
+        for artifact_name, selected in expected.items():
+            declared = manifest_artifact_path(
+                manifest, args.manifest.resolve(), artifact_name
+            ).resolve()
+            if selected.resolve() != declared:
+                raise ValueError(
+                    f"{artifact_name} {selected.resolve()} does not match manifest {declared}"
+                )
+        manifest_provenance = {
+            "path": str(args.manifest.resolve()),
+            "dataset_id": manifest["dataset"]["id"],
+            "scientific_valid": manifest["dataset"]["scientific_valid"],
+            "schema": manifest["schema"],
+        }
     tokens = load_token_list(run_dir)
     pretrained, spec = load_model(run_dir, ckpt_name=args.ckpt)
     random_model = build_model(spec).eval()
@@ -228,6 +253,7 @@ def main():
     results, aggregate, paired = evaluate(features, targets, folds)
     report = {
         "schema_version": 1, "run_id": run_id, "seed": args.seed,
+        "dataset_manifest": manifest_provenance,
         "group_by": args.group_by, "n_splits": args.n_splits,
         "dataset": {"path": str(test_path.resolve()), "sha256": _sha256(test_path)},
         "checkpoint": {"path": str(checkpoint_path.resolve()), "sha256": _sha256(checkpoint_path)},

--- a/scripts/validate_dataset_manifest.py
+++ b/scripts/validate_dataset_manifest.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Validate a versioned CodonLM dataset manifest and its artifacts."""
+
+import argparse
+import json
+
+from src.codonlm.dataset_manifest import load_dataset_manifest
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest")
+    parser.add_argument("--structure-only", action="store_true")
+    args = parser.parse_args()
+    manifest = load_dataset_manifest(
+        args.manifest, verify_artifacts=not args.structure_only
+    )
+    print(
+        json.dumps(
+            {
+                "dataset_id": manifest["dataset"]["id"],
+                "schema": manifest["schema"],
+                "scientific_valid": manifest["dataset"]["scientific_valid"],
+                "artifact_count": len(manifest["artifacts"]),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codonlm/dataset_manifest.py
+++ b/src/codonlm/dataset_manifest.py
@@ -1,0 +1,216 @@
+"""Versioned, content-addressed dataset manifest contracts."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from .training.vocabulary import dataset_token_bounds, load_itos
+
+SCHEMA_NAME = "codonlm_dataset_manifest"
+SCHEMA_VERSION = 1
+SPLITS = ("train", "val", "test")
+
+
+class DatasetManifestError(ValueError):
+    """Raised when a dataset manifest is unsupported or inconsistent."""
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def artifact_entry(path: Path, manifest_dir: Path, role: str) -> dict[str, Any]:
+    resolved = path.resolve()
+    try:
+        stored_path = str(resolved.relative_to(manifest_dir.resolve()))
+    except ValueError:
+        stored_path = str(resolved)
+    return {
+        "path": stored_path,
+        "role": role,
+        "bytes": resolved.stat().st_size,
+        "sha256": file_sha256(resolved),
+    }
+
+
+def _identity_payload(manifest: dict[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(manifest)
+    payload.get("dataset", {}).pop("id", None)
+    for compatibility_key in ("train", "val", "test", "datasets", "genome_sources"):
+        payload.pop(compatibility_key, None)
+    payload.get("vocabulary", {}).pop("itos_path", None)
+    for artifact in payload.get("artifacts", {}).values():
+        artifact.pop("path", None)
+    for source in payload.get("sources", {}).values():
+        source.pop("path", None)
+    return payload
+
+
+def dataset_identity(manifest: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        _identity_payload(manifest), sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def finalize_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(manifest)
+    result.setdefault("dataset", {})["id"] = dataset_identity(result)
+    return result
+
+
+def _require(mapping: dict, key: str, context: str):
+    if key not in mapping:
+        raise DatasetManifestError(f"missing {context}.{key}")
+    return mapping[key]
+
+
+def _resolve_artifact(manifest_path: Path, entry: dict) -> Path:
+    path = Path(_require(entry, "path", "artifact"))
+    return path if path.is_absolute() else manifest_path.parent / path
+
+
+def manifest_artifact_path(manifest: dict, manifest_path: Path, name: str) -> Path:
+    return _resolve_artifact(manifest_path, _require(manifest["artifacts"], name, "artifacts"))
+
+
+def validate_dataset_manifest(
+    manifest: dict[str, Any], manifest_path: Path, *, verify_artifacts: bool = True
+) -> dict[str, Any]:
+    schema = _require(manifest, "schema", "manifest")
+    if schema.get("name") != SCHEMA_NAME or schema.get("version") != SCHEMA_VERSION:
+        raise DatasetManifestError(
+            f"unsupported dataset manifest schema: {schema!r}; expected {SCHEMA_NAME} v{SCHEMA_VERSION}"
+        )
+    dataset = _require(manifest, "dataset", "manifest")
+    declared_id = _require(dataset, "id", "dataset")
+    computed_id = dataset_identity(manifest)
+    if declared_id != computed_id:
+        raise DatasetManifestError(
+            f"dataset identity mismatch: declared={declared_id}, computed={computed_id}"
+        )
+    split_policy = _require(manifest, "split_policy", "manifest")
+    counts = _require(split_policy, "record_counts", "split_policy")
+    if set(counts) != set(SPLITS) or any(int(counts[name]) < 0 for name in SPLITS):
+        raise DatasetManifestError("split record_counts must contain non-negative train/val/test")
+    if sum(int(counts[name]) for name in SPLITS) != int(dataset["source_record_count"]):
+        raise DatasetManifestError("split record counts do not sum to dataset source_record_count")
+    requested = _require(split_policy, "requested_fractions", "split_policy")
+    if any(not 0.0 <= float(value) < 1.0 for value in requested.values()):
+        raise DatasetManifestError("requested split fractions must be in [0, 1)")
+    groups = split_policy.get("groups_by_split")
+    if groups:
+        group_sets = [set(groups[name]) for name in SPLITS]
+        if any(group_sets[i] & group_sets[j] for i in range(3) for j in range(i + 1, 3)):
+            raise DatasetManifestError("split groups overlap")
+    scientific = bool(dataset.get("scientific_valid"))
+    if scientific != bool(split_policy.get("scientific_valid")):
+        raise DatasetManifestError("dataset and split_policy scientific_valid flags disagree")
+    leakage = _require(manifest, "leakage_audit", "manifest")
+    if scientific and (
+        split_policy.get("effective_group_by") == "sequence"
+        or split_policy.get("allow_sequence_split")
+        or leakage.get("status") != "passed"
+        or leakage.get("homology_audit_skipped")
+        or leakage.get("exact_duplicate_override")
+    ):
+        raise DatasetManifestError("unsafe preparation cannot be marked scientific_valid")
+    vocabulary = _require(manifest, "vocabulary", "manifest")
+    sources = _require(manifest, "sources", "manifest")
+    tokenization = _require(manifest, "tokenization", "manifest")
+    packing = _require(manifest, "packing", "manifest")
+    reproducibility = _require(manifest, "reproducibility", "manifest")
+    _require(tokenization, "ambiguous_codon_policy", "tokenization")
+    if packing.get("mode") not in {"fixed", "dynamic", "multi"}:
+        raise DatasetManifestError("packing.mode must be fixed, dynamic, or multi")
+    if packing.get("transition_policy") != "exactly_once":
+        raise DatasetManifestError("packing transition_policy must be exactly_once")
+    for seed_name in ("split_seed", "packing_seed"):
+        _require(reproducibility, seed_name, "reproducibility")
+    for token_name in ("<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>"):
+        _require(vocabulary.get("special_tokens", {}), token_name, "vocabulary.special_tokens")
+    artifacts = _require(manifest, "artifacts", "manifest")
+    for required in (
+        "train_tokens", "val_tokens", "test_tokens", "vocabulary",
+        "source_metadata", "source_dna", "fragment_metadata", "leakage_audit",
+        "train_packing_metadata", "val_packing_metadata", "test_packing_metadata",
+    ):
+        _require(artifacts, required, "artifacts")
+    if verify_artifacts:
+        for source_name, source in sources.items():
+            source_path = Path(source["path"])
+            if not source_path.exists():
+                raise DatasetManifestError(f"source {source_name} not found: {source_path}")
+            if source_path.stat().st_size != int(source["bytes"]):
+                raise DatasetManifestError(f"source {source_name} size mismatch")
+            if file_sha256(source_path) != source["sha256"]:
+                raise DatasetManifestError(f"source {source_name} hash mismatch")
+        for name, entry in artifacts.items():
+            path = _resolve_artifact(manifest_path, entry)
+            if not path.exists():
+                raise DatasetManifestError(f"artifact {name} not found: {path}")
+            if path.stat().st_size != int(entry["bytes"]):
+                raise DatasetManifestError(f"artifact {name} size mismatch: {path}")
+            if file_sha256(path) != entry["sha256"]:
+                raise DatasetManifestError(f"artifact {name} hash mismatch: {path}")
+        vocab_path = _resolve_artifact(manifest_path, artifacts["vocabulary"])
+        tokens = load_itos(vocab_path)
+        if len(tokens) != int(vocabulary["size"]):
+            raise DatasetManifestError("vocabulary size does not match artifact")
+        if file_sha256(vocab_path) != vocabulary["sha256"]:
+            raise DatasetManifestError("vocabulary hash does not match artifact")
+        for token_name, token_id in vocabulary["special_tokens"].items():
+            if int(token_id) < 0 or int(token_id) >= len(tokens) or tokens[int(token_id)] != token_name:
+                raise DatasetManifestError(f"special token mapping is invalid for {token_name}")
+        for split in SPLITS:
+            data_path = _resolve_artifact(manifest_path, artifacts[f"{split}_tokens"])
+            for suffix, role_suffix in (
+                ("_X.npy", "x_npy"), ("_Y.npy", "y_npy"),
+                ("_lengths.npy", "lengths_npy"),
+            ):
+                sidecar = data_path.with_name(data_path.stem + suffix)
+                if sidecar.exists() and f"{split}_{role_suffix}" not in artifacts:
+                    raise DatasetManifestError(
+                        f"untracked memory-map sidecar for {split}: {sidecar}"
+                    )
+            bounds = dataset_token_bounds(data_path)
+            if bounds.minimum is not None and bounds.minimum < 0:
+                raise DatasetManifestError(f"{split} contains negative token IDs")
+            if bounds.maximum is not None and bounds.maximum >= len(tokens):
+                raise DatasetManifestError(f"{split} token IDs exceed vocabulary")
+    return manifest
+
+
+def load_dataset_manifest(path: str | Path, *, verify_artifacts: bool = True):
+    manifest_path = Path(path).expanduser().resolve()
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DatasetManifestError(f"cannot load dataset manifest {manifest_path}: {exc}") from exc
+    validate_dataset_manifest(manifest, manifest_path, verify_artifacts=verify_artifacts)
+    return manifest
+
+
+def discover_manifest(dataset_paths: Iterable[str | Path]) -> Path | None:
+    candidates = {Path(path).expanduser().resolve().parent / "manifest.json" for path in dataset_paths}
+    existing = {path for path in candidates if path.exists()}
+    if not existing:
+        return None
+    if len(existing) != 1 or len(candidates) != 1:
+        raise DatasetManifestError("dataset shards do not share one adjacent manifest.json")
+    return existing.pop()
+
+
+__all__ = [
+    "DatasetManifestError", "SCHEMA_NAME", "SCHEMA_VERSION", "artifact_entry",
+    "dataset_identity", "discover_manifest", "file_sha256", "finalize_manifest",
+    "load_dataset_manifest", "manifest_artifact_path", "validate_dataset_manifest",
+]

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -13,6 +13,11 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from src.codonlm.model_tiny_gpt import TinyGPT
+from src.codonlm.dataset_manifest import (
+    discover_manifest,
+    load_dataset_manifest,
+    manifest_artifact_path,
+)
 from src.codonlm.data_loading import (
     build_codon_lm_dataloaders,
     build_codon_lm_datasets,
@@ -144,6 +149,40 @@ def run_training(cfg: dict, args) -> None:
     cfg["train_npz"] = train_paths
     cfg["val_npz"] = val_paths
     cfg["test_npz"] = test_paths
+
+    manifest_value = cfg.get("dataset_manifest")
+    if isinstance(manifest_value, dict):
+        manifest_value = manifest_value.get("path")
+    manifest_path = (
+        Path(manifest_value).expanduser().resolve()
+        if manifest_value
+        else discover_manifest([*train_paths, *val_paths, *test_paths])
+    )
+    if manifest_path is not None:
+        dataset_manifest = load_dataset_manifest(manifest_path)
+        for split, selected in (
+            ("train", train_paths), ("val", val_paths), ("test", test_paths)
+        ):
+            declared = manifest_artifact_path(
+                dataset_manifest, manifest_path, f"{split}_tokens"
+            ).resolve()
+            resolved_selected = [Path(path).expanduser().resolve() for path in selected]
+            if resolved_selected != [declared]:
+                raise ValueError(
+                    f"{split} dataset paths do not match manifest {manifest_path}: "
+                    f"selected={resolved_selected}, declared={declared}"
+                )
+        cfg["dataset_manifest"] = {
+            "path": str(manifest_path),
+            "dataset_id": dataset_manifest["dataset"]["id"],
+            "scientific_valid": dataset_manifest["dataset"]["scientific_valid"],
+            "schema": dataset_manifest["schema"],
+        }
+    else:
+        cfg["dataset_manifest"] = {
+            "status": "legacy_unverified",
+            "scientific_valid": False,
+        }
 
     configured_vocab_size = cfg.get("vocab_size")
     vocabulary_contract = resolve_vocabulary_contract(

--- a/tests/test_dataset_manifest.py
+++ b/tests/test_dataset_manifest.py
@@ -1,0 +1,150 @@
+import copy
+import json
+import shutil
+
+import numpy as np
+import pytest
+
+from src.codonlm.dataset_manifest import (
+    DatasetManifestError,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    artifact_entry,
+    dataset_identity,
+    finalize_manifest,
+    load_dataset_manifest,
+    validate_dataset_manifest,
+)
+
+
+def _fixture(tmp_path, mode="fixed", mmap_train=False):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    source = tmp_path / "source.gbff"
+    source.write_text("source snapshot\n")
+    vocab = tmp_path / "itos.txt"
+    vocab.write_text("<PAD>\n<BOS_CDS>\n<EOS_CDS>\n<SEP>\nAAA\n")
+    required_files = {
+        "vocabulary": vocab,
+        "source_metadata": tmp_path / "cds_meta.tsv",
+        "source_dna": tmp_path / "cds_dna.txt",
+        "fragment_metadata": tmp_path / "cds_fragments.tsv",
+        "leakage_audit": tmp_path / "leakage_audit.json",
+    }
+    for name, path in required_files.items():
+        if name != "vocabulary":
+            path.write_text(name + "\n")
+    artifacts = {
+        name: artifact_entry(path, tmp_path, name) for name, path in required_files.items()
+    }
+    for split in ("train", "val", "test"):
+        path = tmp_path / f"{split}.npz"
+        if mode == "dynamic":
+            np.savez(path, X=np.array([1, 4, 2], dtype=np.int32), lengths=np.array([3]))
+        else:
+            np.savez(
+                path,
+                X=np.array([[1, 4]], dtype=np.int32),
+                Y=np.array([[4, 2]], dtype=np.int32),
+            )
+        if split == "train" and mmap_train:
+            path.write_bytes(b"")
+            np.save(tmp_path / "train_X.npy", np.array([[1, 4]], dtype=np.int32))
+            np.save(tmp_path / "train_Y.npy", np.array([[4, 2]], dtype=np.int32))
+        artifacts[f"{split}_tokens"] = artifact_entry(path, tmp_path, f"{split}_tokens")
+        packing = tmp_path / f"{split}_packing.tsv"
+        packing.write_text("window_index\n0\n")
+        artifacts[f"{split}_packing_metadata"] = artifact_entry(
+            packing, tmp_path, f"{split}_packing_metadata"
+        )
+    if mmap_train:
+        artifacts["train_x_npy"] = artifact_entry(tmp_path / "train_X.npy", tmp_path, "train_x_npy")
+        artifacts["train_y_npy"] = artifact_entry(tmp_path / "train_Y.npy", tmp_path, "train_y_npy")
+    manifest = {
+        "schema": {"name": SCHEMA_NAME, "version": SCHEMA_VERSION},
+        "dataset": {"id": "pending", "scientific_valid": True, "source_record_count": 3},
+        "sources": {
+            "genome-1": {
+                "path": str(source.resolve()),
+                "sha256": artifacts["source_metadata"]["sha256"],
+                "bytes": source.stat().st_size,
+                "identity_source": "fixture",
+            }
+        },
+        "split_policy": {
+            "scientific_valid": True,
+            "effective_group_by": "genome",
+            "allow_sequence_split": False,
+            "requested_fractions": {"val": 0.2, "test": 0.2},
+            "record_counts": {"train": 1, "val": 1, "test": 1},
+            "groups_by_split": {"train": ["a"], "val": ["b"], "test": ["c"]},
+        },
+        "vocabulary": {
+            "sha256": artifacts["vocabulary"]["sha256"],
+            "size": 5,
+            "special_tokens": {"<PAD>": 0, "<BOS_CDS>": 1, "<EOS_CDS>": 2, "<SEP>": 3},
+        },
+        "leakage_audit": {
+            "status": "passed",
+            "homology_audit_skipped": False,
+            "exact_duplicate_override": False,
+        },
+        "tokenization": {"ambiguous_codon_policy": {"name": "split"}},
+        "packing": {"mode": mode, "transition_policy": "exactly_once"},
+        "reproducibility": {"split_seed": 1337, "packing_seed": 1337},
+        "artifacts": artifacts,
+    }
+    # Correct the intentionally independent source hash.
+    from src.codonlm.dataset_manifest import file_sha256
+    manifest["sources"]["genome-1"]["sha256"] = file_sha256(source)
+    manifest = finalize_manifest(manifest)
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    return manifest_path
+
+
+@pytest.mark.parametrize("mode", ["fixed", "dynamic"])
+def test_fixed_and_dynamic_manifests_validate(tmp_path, mode):
+    path = _fixture(tmp_path / mode, mode=mode)
+    assert load_dataset_manifest(path)["packing"]["mode"] == mode
+
+
+def test_memmap_sidecars_must_be_in_inventory(tmp_path):
+    path = _fixture(tmp_path, mmap_train=True)
+    manifest = load_dataset_manifest(path)
+    manifest["artifacts"].pop("train_x_npy")
+    manifest = finalize_manifest(manifest)
+    with pytest.raises(DatasetManifestError, match="untracked memory-map sidecar"):
+        validate_dataset_manifest(manifest, path)
+
+
+def test_modified_artifact_fails_hash_validation(tmp_path):
+    path = _fixture(tmp_path)
+    (tmp_path / "train.npz").write_bytes(b"changed")
+    with pytest.raises(DatasetManifestError, match="size mismatch|hash mismatch"):
+        load_dataset_manifest(path)
+
+
+def test_unknown_schema_and_unsafe_scientific_claim_fail(tmp_path):
+    path = _fixture(tmp_path)
+    manifest = json.loads(path.read_text())
+    manifest["schema"]["version"] = 999
+    with pytest.raises(DatasetManifestError, match="unsupported"):
+        validate_dataset_manifest(manifest, path, verify_artifacts=False)
+    manifest = json.loads(path.read_text())
+    manifest["split_policy"]["effective_group_by"] = "sequence"
+    manifest = finalize_manifest(manifest)
+    with pytest.raises(DatasetManifestError, match="unsafe preparation"):
+        validate_dataset_manifest(manifest, path, verify_artifacts=False)
+
+
+def test_identity_is_deterministic_and_relocation_independent(tmp_path):
+    original_path = _fixture(tmp_path / "original")
+    original = load_dataset_manifest(original_path)
+    relocated_dir = tmp_path / "relocated"
+    shutil.copytree(original_path.parent, relocated_dir)
+    relocated_path = relocated_dir / "manifest.json"
+    relocated = json.loads(relocated_path.read_text())
+    relocated["sources"]["genome-1"]["path"] = str((relocated_dir / "source.gbff").resolve())
+    relocated_path.write_text(json.dumps(relocated, indent=2, sort_keys=True))
+    assert load_dataset_manifest(relocated_path)["dataset"]["id"] == original["dataset"]["id"]
+    assert dataset_identity(copy.deepcopy(relocated)) == original["dataset"]["id"]

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -190,6 +190,7 @@ def test_global_packing_is_deterministic_for_same_seed(tmp_path):
 
     first_manifest = json.loads(Path(outputs[0]["combined_manifest"]).read_text())
     second_manifest = json.loads(Path(outputs[1]["combined_manifest"]).read_text())
+    assert first_manifest["dataset"]["id"] == second_manifest["dataset"]["id"]
     for key in ("seed", "split_policy", "genome_sources", "packing"):
         assert first_manifest[key] == second_manifest[key]
 
@@ -213,6 +214,12 @@ def test_global_builder_fragments_ambiguity_after_source_split(tmp_path):
 
     assert result.returncode == 0, result.stderr
     manifest = json.loads((output_dir / "manifest.json").read_text())
+    assert manifest["schema"] == {"name": "codonlm_dataset_manifest", "version": 1}
+    assert len(manifest["dataset"]["id"]) == 64
+    assert manifest["dataset"]["scientific_valid"] is False
+    assert set(manifest["artifacts"]) >= {
+        "train_tokens", "val_tokens", "test_tokens", "vocabulary", "leakage_audit"
+    }
     policy = manifest["tokenization"]["ambiguous_codon_policy"]
     assert policy["name"] == "split"
     assert policy["min_fragment_codons"] == 2
@@ -464,6 +471,8 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
         str(train_npz),
         "--test_npz",
         str(test_npz),
+        "--manifest",
+        str(output_dir / "manifest.json"),
     ]
     
     res_baselines = subprocess.run(cmd_baselines, capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- define and validate the codonlm_dataset_manifest v1 contract for sources, splits, tokenization, lossless packing, vocabulary, leakage gates, seeds, and artifact hashes
- compute relocation-independent dataset IDs and reject missing, modified, inconsistent, unsafe, or untracked artifacts
- make the global builder validate its own authoritative and run-compatibility manifests
- validate manifests at training, perplexity, and DNA-shape evaluation boundaries while labeling absent manifests legacy/unverified
- add a validation CLI, fixed/dynamic/memmap fixtures, deterministic identity checks, documentation, and a consolidated Stage 29 development-log record for PRs #94-#107

Refs #92

## Testing
- pytest -q (256 passed, 1 skipped, 1 xpassed)
- ruff check src/codonlm/dataset_manifest.py scripts/validate_dataset_manifest.py scripts/build_global_manifest.py src/codonlm/training/loop.py scripts/eval_ppl_baselines.py scripts/eval_shape_baselines.py tests/test_dataset_manifest.py tests/test_global_split_and_baselines.py
- git diff --check