### PR TITLE
Add corrected CPU and MPS training preflight

### DIFF
--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -1,7 +1,8 @@
 # Leakage-Controlled CodonLM Revalidation Plan
 
 ## Status
-Planned. Full retraining is blocked until Phase 3 is complete.
+In progress. Engineering gates are complete; full retraining remains blocked on
+the corrected dataset freeze.
 
 ## Phase 1: Governance and CI
 - [x] Relabel legacy results and unsupported claims (#87).
@@ -29,7 +30,7 @@ is lost or duplicated, and every derived fragment/chunk retains its source split
 - [x] Apply configured attention dropout consistently in SDPA and manual paths (#81).
 - [x] Resolve new-run vocabulary exclusively from the tokenizer artifact and fail on
   dataset, config, or checkpoint mismatch (#84).
-- [ ] Run CPU integration tests and MPS smoke train/save/resume tests on the corrected
+- [x] Run CPU integration tests and MPS smoke train/save/resume tests on the corrected
   representation.
 
 Exit gate: all blocking data and trainer PRs are merged, CI is green, and an MPS

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -647,6 +647,11 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     the versioned dataset-manifest contract, CPU/MPS train-save-resume preflight, and
     immutable genome/genus-held-out dataset freeze. Only then should models be retrained
     from random initialization and the controlled evaluations rerun.
+*   **Corrected Training Lifecycle Preflight:** Added explicit CPU/MPS device selection,
+    committed non-PAD token accounting, checkpointed peak-memory telemetry, strict
+    dataset-identity resume validation, and a two-process train/save/resume integration
+    command. The 2026-07-21 host M2 run completed on MPS with four total optimizer
+    steps, 80 committed tokens, and zero non-finite or aborted accumulation groups.
 
 ---
 *End of Log*

--- a/docs/TRAINING_PREFLIGHT.md
+++ b/docs/TRAINING_PREFLIGHT.md
@@ -1,0 +1,39 @@
+# Corrected Training Preflight
+
+Run this gate before freezing datasets or starting a long training job. It creates
+a tiny manifest-validated dataset, trains through the real CLI, saves a checkpoint,
+restarts the process, resumes for another epoch, and validates optimizer, scheduler,
+committed-token, vocabulary, dataset-identity, accumulation-health, and memory state.
+
+CPU integration, also executed in CI:
+
+```bash
+python -m scripts.training_preflight \
+  --device cpu \
+  --work-dir /tmp/codonlm-preflight-cpu
+```
+
+Apple Silicon MPS integration:
+
+```bash
+python -m scripts.training_preflight \
+  --device mps \
+  --work-dir /tmp/codonlm-preflight-mps
+```
+
+Explicit device requests never fall back. `--device mps` fails when MPS is not
+available. The report is written to `<work-dir>/preflight_report.json`; child
+training logs and checkpoints remain under the same isolated directory.
+
+## Passing Gate
+
+A pass requires the requested and actual devices to match, optimizer and scheduler
+steps to advance after restart, committed non-PAD tokens to increase, dataset and
+vocabulary identities to remain unchanged, and all non-finite/aborted accumulation
+counters to remain zero. Resume on a different manifest identity is fatal.
+
+On 2026-07-21, the host M2 MPS run passed with 2 optimizer steps and 40 committed
+tokens before restart, 4 steps and 80 tokens after resume, zero invalid groups,
+approximately 90 KB peak live MPS tensor allocation, approximately 20.9 MB peak MPS
+driver allocation, and 4.43 seconds total preflight wall time. These figures validate
+the lifecycle only; they are not training-throughput or model-quality measurements.

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -151,6 +151,11 @@ gene-grouped results only when genome metadata is unavailable.
 
 ## 5. Performance and Architectural Ablations
 
+Before freezing data or starting corrected training, run the lifecycle preflight on
+CPU and the target Apple Silicon host as documented in
+[`TRAINING_PREFLIGHT.md`](TRAINING_PREFLIGHT.md). The MPS command must report
+`actual_device: mps`; CPU fallback is not a pass.
+
 Before merging changes that modify attention kernels (e.g., GQA, SDPA) or data loader structures:
 1. Run the throughput benchmark to record step rates:
    ```bash

--- a/scripts/training_preflight.py
+++ b/scripts/training_preflight.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Run a corrected dataset -> train -> checkpoint -> resume preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import yaml
+
+from src.codonlm.dataset_manifest import (
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    artifact_entry,
+    file_sha256,
+    finalize_manifest,
+    load_dataset_manifest,
+)
+
+
+def _write_fixture(root: Path) -> tuple[Path, dict]:
+    data_dir = root / "dataset"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    source = data_dir / "source.gbff"
+    source.write_text("LOCUS preflight fixture\n")
+    tokens = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>", "AAA", "CCC", "GGG", "TTT"]
+    vocabulary = data_dir / "itos.txt"
+    vocabulary.write_text("\n".join(tokens) + "\n")
+    auxiliary = {
+        "source_metadata": data_dir / "cds_meta.tsv",
+        "source_dna": data_dir / "cds_dna.txt",
+        "fragment_metadata": data_dir / "cds_fragments.tsv",
+        "leakage_audit": data_dir / "leakage_audit.json",
+    }
+    for name, path in auxiliary.items():
+        path.write_text(json.dumps({"fixture": name, "status": "passed"}) + "\n")
+    artifacts = {
+        "vocabulary": artifact_entry(vocabulary, data_dir, "vocabulary"),
+        **{name: artifact_entry(path, data_dir, name) for name, path in auxiliary.items()},
+    }
+    split_rows = {"train": 5, "val": 2, "test": 2}
+    for split, rows in split_rows.items():
+        x = np.tile(np.array([1, 4, 5, 6, 7, 4, 5, 6], dtype=np.int32), (rows, 1))
+        y = np.tile(np.array([4, 5, 6, 7, 4, 5, 6, 2], dtype=np.int32), (rows, 1))
+        dataset = data_dir / f"{split}.npz"
+        np.savez_compressed(dataset, X=x, Y=y)
+        artifacts[f"{split}_tokens"] = artifact_entry(dataset, data_dir, f"{split}_tokens")
+        packing = data_dir / f"{split}_packing.tsv"
+        packing.write_text("window_index\n" + "\n".join(map(str, range(rows))) + "\n")
+        artifacts[f"{split}_packing_metadata"] = artifact_entry(
+            packing, data_dir, f"{split}_packing_metadata"
+        )
+    manifest = finalize_manifest(
+        {
+            "schema": {"name": SCHEMA_NAME, "version": SCHEMA_VERSION},
+            "dataset": {"id": "pending", "scientific_valid": True, "source_record_count": 9},
+            "sources": {
+                "preflight-genome": {
+                    "path": str(source.resolve()),
+                    "sha256": file_sha256(source),
+                    "bytes": source.stat().st_size,
+                    "identity_source": "preflight_fixture",
+                }
+            },
+            "split_policy": {
+                "effective_group_by": "genome",
+                "allow_sequence_split": False,
+                "scientific_valid": True,
+                "requested_fractions": {"val": 2 / 9, "test": 2 / 9},
+                "record_counts": split_rows,
+                "groups_by_split": {
+                    "train": ["train-genome"], "val": ["val-genome"], "test": ["test-genome"]
+                },
+            },
+            "vocabulary": {
+                "sha256": file_sha256(vocabulary),
+                "size": len(tokens),
+                "special_tokens": {"<PAD>": 0, "<BOS_CDS>": 1, "<EOS_CDS>": 2, "<SEP>": 3},
+            },
+            "leakage_audit": {
+                "status": "passed", "homology_audit_skipped": False,
+                "exact_duplicate_override": False,
+            },
+            "tokenization": {"ambiguous_codon_policy": {"name": "split"}},
+            "packing": {"mode": "fixed", "transition_policy": "exactly_once"},
+            "reproducibility": {"split_seed": 1337, "packing_seed": 1337},
+            "artifacts": artifacts,
+        }
+    )
+    manifest_path = data_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    load_dataset_manifest(manifest_path)
+    return manifest_path, manifest
+
+
+def _config(root: Path, manifest_path: Path, device: str, epochs: int) -> Path:
+    data_dir = manifest_path.parent
+    config = {
+        "vocab_size": 8, "block_size": 8, "n_layer": 1, "n_head": 1,
+        "n_embd": 16, "dropout": 0.1, "batch_size": 2,
+        "grad_accum_steps": 2, "lr": 0.001, "min_lr": 0.0001,
+        "weight_decay": 0.0, "warmup_steps": 0, "epochs": epochs,
+        "optimizer": "adamw", "scheduler": "cosine", "amp": False,
+        "use_checkpoint": False, "use_sdpa": True, "sep_mask_enabled": True,
+        "early_stop_patience": 10, "seed": 1337, "num_workers": 0,
+        "device": device, "dataset_manifest": str(manifest_path),
+        "itos_path": str(data_dir / "itos.txt"),
+        "train_npz": str(data_dir / "train.npz"),
+        "val_npz": str(data_dir / "val.npz"),
+        "test_npz": str(data_dir / "test.npz"),
+        "out_dir": str(root / "unused-checkpoints"),
+        "scores_dir": str(root / "unused-scores"),
+    }
+    config_path = root / "preflight.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=True))
+    return config_path
+
+
+def _run_training(repo: Path, root: Path, config: Path, resume: Path | None = None):
+    command = [
+        sys.executable, "-m", "src.codonlm.train_codon_lm", "--config", str(config),
+        "--run_id", "corrected-preflight",
+    ]
+    if resume is not None:
+        command.extend(["--resume", str(resume)])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(repo) + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(command, cwd=root, env=env, capture_output=True, text=True)
+    log_name = "resume.log" if resume else "initial.log"
+    (root / log_name).write_text(result.stdout + result.stderr)
+    if result.returncode:
+        raise RuntimeError(f"training command failed; see {root / log_name}")
+    return command
+
+
+def _checkpoint_summary(path: Path):
+    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    return {
+        "path": str(path.resolve()),
+        "step": int(checkpoint["step"]),
+        "epoch": int(checkpoint["epoch"]),
+        "scheduler_last_epoch": int(checkpoint["scheduler"]["last_epoch"]),
+        "consumed_train_tokens": int(checkpoint["consumed_train_tokens"]),
+        "accumulation_health": checkpoint["accumulation_health"],
+        "runtime_memory": checkpoint["runtime_memory"],
+        "dataset_manifest": checkpoint["cfg"]["dataset_manifest"],
+        "vocabulary_sha256": checkpoint["cfg"]["vocabulary"]["sha256"],
+        "device": checkpoint["cfg"]["device"],
+    }
+
+
+def _mps_memory():
+    if not torch.backends.mps.is_available():
+        return None
+    driver = getattr(torch.mps, "driver_allocated_memory", None)
+    return {
+        "current_allocated_bytes": int(torch.mps.current_allocated_memory()),
+        "driver_allocated_bytes": int(driver()) if callable(driver) else None,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", choices=("cpu", "mps"), required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    args = parser.parse_args()
+    if args.device == "mps" and not torch.backends.mps.is_available():
+        parser.error("--device mps requested but MPS is not available")
+    root = args.work_dir.expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    repo = Path(__file__).resolve().parents[1]
+    started = time.perf_counter()
+    memory_before = _mps_memory()
+    manifest_path, manifest = _write_fixture(root)
+    config = _config(root, manifest_path, args.device, epochs=1)
+    initial_command = _run_training(repo, root, config)
+    checkpoint = root / "runs" / "corrected-preflight" / "checkpoints" / "last.pt"
+    initial = _checkpoint_summary(checkpoint)
+    config = _config(root, manifest_path, args.device, epochs=2)
+    resume_command = _run_training(repo, root, config, checkpoint)
+    resumed = _checkpoint_summary(checkpoint)
+    if resumed["step"] <= initial["step"]:
+        raise RuntimeError("optimizer step did not advance after resume")
+    if resumed["scheduler_last_epoch"] <= initial["scheduler_last_epoch"]:
+        raise RuntimeError("scheduler did not advance after resume")
+    if resumed["consumed_train_tokens"] <= initial["consumed_train_tokens"]:
+        raise RuntimeError("committed non-PAD token count did not advance after resume")
+    if resumed["dataset_manifest"]["dataset_id"] != manifest["dataset"]["id"]:
+        raise RuntimeError("checkpoint dataset identity does not match fixture manifest")
+    expected_health = {
+        "active_microbatches": 0, "nonfinite_microbatches": 0,
+        "aborted_groups": 0, "discarded_finite_microbatches": 0,
+    }
+    if resumed["accumulation_health"] != expected_health:
+        raise RuntimeError(f"unexpected accumulation health: {resumed['accumulation_health']}")
+    if args.device == "mps":
+        torch.mps.synchronize()
+    report = {
+        "status": "passed", "requested_device": args.device,
+        "actual_device": resumed["device"], "dataset_id": manifest["dataset"]["id"],
+        "dataset_schema": manifest["schema"], "initial": initial, "resumed": resumed,
+        "commands": {"initial": initial_command, "resume": resume_command},
+        "wall_seconds": time.perf_counter() - started,
+        "memory": {
+            "mps_before": memory_before, "mps_after": _mps_memory(),
+            "process_max_rss_raw": int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss),
+            "children_max_rss_raw": int(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss),
+        },
+        "environment": {
+            "python": sys.version, "pytorch": torch.__version__,
+            "platform": platform.platform(), "mps_available": torch.backends.mps.is_available(),
+        },
+    }
+    report_path = root / "preflight_report.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"status": "passed", "report": str(report_path), "steps": resumed["step"]}))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -5,6 +5,7 @@ import math
 import csv
 import json
 import logging
+import resource
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -124,8 +125,22 @@ def _average_accumulated_gradients(parameters, microbatch_count: int) -> None:
         if param.grad is not None:
             param.grad.div_(microbatch_count)
 
-def dev(force_gpu: bool = False):
-    device = default_device()
+def dev(force_gpu: bool = False, requested: str = "auto"):
+    requested = str(requested or "auto").lower()
+    if requested not in {"auto", "cpu", "mps", "cuda"}:
+        raise ValueError(f"unsupported device {requested!r}; expected auto, cpu, mps, or cuda")
+    if requested == "cpu":
+        device = torch.device("cpu")
+    elif requested == "mps":
+        if not torch.backends.mps.is_available():
+            raise RuntimeError("requested device=mps but MPS is not available")
+        device = torch.device("mps")
+    elif requested == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("requested device=cuda but CUDA is not available")
+        device = torch.device("cuda")
+    else:
+        device = default_device()
     if force_gpu and device.type == "cpu":
         raise RuntimeError("force_gpu=true but no CUDA or MPS device is available")
     return device
@@ -178,11 +193,13 @@ def run_training(cfg: dict, args) -> None:
             "scientific_valid": dataset_manifest["dataset"]["scientific_valid"],
             "schema": dataset_manifest["schema"],
         }
+        current_dataset_id = dataset_manifest["dataset"]["id"]
     else:
         cfg["dataset_manifest"] = {
             "status": "legacy_unverified",
             "scientific_valid": False,
         }
+        current_dataset_id = None
 
     configured_vocab_size = cfg.get("vocab_size")
     vocabulary_contract = resolve_vocabulary_contract(
@@ -195,7 +212,9 @@ def run_training(cfg: dict, args) -> None:
     if resume_path and not os.path.isfile(resume_path):
         raise FileNotFoundError(f"Resume checkpoint not found: {resume_path}")
     if resume_path:
-        validate_resume_checkpoint(resume_path, vocabulary_contract)
+        validate_resume_checkpoint(
+            resume_path, vocabulary_contract, dataset_id=current_dataset_id
+        )
 
     transfer_path = None if resume_path else (args.transfer_from or cfg.pop("transfer_from", None))
     if transfer_path and not os.path.isfile(transfer_path):
@@ -376,7 +395,10 @@ def run_training(cfg: dict, args) -> None:
             ])
 
     try:
-        device = dev(force_gpu=bool(cfg.get("force_gpu", False)))
+        device = dev(
+            force_gpu=bool(cfg.get("force_gpu", False)),
+            requested=str(cfg.get("device", "auto")),
+        )
     except Exception as exc:
         print(f"[error] training failed: {exc}", file=sys.stderr)
         write_failure_meta(exc)
@@ -658,6 +680,13 @@ def run_training(cfg: dict, args) -> None:
     best = float("inf")
     no_improve = 0
     step = 0
+    consumed_train_tokens = 0
+    pending_train_tokens = 0
+    runtime_memory = {
+        "process_max_rss_raw": int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss),
+        "mps_peak_allocated_bytes": 0,
+        "mps_peak_driver_bytes": 0,
+    }
     best_epoch = None
     resume_microbatch_idx = 0
     current_epoch_idx = 0
@@ -742,6 +771,15 @@ def run_training(cfg: dict, args) -> None:
                     print(f"[resume] scheduler state load failed: {exc}")
             start_epoch = int(ckpt_resume.get("epoch", 0))
             step = int(ckpt_resume.get("step", step))
+            consumed_train_tokens = int(
+                ckpt_resume.get("consumed_train_tokens", consumed_train_tokens)
+            )
+            pending_train_tokens = 0
+            previous_memory = ckpt_resume.get("runtime_memory", {})
+            for key in runtime_memory:
+                runtime_memory[key] = max(
+                    runtime_memory[key], int(previous_memory.get(key, 0) or 0)
+                )
             best = float(ckpt_resume.get("best_val", best))
             best_epoch = ckpt_resume.get("best_epoch", best_epoch)
             no_improve = int(ckpt_resume.get("no_improve", no_improve))
@@ -804,6 +842,8 @@ def run_training(cfg: dict, args) -> None:
                 "best_epoch": best_epoch,
                 "no_improve": no_improve,
                 "step": step,
+                "consumed_train_tokens": int(consumed_train_tokens),
+                "runtime_memory": dict(runtime_memory),
                 "epoch_microbatch_idx": (
                     0 if val_loss != float("inf") else int(current_resume_microbatch_idx)
                 ),
@@ -828,6 +868,7 @@ def run_training(cfg: dict, args) -> None:
 
         def one_pass(split, loader, epoch_idx: int, skip_microbatches: int = 0):
             nonlocal step, current_epoch_idx, current_microbatch_idx, current_resume_microbatch_idx, replay_iter
+            nonlocal consumed_train_tokens, pending_train_tokens
             mps_autocast_ok = True
             model.train(split=="train")
             total, next_total, term_total, replay_total, n = 0.0, 0.0, 0.0, 0.0, 0
@@ -838,6 +879,22 @@ def run_training(cfg: dict, args) -> None:
             optim.zero_grad(set_to_none=True)
             skipped = 0
             health_before = accumulation_health.state_dict()
+
+            def sample_runtime_memory() -> None:
+                runtime_memory["process_max_rss_raw"] = max(
+                    runtime_memory["process_max_rss_raw"],
+                    int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss),
+                )
+                if device.type == "mps":
+                    runtime_memory["mps_peak_allocated_bytes"] = max(
+                        runtime_memory["mps_peak_allocated_bytes"],
+                        int(torch.mps.current_allocated_memory()),
+                    )
+                    driver = getattr(torch.mps, "driver_allocated_memory", None)
+                    if callable(driver):
+                        runtime_memory["mps_peak_driver_bytes"] = max(
+                            runtime_memory["mps_peak_driver_bytes"], int(driver())
+                        )
             start_time = time.perf_counter()
             if split == "train" and skip_microbatches > 0:
                 print(f"[resume] skipping {skip_microbatches}/{len(loader)} already-applied train microbatches")
@@ -922,6 +979,7 @@ def run_training(cfg: dict, args) -> None:
 
                 def step_optimizer(group_size: int) -> None:
                     nonlocal step, current_resume_microbatch_idx
+                    nonlocal consumed_train_tokens, pending_train_tokens
                     if group_size <= 0:
                         return
                     _average_accumulated_gradients(trainable_params, group_size)
@@ -932,6 +990,8 @@ def run_training(cfg: dict, args) -> None:
                     optim.step()
                     optim.zero_grad(set_to_none=True)
                     accumulation_health.complete_group()
+                    consumed_train_tokens += pending_train_tokens
+                    pending_train_tokens = 0
                     step += 1
                     current_resume_microbatch_idx = batch_idx + 1
                     if use_cosine:
@@ -954,6 +1014,7 @@ def run_training(cfg: dict, args) -> None:
                     skipped += 1
                     if split == "train":
                         discarded = accumulation_health.abort_group(optim)
+                        pending_train_tokens = 0
                         current_resume_microbatch_idx = batch_idx + 1
                         print(
                             "[train] aborted nonfinite accumulation group "
@@ -968,6 +1029,7 @@ def run_training(cfg: dict, args) -> None:
                     continue
                 if split=="train":
                     loss.backward()
+                    pending_train_tokens += int(yb.ne(PAD_ID).sum().item())
                     accumulation_health.record_finite_microbatch()
                     if accumulation_health.active_microbatches == gacc:
                         step_optimizer(accumulation_health.active_microbatches)
@@ -985,6 +1047,7 @@ def run_training(cfg: dict, args) -> None:
                     offset_totals[offset] += float(offset_loss.detach().item())
                     offset_counts[offset] += 1
                 n += 1
+                sample_runtime_memory()
                 wall_timer.check()
             
             if split == "train" and accumulation_health.active_microbatches:

--- a/src/codonlm/training/vocabulary.py
+++ b/src/codonlm/training/vocabulary.py
@@ -194,7 +194,12 @@ def checkpoint_embedding_rows(checkpoint: dict) -> tuple[int | None, int | None]
     )
 
 
-def validate_resume_checkpoint(checkpoint_path: str | Path, contract: VocabularyContract) -> None:
+def validate_resume_checkpoint(
+    checkpoint_path: str | Path,
+    contract: VocabularyContract,
+    *,
+    dataset_id: str | None = None,
+) -> None:
     checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     embedding_rows, output_rows = checkpoint_embedding_rows(checkpoint)
     checkpoint_cfg = checkpoint.get("cfg", {}) if isinstance(checkpoint, dict) else {}
@@ -210,6 +215,17 @@ def validate_resume_checkpoint(checkpoint_path: str | Path, contract: Vocabulary
     checkpoint_hash = checkpoint_vocab.get("sha256") if isinstance(checkpoint_vocab, dict) else None
     if checkpoint_hash is not None and checkpoint_hash != contract.sha256:
         mismatches.append(f"checkpoint vocabulary sha256={checkpoint_hash}")
+    if dataset_id is not None:
+        checkpoint_manifest = checkpoint_cfg.get("dataset_manifest", {})
+        checkpoint_dataset_id = (
+            checkpoint_manifest.get("dataset_id")
+            if isinstance(checkpoint_manifest, dict)
+            else None
+        )
+        if checkpoint_dataset_id != dataset_id:
+            mismatches.append(
+                f"checkpoint dataset_id={checkpoint_dataset_id!r}, current dataset_id={dataset_id!r}"
+            )
     if mismatches:
         raise VocabularyContractError(
             f"Resume checkpoint {checkpoint_path} is incompatible with tokenizer "

--- a/tests/test_nonfinite_accumulation.py
+++ b/tests/test_nonfinite_accumulation.py
@@ -101,6 +101,7 @@ def test_nonfinite_abort_checkpoint_and_resume_preserve_step_counters(
     checkpoint_path = tmp_path / "runs/nonfinite-resume/checkpoints/last.pt"
     checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     assert checkpoint["step"] == 0
+    assert checkpoint["consumed_train_tokens"] == 0
     assert checkpoint["scheduler"]["last_epoch"] == 0
     assert checkpoint["epoch_microbatch_idx"] == 2
     assert checkpoint["accumulation_health"] == {
@@ -125,6 +126,7 @@ def test_nonfinite_abort_checkpoint_and_resume_preserve_step_counters(
 
     resumed = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     assert resumed["step"] == 2
+    assert resumed["consumed_train_tokens"] == 12
     assert resumed["scheduler"]["last_epoch"] == 2
     assert resumed["epoch_microbatch_idx"] == 0
     assert resumed["accumulation_health"]["aborted_groups"] == 1

--- a/tests/test_training_preflight.py
+++ b/tests/test_training_preflight.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import sys
+
+import torch
+
+from src.codonlm.training.loop import dev
+
+
+def test_explicit_cpu_device_never_auto_selects_accelerator():
+    assert dev(requested="cpu") == torch.device("cpu")
+
+
+def test_cpu_train_checkpoint_resume_preflight(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.training_preflight",
+            "--device",
+            "cpu",
+            "--work-dir",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads((tmp_path / "preflight_report.json").read_text())
+    assert report["status"] == "passed"
+    assert report["requested_device"] == report["actual_device"] == "cpu"
+    assert report["initial"]["step"] == 2
+    assert report["resumed"]["step"] == 4
+    assert report["initial"]["consumed_train_tokens"] == 40
+    assert report["resumed"]["consumed_train_tokens"] == 80
+    assert report["resumed"]["scheduler_last_epoch"] == 4
+    assert report["resumed"]["accumulation_health"] == {
+        "active_microbatches": 0,
+        "nonfinite_microbatches": 0,
+        "aborted_groups": 0,
+        "discarded_finite_microbatches": 0,
+    }
+    assert report["initial"]["dataset_manifest"]["dataset_id"] == report["dataset_id"]
+    assert report["resumed"]["runtime_memory"]["process_max_rss_raw"] > 0

--- a/tests/test_vocabulary_contract.py
+++ b/tests/test_vocabulary_contract.py
@@ -126,3 +126,29 @@ def test_resume_requires_exact_embedding_output_and_checkpoint_vocab(tmp_path):
     )
     with pytest.raises(VocabularyContractError, match="Use transfer_from"):
         validate_resume_checkpoint(legacy_checkpoint, contract)
+
+
+def test_resume_rejects_different_dataset_identity(tmp_path):
+    vocab = _write_vocab(tmp_path / "itos.txt")
+    dataset = tmp_path / "train.npz"
+    np.savez(dataset, X=np.array([[0, 1]]), Y=np.array([[1, 0]]))
+    contract = resolve_vocabulary_contract(
+        [dataset], configured_path=vocab, configured_size=None
+    )
+    checkpoint = tmp_path / "checkpoint.pt"
+    torch.save(
+        {
+            "model": {
+                "tok_emb.weight": torch.zeros(contract.size, 4),
+                "head.weight": torch.zeros(contract.size, 4),
+            },
+            "cfg": {
+                "vocab_size": contract.size,
+                "vocabulary": {"sha256": contract.sha256},
+                "dataset_manifest": {"dataset_id": "dataset-a"},
+            },
+        },
+        checkpoint,
+    )
+    with pytest.raises(VocabularyContractError, match="current dataset_id='dataset-b'"):
+        validate_resume_checkpoint(checkpoint, contract, dataset_id="dataset-b")


### PR DESCRIPTION
## Summary
- add an explicit CPU/MPS train-save-resume preflight using the real training CLI and a manifest-validated corrected fixture
- require requested devices without silent fallback and record actual device/environment data
- checkpoint committed non-PAD token exposure and in-process RSS/MPS peak-memory telemetry
- reject checkpoint resume when the dataset manifest identity changes, even if vocabulary and shapes still match
- verify optimizer, scheduler, epoch, token, accumulation-health, vocabulary, and dataset provenance continuity
- document the local MPS gate and mark the conductor engineering phase complete

Refs #92

## Host MPS result
- actual device: mps
- optimizer steps: 2 before restart, 4 after resume
- committed tokens: 40 before restart, 80 after resume
- invalid/aborted groups: 0
- peak live MPS allocation: 90,624 bytes
- peak MPS driver allocation: 20,905,984 bytes
- wall time: 4.43 seconds

## Testing
- pytest -q (259 passed, 1 skipped, 1 xpassed)
- pytest -q tests/test_training_preflight.py tests/test_nonfinite_accumulation.py tests/test_vocabulary_contract.py tests/test_trainer_utils.py
- ruff check scripts/training_preflight.py src/codonlm/training/loop.py src/codonlm/training/vocabulary.py tests/test_training_preflight.py tests/test_nonfinite_accumulation.py tests/test_vocabulary_contract.py
- git diff --check