### PR TITLE
Add corrected training plan and dataset freeze entry point

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -81,6 +81,10 @@ This file tracks all major tracks for the project. Each track has its own detail
 *Link: [./tracks/leakage_controlled_revalidation_20260719/](./tracks/leakage_controlled_revalidation_20260719/)*
 *Summary: Correct tokenization, packing, leakage gates, trainer semantics, and evaluation provenance; freeze versioned genome/genus-held-out datasets; then retrain from scratch once and publish corrected intrinsic and downstream results separately from legacy Stage 2.6.*
 
+- [ ] **Track: Corrected CodonLM Training Program**
+*Link: [./tracks/corrected_model_training_20260721/](./tracks/corrected_model_training_20260721/)*
+*Summary: Train and validate a basic next-codon CodonLM first, then evaluate multi-offset, termination/replay, and biophysical shape-guided models as separately gated extensions with matched controls and complete provenance.*
+
 - [x] **Track: CodonLM Trainer Refactor**
 *Link: [./tracks/codonlm_trainer_refactor_20260622/](./tracks/codonlm_trainer_refactor_20260622/)*
 *Summary: Completed. Refactored the monolithic 1,200-line `train_codon_lm.py` script into a modular `src/codonlm/training/` subpackage (separating config, checkpoints, objectives, and training loop) while preserving CLI backwards compatibility and mid-epoch resume semantics. Updated all import locations across scripts and tests.*

--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -1,0 +1,117 @@
+# Corrected CodonLM Training Program Plan
+
+## Status
+
+Planned. The program is blocked on the corrected dataset and evaluator freeze.
+
+## Phase 0: Close Pre-Training Gates
+
+- [x] Pin the intended 24-source GBFF inventory by explicit assembly ID, byte size,
+  and SHA-256 digest.
+- [x] Add a fail-closed command that builds genome/genus protocols, validates their
+  shared source/vocabulary/packing contract, and emits a content-addressed freeze
+  index.
+- [ ] Complete Phase 4 of the leakage-controlled revalidation track: freeze immutable
+  genome-held-out and genus-held-out datasets.
+- [ ] Publish source, split, fragment, chunk, packed-array, vocabulary, and audit
+  hashes plus count summaries.
+- [ ] Complete frozen-manifest evaluator fixtures and provenance validation.
+- [ ] Resolve generation protocol issue #85 before generation comparisons.
+- [ ] Benchmark issue #90 on MPS and either promote batch-aware memmap conversion or
+  close it with evidence of no useful benefit.
+- [ ] Select the MPS runtime policy through an equal-token quality gate.
+- [ ] Add immutable corrected primary configs and config-contract tests.
+
+Exit gate: the frozen artifacts reproduce, all leakage gates pass, evaluator fixtures
+pass, MPS preflight passes, and no unresolved semantic choice can change the training
+stream.
+
+## Phase 1: Train the Primary Basic Model
+
+- [ ] Run a bounded end-to-end pilot from random initialization on the frozen
+  genome-held-out dataset; verify loss scale, token counters, validation, checkpoint,
+  resume, memory, and wall-time estimates.
+- [ ] Train the genome-held-out primary model at seed `1337`.
+- [ ] Train the identical genome-held-out primary model at seed `2027`.
+- [ ] Train the separately labeled genus-held-out primary model from random
+  initialization.
+- [ ] Verify matched non-PAD exposure and config identity across comparable runs.
+- [ ] Archive complete run manifests, checkpoints, logs, and failure telemetry.
+
+Exit gate: all declared primary runs complete without leakage, OOM, non-finite update,
+counter mismatch, or provenance failure.
+
+## Phase 2: Evaluate and Decide on the Primary Model
+
+- [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test tokens.
+- [ ] Report per-seed and aggregate loss, perplexity, bits/codon, and improvement over
+  the best simple baseline.
+- [ ] Extract causal embeddings with dataset/checkpoint/vocabulary/code provenance.
+- [ ] Run EC, essentiality, AMR, and DNA-shape evaluations with controlled splits and
+  shared controls.
+- [ ] Run generated-sequence memorization, nucleotide-neighbor, and protein-neighbor
+  audits using the separated generation protocols.
+- [ ] Publish the corrected primary report with confidence intervals and limitations.
+- [ ] Record a go/no-go decision for extension training.
+
+Exit gate: the primary model outperforms the best simple intrinsic baseline and the
+report satisfies the corrected promotion criteria. Otherwise pause and audit.
+
+## Phase 3: Multi-Offset `n+x` Ablation
+
+- [ ] Predeclare offsets, weights, initialization policy, token budget, metrics, and
+  acceptance thresholds.
+- [ ] Train matched multi-offset runs without changing the primary architecture or
+  data split.
+- [ ] Report next-token and per-offset losses separately.
+- [ ] Rerun intrinsic, long-range, downstream, termination, and memory evaluations.
+- [ ] Promote or reject the extension using the specification gates.
+
+Exit gate: any accepted long-range gain is replicated and does not materially degrade
+next-token loss, termination, stability, or runtime reliability.
+
+## Phase 4: Termination and Replay Ablation
+
+- [ ] Predeclare termination buckets, replay construction, decoding conditions, and
+  matched prompt/sample seeds.
+- [ ] Train the termination-head condition without replay.
+- [ ] Train the generated-prefix replay condition if the head-only result is
+  insufficient.
+- [ ] Compare natural, syntax-constrained, replay-trained, and decoder-biased behavior
+  without conflating them.
+- [ ] Report length distributions, natural-stop, early-stop, and hard-cap rates plus
+  primary loss and sequence-quality controls.
+- [ ] Promote or reject the termination extension.
+
+Exit gate: natural completion improves without forced-stop dependence, short-sequence
+collapse, or material primary-quality regression.
+
+## Phase 5: Biophysical Shape-Guidance Ablation
+
+- [ ] Freeze and document the shape-encoder artifact, targets, training sources, and
+  relationship to all heldout groups.
+- [ ] Train the frozen-encoder condition from the corrected primary checkpoint.
+- [ ] Train the jointly unfrozen condition with recorded discriminative learning
+  rates and matched token exposure.
+- [ ] Run grouped DNA-shape evaluation with one-hot, random-model, 5-mer, and 7-mer
+  controls on shared folds.
+- [ ] Rerun synonymous and de novo generation with matched seeds, confidence
+  intervals, absolute effects, and memorization audits.
+- [ ] Promote or reject shape guidance independently of termination and multi-offset
+  objectives.
+
+Exit gate: replicated shape-guided improvement survives sequence controls and does
+not depend on leakage, unmatched decoding, or proxy-only interpretation.
+
+## Phase 6: Combined Candidate and Final Report
+
+- [ ] Combine only independently promoted extensions and predeclare the rationale.
+- [ ] Train a matched combined candidate; do not replace independent ablations.
+- [ ] Rerun the complete intrinsic, downstream, generation, memorization, runtime, and
+  provenance suite.
+- [ ] Publish a versioned comparison covering the basic model and every extension.
+- [ ] Update repository headline tables while preserving a separate legacy section.
+- [ ] Close or create follow-up issues based on failed gates and remaining limitations.
+
+Exit gate: the selected model is supported by corrected replicated evidence, and each
+claimed gain can be attributed to a tested extension.

--- a/conductor/tracks/corrected_model_training_20260721/spec.md
+++ b/conductor/tracks/corrected_model_training_20260721/spec.md
@@ -1,0 +1,185 @@
+# Corrected CodonLM Training Program
+
+## Status
+
+Planned. Dataset freeze and evaluator validation are prerequisites; no full training
+run is authorized until their gates pass.
+
+## Objective
+
+Train a leakage-controlled causal CodonLM from random initialization, establish its
+value over simple sequence baselines, and then test long-range, termination, and
+biophysical extensions as separately attributable experiments.
+
+This track defines the model sequence within the broader
+[leakage-controlled revalidation track](../leakage_controlled_revalidation_20260719/).
+That track owns dataset correctness and publication requirements. This track owns
+which models are trained, how they are compared, and when an extension is promoted.
+
+## Scientific Questions
+
+1. Does a basic causal Transformer outperform uniform, unigram, bigram, and trigram
+   predictors on truly held-out genomes and genera?
+2. Do corrected causal embeddings improve controlled downstream tasks?
+3. Do multi-offset heads add useful long-range information without degrading the
+   primary next-codon model?
+4. Does an explicit termination objective improve natural sequence completion rather
+   than merely forcing a decoder stop?
+5. Does DNA-shape conditioning add information beyond codon identity and local
+   nucleotide-context controls?
+
+## Prerequisite Gates
+
+Full training is blocked until all of the following are true:
+
+- The corrected genome-held-out and genus-held-out datasets are immutable and
+  identified by versioned manifests and artifact hashes.
+- Ambiguity fragmentation, chunking, packing, vocabulary, exact-duplicate, and
+  protein-homology gates pass.
+- Every final evaluator consumes explicit frozen artifacts and emits provenance.
+- CPU integration and MPS train/save/resume preflights pass.
+- The MPS runtime policy is selected by an equal-token quality comparison without
+  changing model architecture or objectives.
+
+## Stage 1: Primary Basic CodonLM
+
+The headline corrected model is a decoder-only causal Transformer trained solely on
+next-codon prediction.
+
+### Fixed model family
+
+- 10 Transformer layers.
+- 8 query heads.
+- Embedding width 384.
+- Maximum context 512 unless a corrected-data context ablation later promotes a
+  shorter context.
+- Dropout 0.1, including attention-probability dropout during training.
+- Vocabulary resolved exclusively from the frozen tokenizer artifact.
+- Standard multi-head or grouped-query attention selected only through the MPS
+  runtime/quality gate.
+
+### Excluded from the primary model
+
+- Shape or nucleotide-physics encoder.
+- Multi-offset `n+x` prediction heads.
+- Termination-distance head or generated-prefix replay.
+- Protein critic or energy-guided objective.
+- Legacy checkpoint transfer.
+- RoPE, SwiGLU, model-size, or other architecture changes mixed into this comparison.
+
+### Required runs
+
+- Genome-held-out training from random initialization at seeds `1337` and `2027`.
+- A separately labeled genus-held-out run from random initialization.
+- Matched non-PAD token exposure, objective, architecture, tokenizer, and evaluation
+  commands across comparable runs.
+
+The two genome seeds form the primary result. Genus holdout measures a harder and
+different generalization regime and must not be pooled with genome-holdout metrics.
+
+## Stage 2: Primary Evaluation Gate
+
+Before extensions are trained, the primary model must be compared with uniform,
+unigram, bigram, and trigram baselines on the identical held-out token stream. Report
+loss, perplexity, bits/codon, token count, and improvement over the best simple
+baseline.
+
+Corrected causal embeddings must then be evaluated on EC, essentiality, AMR, and
+DNA-shape tasks using their controlled group/homology splits and shared controls.
+Generated samples require nucleotide/protein nearest-neighbor and training-match
+coverage audits before novelty claims.
+
+Failure to outperform the best simple intrinsic baseline pauses extension training
+and triggers a data, objective, optimization, and evaluation audit. Extensions must
+not be used to conceal a failed primary model.
+
+## Stage 3: Multi-Offset Long-Range Extension
+
+Multi-offset heads predict future tokens such as `n+4`, `n+8`, `n+16`, and `n+32`
+from the causal hidden state. They are auxiliary training signals intended to retain
+longer-range information; they do not replace next-token prediction.
+
+Train this as a labeled ablation from a corrected primary checkpoint or under a
+matched from-scratch protocol. Use the same frozen data, heldouts, token budget, and
+seeds as its primary control. Report each offset loss separately.
+
+Promotion requires:
+
+- Primary next-token validation loss no more than 2% worse than the matched control.
+- No termination, stability, memory, or non-finite-update regression.
+- Improvement with confidence intervals in at least one predeclared long-range or
+  downstream metric.
+
+## Stage 4: Termination and Length Extension
+
+The termination head predicts distance-to-stop categories. Generated-prefix replay
+may expose it to off-distribution states encountered during autoregressive decoding.
+Decoder stop bias is a separate inference intervention and must not be conflated with
+natural model termination.
+
+Compare, using matched prompts and decoding seeds:
+
+1. Primary model with raw or syntax-constrained decoding as declared.
+2. Termination-head model without decoder bias.
+3. Termination-head model with generated-prefix replay.
+4. Decoder-biased generation, reported only as an intervention.
+
+Promotion requires improved natural terminal-stop and hard-cap rates without short
+peptide collapse, material perplexity regression, or degradation in sequence-quality
+controls.
+
+## Stage 5: Biophysical Shape-Guided Extension
+
+The biophysical extension conditions causal token representations on a nucleotide
+shape encoder. It tests whether explicit local physical descriptors add information
+beyond sequence identity; its computed stability and shape targets remain proxies,
+not experimental evidence.
+
+Run the following matched conditions:
+
+1. Corrected primary CodonLM.
+2. Primary CodonLM plus a frozen, provenance-recorded shape encoder.
+3. Primary CodonLM plus a jointly trained shape encoder using discriminative learning
+   rates.
+4. Shape plus termination only after both independent extensions pass their gates.
+
+All extension runs must initialize from a corrected primary checkpoint, or be clearly
+labeled as matched from-scratch experiments. Legacy checkpoints cannot support
+corrected held-out claims.
+
+Promotion requires paired confidence intervals and improvement over one-hot codon,
+random-model, 5-mer, and 7-mer controls under gene/genome-grouped folds. Parameter
+movement alone is not evidence of useful co-adaptation.
+
+## Artifact Contract
+
+Every run must preserve:
+
+- Git SHA and exact resolved configuration.
+- Source, dataset-manifest, tokenizer, vocabulary, and audit hashes.
+- Initialization checkpoint identity or an explicit random-initialization declaration.
+- Seed, split regime, model/objective flags, and trainable parameter groups.
+- Committed non-PAD tokens, optimizer/scheduler counters, wall time, throughput, peak
+  memory, non-finite batches, aborted groups, and termination reason.
+- `last` and `best` checkpoints with exact-resume state.
+- Machine-readable evaluation results and a human-readable comparison report.
+
+## Claim Discipline
+
+- Legacy results remain historical hypotheses and cannot initialize the primary run.
+- Report absolute changes alongside relative ratios.
+- Computational stability, Pfam, EC, critic, and DNA-shape scores are proxy outcomes.
+- Synonymous generation measures codon choice for a fixed protein, not de novo protein
+  discovery.
+- Raw, CDS-constrained, decoder-biased, and critic-guided generation are distinct
+  protocols.
+- A result becomes a corrected headline only after every prerequisite, replication,
+  baseline, provenance, and audit gate passes.
+
+## Non-Goals
+
+- Training every implemented extension in one model.
+- Selecting an architecture based only on throughput.
+- Treating smoke runs as quality evidence.
+- Reusing legacy holdout-exposed checkpoints for corrected claims.
+- Claiming experimental function or stability from computational proxy scores.

--- a/configs/corrected_codonlm_dataset_v1.yaml
+++ b/configs/corrected_codonlm_dataset_v1.yaml
@@ -1,0 +1,134 @@
+# Immutable source inventory and preparation policy for the first corrected CodonLM run.
+# Source hashes bind the local GBFF snapshots; any source drift is fatal.
+
+block_size: 512
+pack_mode: multi
+windows_per_seq: 1
+val_frac: 0.1
+test_frac: 0.1
+min_len: 90
+min_fragment_codons: 10
+max_cross_split_protein_identity: 0.3
+min_homology_coverage: 0.8
+
+datasets:
+  - name: ecoli_k12
+    genome_id: GCF_000005845
+    gbff: data/raw/Enterobacteriaceae/GCF_000005845.gbff
+    bytes: 11882100
+    sha256: 0bf75744d8ef1c9c5bae4ef2e18bf9dda06c1ffae29d1c14265068a90e575827
+  - name: streptomyces_avermitilis
+    genome_id: GCF_000009765
+    gbff: data/raw/Enterobacteriaceae/GCF_000009765.gbff
+    bytes: 23952978
+    sha256: 8d8f7eeeec00777657395dea30aa778f13c4bfc8a7349261a2f8d01648264158
+  - name: klebsiella_pneumoniae
+    genome_id: GCF_000240185
+    gbff: data/raw/Enterobacteriaceae/GCF_000240185.gbff
+    bytes: 12420539
+    sha256: 1c820fffce2db787627e515308f18e44d98dea6284879dd8aefd728458d4b6c9
+  - name: nitrososphaera_viennensis
+    genome_id: GCF_000698785
+    gbff: data/raw/Enterobacteriaceae/GCF_000698785.gbff
+    bytes: 6915778
+    sha256: ae4582e9c25581f3e52a2af2570e48e650b32b4ea39b34fe4c5ff5c5a4642955
+  - name: salmonella_enterica
+    genome_id: GCF_000006945
+    gbff: data/raw/Enterobacteriaceae/GCF_000006945.gbff
+    bytes: 12753261
+    sha256: 4eb18db183e4216a5c82540574ec16042f96ae3d44a81f28ec54139feceb0c82
+  - name: bacillus_subtilis
+    genome_id: GCF_000009045
+    gbff: data/raw/gram_pos/GCF_000009045.gbff
+    bytes: 13416020
+    sha256: dec50c042eac02710a380ea72db40a1cb5ce6af17556a1668a674f06cfea16d0
+  - name: staphylococcus_aureus
+    genome_id: GCF_000013425
+    gbff: data/raw/gram_pos/GCF_000013425.gbff
+    bytes: 6335681
+    sha256: 7833f1e79c1fb7b0b5212d7f8ec2ace7119591391382ae51c8fee215959d134b
+  - name: pseudomonas_aeruginosa
+    genome_id: GCF_000006765
+    gbff: data/raw/high-gc/GCF_000006765.gbff
+    bytes: 14682016
+    sha256: a745f10b2ec129bf81d855af17c13e9d1a7864ddb664fc88b773b06ba5d2d9d9
+  - name: streptomyces_coelicolor
+    genome_id: GCF_000203835
+    gbff: data/raw/high-gc/GCF_000203835.gbff
+    bytes: 22652642
+    sha256: 00e9562a3afbcd1b13faf1b6f458e8727ea6d4e7e45e5cb72d081a167e1c148e
+  - name: vibrio_cholerae
+    genome_id: GCF_000006745.1
+    gbff: data/raw/expanded/GCF_000006745.1.gbff
+    bytes: 10448757
+    sha256: f1cca2e36c6bda695f50d6ac9fdd1cdc54c571cfc829beed438c0c529859dff2
+  - name: caulobacter_vibrioides
+    genome_id: GCF_000006905.1
+    gbff: data/raw/expanded/GCF_000006905.1.gbff
+    bytes: 10437485
+    sha256: e22bfe1bee5b5e32bda1bf3b0fc4d89a5882987516e5ffc3920cba88870569a6
+  - name: shigella_flexneri
+    genome_id: GCF_000006925.2
+    gbff: data/raw/expanded/GCF_000006925.2.gbff
+    bytes: 10571574
+    sha256: 5997ec0ad92bfcae880354e56e3f7b4a029f6d6f2748115d3439daeb6219e6e7
+  - name: streptococcus_pneumoniae
+    genome_id: GCF_000007045.1
+    gbff: data/raw/expanded/GCF_000007045.1.gbff
+    bytes: 5280630
+    sha256: ced8476662772238876039ea4900c7d6dda4594ac5961f7e9d03877d76a4d15f
+  - name: geobacter_sulfurreducens
+    genome_id: GCF_000007985.2
+    gbff: data/raw/expanded/GCF_000007985.2.gbff
+    bytes: 9563743
+    sha256: bf6ae3e9ecbe4606b4445e9c7540c448295642485a0cb80392cda27bba51e2b9
+  - name: helicobacter_pylori
+    genome_id: GCF_000008525.1
+    gbff: data/raw/expanded/GCF_000008525.1.gbff
+    bytes: 4344891
+    sha256: 7919a5230ec625da7b136226255bbfac251d30b70f840a0f3206586e55d698ac
+  - name: borreliella_burgdorferi
+    genome_id: GCF_000008685.2
+    gbff: data/raw/expanded/GCF_000008685.2.gbff
+    bytes: 3955770
+    sha256: b23aa454330184dc0db35c512258faad21e81f3e90204dce54e4574dc5ca9db7
+  - name: chlamydia_trachomatis
+    genome_id: GCF_000008725.1
+    gbff: data/raw/expanded/GCF_000008725.1.gbff
+    bytes: 2228791
+    sha256: ecc60e51ba4ad7fa23a1d960257a2c8817e4220a0ae83981b006ee81f0757ffe
+  - name: neisseria_meningitidis
+    genome_id: GCF_000008805.1
+    gbff: data/raw/expanded/GCF_000008805.1.gbff
+    bytes: 5765110
+    sha256: 6aa1cf795af6c5b94b58f8488e6f17bac99bc3e841c584d26150773858f99aec
+  - name: ralstonia_pseudosolanacearum
+    genome_id: GCF_000009125.1
+    gbff: data/raw/expanded/GCF_000009125.1.gbff
+    bytes: 15159743
+    sha256: 1527c186848c25056cf8dfbb89c8536682ad68c710611daed35d0a0837276639
+  - name: synechocystis_sp
+    genome_id: GCF_000009725.1
+    gbff: data/raw/expanded/GCF_000009725.1.gbff
+    bytes: 9974821
+    sha256: a2575d062aab4cdb80ea75e6ec5f1d3d23fad13bda0aeecefee5e038dbaf2d7d
+  - name: bacteroides_thetaiotaomicron
+    genome_id: GCF_000011065.1
+    gbff: data/raw/expanded/GCF_000011065.1.gbff
+    bytes: 15154141
+    sha256: 42972ae2f0b669bf2dabe1f04045799a406cc8fc6f254b0b8a8a93bf94f746ba
+  - name: ruegeria_pomeroyi
+    genome_id: GCF_000011965.2
+    gbff: data/raw/expanded/GCF_000011965.2.gbff
+    bytes: 11979544
+    sha256: e53f29f73e90cead19e03ed247b39c2cc4ddaded701f8d676d031d7da0c8d4e2
+  - name: mycoplasmoides_genitalium
+    genome_id: GCF_000027325.1
+    gbff: data/raw/expanded/GCF_000027325.1.gbff
+    bytes: 1522816
+    sha256: 9f77e43e8b5a755a1d7eefaab7e3f48f0d751088ce7f478fe453da4c411a062b
+  - name: lactiplantibacillus_plantarum
+    genome_id: GCF_000203855.3
+    gbff: data/raw/expanded/GCF_000203855.3.gbff
+    bytes: 8560998
+    sha256: 287259f644e52b71d1904bb4589d663c2b00012e8e4cfb8a7acd94e1ea310d05

--- a/docs/DATASET_MANIFEST.md
+++ b/docs/DATASET_MANIFEST.md
@@ -35,3 +35,31 @@ as `legacy_unverified`; an explicit or discovered invalid manifest is fatal.
 
 Evaluators record the validated dataset ID when `--manifest` is supplied. Results
 without it remain legacy/unverified and cannot support corrected headline claims.
+
+## Corrected Dataset Freeze
+
+The first corrected training program uses the pinned 24-genome inventory in
+`configs/corrected_codonlm_dataset_v1.yaml`. Verify that every local GBFF still
+matches its declared assembly ID, byte size, and SHA-256 digest without creating
+derived data:
+
+```bash
+python -m scripts.freeze_corrected_datasets \
+  --config configs/corrected_codonlm_dataset_v1.yaml \
+  --freeze-id corrected-codonlm-v1 \
+  --verify-sources-only
+```
+
+Build both genome- and genus-held-out protocols and bind their manifests into one
+content-addressed `freeze.json`:
+
+```bash
+python -m scripts.freeze_corrected_datasets \
+  --config configs/corrected_codonlm_dataset_v1.yaml \
+  --freeze-id corrected-codonlm-v1 \
+  --seed 1337 \
+  --audit-threads 4
+```
+
+MMseqs2 is mandatory for this command. The freeze refuses to skip its cross-split
+protein-homology gate and refuses to overwrite an existing freeze ID.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -652,6 +652,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     dataset-identity resume validation, and a two-process train/save/resume integration
     command. The 2026-07-21 host M2 run completed on MPS with four total optimizer
     steps, 80 committed tokens, and zero non-finite or aborted accumulation groups.
+*   **Corrected Training Program and Dataset-Freeze Entry Point:** Defined the staged
+    basic, multi-offset, termination/replay, and biophysical training program. Pinned
+    the first corrected corpus to 24 explicit GBFF assembly snapshots using byte sizes
+    and SHA-256 hashes, made the global builder fail on source drift, and added a
+    fail-closed command that prepares both genome- and genus-held-out protocols and
+    binds their validated manifests into one content-addressed freeze index. The local
+    source-only preflight passes; the scientific freeze remains pending because its
+    mandatory MMseqs2 homology audit has not yet run on this host.
 
 ---
 *End of Log*

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -82,6 +82,26 @@ def _parse_extra_dataset(spec: str) -> dict:
     return entry
 
 
+def validate_pinned_source(dataset: dict, gbff_path: Path) -> None:
+    """Fail before extraction when a configured immutable source has drifted."""
+    expected_sha256 = str(dataset.get("sha256", "")).strip().lower()
+    expected_bytes = dataset.get("bytes")
+    if expected_bytes is not None and gbff_path.stat().st_size != int(expected_bytes):
+        raise ValueError(
+            f"Source size mismatch for {gbff_path}: expected {expected_bytes}, "
+            f"found {gbff_path.stat().st_size}"
+        )
+    if expected_sha256:
+        if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+            raise ValueError(f"Invalid configured sha256 for {gbff_path}")
+        observed_sha256 = file_sha256(gbff_path)
+        if observed_sha256 != expected_sha256:
+            raise ValueError(
+                f"Source SHA-256 mismatch for {gbff_path}: expected "
+                f"{expected_sha256}, found {observed_sha256}"
+            )
+
+
 def resolve_genome_identity(dataset: dict, gbff_path: Path, record) -> tuple[str, str]:
     """Resolve a stable genome identity and describe its provenance."""
     for key in ("genome_id", "assembly_accession", "accession"):
@@ -254,6 +274,10 @@ def main() -> None:
         gbff_path = Path(ds["gbff"])
         if not gbff_path.exists():
             raise FileNotFoundError(f"GBFF not found: {gbff_path}")
+        try:
+            validate_pinned_source(ds, gbff_path)
+        except ValueError as exc:
+            raise SystemExit(f"[error] {exc}") from exc
         
         dataset_min_len = int(ds.get("min_len", min_len))
         for rec in SeqIO.parse(gbff_path, "genbank"):

--- a/scripts/freeze_corrected_datasets.py
+++ b/scripts/freeze_corrected_datasets.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Build and bind corrected genome/genus holdout datasets into one freeze index."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.build_global_manifest import validate_pinned_source
+from src.codonlm.dataset_manifest import file_sha256, load_dataset_manifest
+
+
+FREEZE_SCHEMA_NAME = "codonlm_dataset_freeze"
+FREEZE_SCHEMA_VERSION = 1
+GROUP_PROTOCOLS = ("genome", "genus")
+
+
+def load_and_validate_source_config(path: Path) -> dict[str, Any]:
+    cfg = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(cfg, dict):
+        raise ValueError("dataset config must be a mapping")
+    datasets = cfg.get("datasets")
+    if not isinstance(datasets, list) or len(datasets) < 3:
+        raise ValueError("dataset config must contain at least three pinned sources")
+
+    genome_ids: set[str] = set()
+    source_paths: set[Path] = set()
+    for index, dataset in enumerate(datasets):
+        if not isinstance(dataset, dict):
+            raise ValueError(f"datasets[{index}] must be a mapping")
+        genome_id = str(dataset.get("genome_id", "")).strip()
+        if not genome_id:
+            raise ValueError(f"datasets[{index}] is missing explicit genome_id")
+        if genome_id in genome_ids:
+            raise ValueError(f"duplicate genome_id in source inventory: {genome_id}")
+        genome_ids.add(genome_id)
+
+        if "sha256" not in dataset or "bytes" not in dataset:
+            raise ValueError(f"source {genome_id} must pin sha256 and bytes")
+        source_path = Path(str(dataset.get("gbff", ""))).expanduser().resolve()
+        if source_path in source_paths:
+            raise ValueError(f"duplicate source path in inventory: {source_path}")
+        source_paths.add(source_path)
+        if not source_path.is_file():
+            raise ValueError(f"source {genome_id} not found: {source_path}")
+        validate_pinned_source(dataset, source_path)
+    return cfg
+
+
+def validate_protocol_manifests(
+    manifests: dict[str, tuple[dict[str, Any], Path]],
+) -> None:
+    reference_sources = None
+    reference_vocab = None
+    reference_packing = None
+    for protocol in GROUP_PROTOCOLS:
+        manifest, _ = manifests[protocol]
+        if not manifest["dataset"].get("scientific_valid"):
+            raise ValueError(f"{protocol} dataset is not marked scientific_valid")
+        if manifest["split_policy"].get("effective_group_by") != protocol:
+            raise ValueError(f"{protocol} manifest uses the wrong split protocol")
+        if manifest["leakage_audit"].get("status") != "passed":
+            raise ValueError(f"{protocol} leakage audit did not pass")
+
+        sources = {
+            key: {"sha256": value["sha256"], "bytes": int(value["bytes"])}
+            for key, value in manifest["sources"].items()
+        }
+        vocab = {
+            "sha256": manifest["vocabulary"]["sha256"],
+            "size": int(manifest["vocabulary"]["size"]),
+            "special_tokens": manifest["vocabulary"]["special_tokens"],
+        }
+        packing = {
+            key: manifest["packing"][key]
+            for key in ("schema_version", "mode", "block_size", "transition_policy")
+        }
+        if reference_sources is None:
+            reference_sources = sources
+            reference_vocab = vocab
+            reference_packing = packing
+        elif sources != reference_sources:
+            raise ValueError("genome and genus manifests do not share the same sources")
+        elif vocab != reference_vocab:
+            raise ValueError("genome and genus manifests do not share the same vocabulary")
+        elif packing != reference_packing:
+            raise ValueError("genome and genus manifests do not share the same packing policy")
+
+
+def build_freeze_index(
+    *,
+    config_path: Path,
+    seed: int,
+    manifests: dict[str, tuple[dict[str, Any], Path]],
+) -> dict[str, Any]:
+    validate_protocol_manifests(manifests)
+    protocols = {}
+    for protocol in GROUP_PROTOCOLS:
+        manifest, manifest_path = manifests[protocol]
+        protocols[protocol] = {
+            "dataset_id": manifest["dataset"]["id"],
+            "manifest_path": str(manifest_path.resolve()),
+            "manifest_sha256": file_sha256(manifest_path),
+            "record_counts": manifest["split_policy"]["record_counts"],
+            "group_counts": manifest["split_policy"]["group_counts"],
+            "achieved_record_fractions": manifest["split_policy"][
+                "achieved_record_fractions"
+            ],
+        }
+    payload = {
+        "schema": {"name": FREEZE_SCHEMA_NAME, "version": FREEZE_SCHEMA_VERSION},
+        "config": {
+            "path": str(config_path.resolve()),
+            "sha256": file_sha256(config_path),
+        },
+        "split_seed": int(seed),
+        "protocols": protocols,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    payload["freeze_id"] = hashlib.sha256(encoded).hexdigest()
+    return payload
+
+
+def _run_builder(
+    *,
+    config_path: Path,
+    freeze_id: str,
+    protocol: str,
+    seed: int,
+    output_root: Path,
+    run_root: Path,
+    mmseqs_executable: str,
+    audit_threads: int,
+) -> Path:
+    output_dir = output_root / freeze_id / protocol
+    run_dir = run_root / freeze_id / protocol
+    if output_dir.exists() or run_dir.exists():
+        raise ValueError(
+            f"refusing to overwrite freeze output for {protocol}; choose a new "
+            "freeze id or remove the incomplete artifacts explicitly"
+        )
+    command = [
+        sys.executable,
+        "-m",
+        "scripts.build_global_manifest",
+        "--config",
+        str(config_path),
+        "--run-id",
+        f"{freeze_id}-{protocol}",
+        "--run-dir",
+        str(run_dir),
+        "--output-dir",
+        str(output_dir),
+        "--group-by",
+        protocol,
+        "--seed",
+        str(seed),
+        "--mmseqs-executable",
+        mmseqs_executable,
+        "--audit-threads",
+        str(audit_threads),
+    ]
+    subprocess.run(command, check=True)
+    return output_dir / "manifest.json"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--freeze-id", required=True)
+    parser.add_argument("--output-root", default="data/processed/corrected")
+    parser.add_argument("--run-root", default="runs/dataset_freeze")
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument("--audit-threads", type=int, default=1)
+    parser.add_argument(
+        "--verify-sources-only",
+        action="store_true",
+        help="Verify the pinned inventory without building derived datasets.",
+    )
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    cfg = load_and_validate_source_config(config_path)
+    print(f"[freeze] Verified {len(cfg['datasets'])} pinned source files.")
+    if args.verify_sources_only:
+        return
+    if shutil.which(args.mmseqs_executable) is None:
+        raise SystemExit(
+            f"[error] MMseqs2 executable not found: {args.mmseqs_executable}; "
+            "the scientific freeze cannot skip the homology gate"
+        )
+
+    output_root = Path(args.output_root)
+    run_root = Path(args.run_root)
+    manifest_paths = {
+        protocol: _run_builder(
+            config_path=config_path,
+            freeze_id=args.freeze_id,
+            protocol=protocol,
+            seed=args.seed,
+            output_root=output_root,
+            run_root=run_root,
+            mmseqs_executable=args.mmseqs_executable,
+            audit_threads=args.audit_threads,
+        )
+        for protocol in GROUP_PROTOCOLS
+    }
+    manifests = {
+        protocol: (load_dataset_manifest(path), path)
+        for protocol, path in manifest_paths.items()
+    }
+    index = build_freeze_index(
+        config_path=config_path,
+        seed=args.seed,
+        manifests=manifests,
+    )
+    index_path = output_root / args.freeze_id / "freeze.json"
+    index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n")
+    print(f"[freeze] Completed {index['freeze_id']}: {index_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dataset_freeze.py
+++ b/tests/test_dataset_freeze.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.freeze_corrected_datasets import (
+    build_freeze_index,
+    load_and_validate_source_config,
+    validate_protocol_manifests,
+)
+
+
+def _source_config(tmp_path: Path) -> Path:
+    datasets = []
+    for index in range(3):
+        source = tmp_path / f"source-{index}.gbff"
+        source.write_bytes(f"source-{index}".encode())
+        datasets.append(
+            {
+                "name": f"source_{index}",
+                "genome_id": f"GCF_{index:09d}.1",
+                "gbff": str(source),
+                "bytes": source.stat().st_size,
+                "sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+            }
+        )
+    path = tmp_path / "sources.yaml"
+    path.write_text(yaml.safe_dump({"datasets": datasets}))
+    return path
+
+
+def _protocol_manifest(protocol: str) -> dict:
+    return {
+        "dataset": {"id": f"{protocol}-id", "scientific_valid": True},
+        "split_policy": {
+            "effective_group_by": protocol,
+            "record_counts": {"train": 8, "val": 1, "test": 1},
+            "group_counts": {"train": 8, "val": 1, "test": 1},
+            "achieved_record_fractions": {"train": 0.8, "val": 0.1, "test": 0.1},
+        },
+        "leakage_audit": {"status": "passed"},
+        "sources": {
+            "GCF_000000001.1": {"sha256": "a" * 64, "bytes": 100},
+            "GCF_000000002.1": {"sha256": "b" * 64, "bytes": 200},
+        },
+        "vocabulary": {
+            "sha256": "c" * 64,
+            "size": 68,
+            "special_tokens": {
+                "<PAD>": 0,
+                "<BOS_CDS>": 1,
+                "<EOS_CDS>": 2,
+                "<SEP>": 3,
+            },
+        },
+        "packing": {
+            "schema_version": 1,
+            "mode": "multi",
+            "block_size": 512,
+            "transition_policy": "exactly_once",
+        },
+    }
+
+
+def test_source_inventory_requires_and_verifies_content_pins(tmp_path):
+    config_path = _source_config(tmp_path)
+    config = load_and_validate_source_config(config_path)
+    assert len(config["datasets"]) == 3
+
+    Path(config["datasets"][0]["gbff"]).write_text("drifted")
+    with pytest.raises(ValueError, match="Source size mismatch|Source SHA-256 mismatch"):
+        load_and_validate_source_config(config_path)
+
+
+def test_source_inventory_rejects_duplicate_genome_ids(tmp_path):
+    config_path = _source_config(tmp_path)
+    config = yaml.safe_load(config_path.read_text())
+    config["datasets"][1]["genome_id"] = config["datasets"][0]["genome_id"]
+    config_path.write_text(yaml.safe_dump(config))
+
+    with pytest.raises(ValueError, match="duplicate genome_id"):
+        load_and_validate_source_config(config_path)
+
+
+def test_freeze_index_binds_both_scientific_protocols(tmp_path):
+    config_path = _source_config(tmp_path)
+    manifests = {}
+    for protocol in ("genome", "genus"):
+        path = tmp_path / f"{protocol}-manifest.json"
+        path.write_text(json.dumps(_protocol_manifest(protocol), sort_keys=True))
+        manifests[protocol] = (_protocol_manifest(protocol), path)
+
+    index = build_freeze_index(
+        config_path=config_path,
+        seed=1337,
+        manifests=manifests,
+    )
+
+    assert len(index["freeze_id"]) == 64
+    assert index["split_seed"] == 1337
+    assert set(index["protocols"]) == {"genome", "genus"}
+    assert index["protocols"]["genome"]["dataset_id"] == "genome-id"
+
+
+def test_freeze_rejects_cross_protocol_source_drift(tmp_path):
+    genome = _protocol_manifest("genome")
+    genus = _protocol_manifest("genus")
+    genus["sources"]["GCF_000000002.1"]["bytes"] = 201
+
+    with pytest.raises(ValueError, match="same sources"):
+        validate_protocol_manifests(
+            {
+                "genome": (genome, tmp_path / "genome.json"),
+                "genus": (genus, tmp_path / "genus.json"),
+            }
+        )
+
+
+def test_freeze_rejects_non_scientific_manifest(tmp_path):
+    genome = _protocol_manifest("genome")
+    genome["dataset"]["scientific_valid"] = False
+
+    with pytest.raises(ValueError, match="not marked scientific_valid"):
+        validate_protocol_manifests(
+            {
+                "genome": (genome, tmp_path / "genome.json"),
+                "genus": (_protocol_manifest("genus"), tmp_path / "genus.json"),
+            }
+        )

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -9,13 +9,14 @@ from collections import Counter
 from pathlib import Path
 
 import numpy as np
+import pytest
 import yaml
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
 
-from scripts.build_global_manifest import resolve_genome_identity
+from scripts.build_global_manifest import resolve_genome_identity, validate_pinned_source
 from src.codonlm.codon_tokenize import itos, stoi, to_ids
 from src.codonlm.extract_cds_from_genbank import reverse_complement
 
@@ -112,6 +113,20 @@ def test_resolve_genome_identity_prefers_explicit_config(tmp_path):
 
     assert genome_id == "GCF_123456789.1"
     assert source == "config.genome_id"
+
+
+def test_global_builder_source_pin_detects_content_drift(tmp_path):
+    gbff = tmp_path / "source.gbff"
+    gbff.write_bytes(b"original")
+    dataset = {
+        "bytes": gbff.stat().st_size,
+        "sha256": hashlib.sha256(gbff.read_bytes()).hexdigest(),
+    }
+    validate_pinned_source(dataset, gbff)
+
+    gbff.write_bytes(b"modified")
+    with pytest.raises(ValueError, match="Source SHA-256 mismatch"):
+        validate_pinned_source(dataset, gbff)
 
 
 def test_reverse_complement_supports_iupac_ambiguity():


### PR DESCRIPTION
## Summary
- define the staged corrected CodonLM training program and promotion gates
- pin the 24-source GBFF inventory by assembly ID, byte size, and SHA-256
- add a fail-closed command that builds genome/genus holdouts and writes a content-addressed freeze index
- make global preparation reject drifted pinned sources
- document and test the source and cross-protocol contracts

## Validation
- `python -m scripts.freeze_corrected_datasets --config configs/corrected_codonlm_dataset_v1.yaml --freeze-id corrected-codonlm-v1 --verify-sources-only`
- `ruff check scripts/build_global_manifest.py scripts/freeze_corrected_datasets.py tests/test_dataset_freeze.py tests/test_global_split_and_baselines.py`
- `pytest -q` (265 passed, 1 skipped, 1 xpassed)

## Current gate
The 24-source preflight passes. The scientific dataset freeze is intentionally not marked complete because MMseqs2 is not installed on this host; the command fails before creating artifacts rather than skipping the required protein-homology audit.
