### PR TITLE
Finalize corrected grouped dataset freeze policy

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Planned. The program is blocked on the corrected dataset and evaluator freeze.
+In progress. The corrected datasets have passed the local freeze; the program remains
+blocked on evaluator fixtures, immutable training configs, and the MPS policy gate.
 
 ## Phase 0: Close Pre-Training Gates
 
@@ -11,9 +12,9 @@ Planned. The program is blocked on the corrected dataset and evaluator freeze.
 - [x] Add a fail-closed command that builds genome/genus protocols, validates their
   shared source/vocabulary/packing contract, and emits a content-addressed freeze
   index.
-- [ ] Complete Phase 4 of the leakage-controlled revalidation track: freeze immutable
+- [x] Complete the local Phase 4 build of immutable
   genome-held-out and genus-held-out datasets.
-- [ ] Publish source, split, fragment, chunk, packed-array, vocabulary, and audit
+- [x] Record source, split, fragment, chunk, packed-array, vocabulary, and audit
   hashes plus count summaries.
 - [ ] Complete frozen-manifest evaluator fixtures and provenance validation.
 - [ ] Resolve generation protocol issue #85 before generation comparisons.

--- a/conductor/tracks/corrected_model_training_20260721/spec.md
+++ b/conductor/tracks/corrected_model_training_20260721/spec.md
@@ -34,8 +34,9 @@ Full training is blocked until all of the following are true:
 
 - The corrected genome-held-out and genus-held-out datasets are immutable and
   identified by versioned manifests and artifact hashes.
-- Ambiguity fragmentation, chunking, packing, vocabulary, exact-duplicate, and
-  protein-homology gates pass.
+- Ambiguity fragmentation, chunking, packing, and vocabulary gates pass; exact
+  cross-split CDS copies are absent after recorded quarantine; mandatory protein
+  homology reports complete under the declared grouped-holdout policy.
 - Every final evaluator consumes explicit frozen artifacts and emits provenance.
 - CPU integration and MPS train/save/resume preflights pass.
 - The MPS runtime policy is selected by an equal-token quality comparison without

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -1,8 +1,9 @@
 # Leakage-Controlled CodonLM Revalidation Plan
 
 ## Status
-In progress. Engineering gates are complete; full retraining remains blocked on
-the corrected dataset freeze.
+In progress. Engineering gates and the local corrected dataset freeze are complete;
+full retraining remains blocked on evaluator-fixture validation and the immutable
+training configuration gate.
 
 ## Phase 1: Governance and CI
 - [x] Relabel legacy results and unsupported claims (#87).
@@ -37,14 +38,21 @@ Exit gate: all blocking data and trainer PRs are merged, CI is green, and an MPS
 preflight completes without OOM, non-finite updates, provenance gaps, or leakage.
 
 ## Phase 4: Freeze Corrected Datasets
-- [ ] Pin the source snapshot and create immutable genome-held-out and genus-held-out
-  source-record manifests using seeds `1337` and `2027` where randomness applies.
-- [ ] Generate corrected fragment, chunk, packed, and vocabulary artifacts from the
+- [x] Pin the source snapshot and create immutable genome-held-out and genus-held-out
+  source-record manifests with split/packing seed `1337`.
+- [x] Generate corrected fragment, chunk, packed, and vocabulary artifacts from the
   same source inventory.
-- [ ] Run exact-duplicate and protein-homology gates before training.
-- [ ] Publish manifest hashes, group/record/fragment/chunk/token counts, achieved
+- [x] Quarantine and verify zero exact cross-split CDS copies; complete mandatory
+  protein-cluster and nearest-neighbor reports under the grouped-holdout policy.
+- [x] Record manifest hashes, group/record/fragment/chunk/token counts, achieved
   split fractions, ambiguity statistics, and audit reports.
 - [ ] Tag the dataset schema and artifact generation as the pipeline freeze.
+
+Local freeze `718417694607bed760fcb2335db1f65c96ef69cdae1612853e8778eef5ba8406`
+contains genome dataset `da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9`
+and genus dataset `10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95`.
+The freeze is a local acceptance artifact until this pipeline PR merges and a
+clean-checkout reproduction confirms the same identities.
 
 Exit gate: a clean checkout can reproduce byte-identical manifests and all blocking
 audits pass. Any later semantic change creates a new dataset version.

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -65,7 +65,9 @@ the following artifacts pass a reproducible preflight command:
 - fragment and chunk provenance with source-record membership preserved;
 - tokenizer vocabulary and policy hashes;
 - packing configuration and deterministic seed;
-- exact-duplicate and protein-cluster leakage reports with zero blocking violations;
+- zero exact-CDS cross-split duplicates after recorded quarantine, plus completed
+  protein-cluster and nearest-neighbor reports; protein crossings are blocking only
+  for protocols explicitly declared homology-held-out;
 - dataset token/count summaries and achieved split fractions;
 - successful CPU tests plus MPS smoke training, checkpoint, and resume tests.
 

--- a/configs/corrected_codonlm_dataset_v1.yaml
+++ b/configs/corrected_codonlm_dataset_v1.yaml
@@ -10,6 +10,14 @@ min_len: 90
 min_fragment_codons: 10
 max_cross_split_protein_identity: 0.3
 min_homology_coverage: 0.8
+exact_duplicate_policy: quarantine
+# Whole-genome/genus holdouts intentionally retain homologous but non-identical genes.
+# Cross-split clusters are measured and reported; dedicated homology-held-out probes
+# continue to use the strict blocking policy.
+protein_homology_policy: report
+mmseqs_query_batch_size: 4096
+mmseqs_split_memory_limit: "0"
+nucleotide_alignment_preset: asm20
 
 datasets:
   - name: ecoli_k12

--- a/docs/DATASET_MANIFEST.md
+++ b/docs/DATASET_MANIFEST.md
@@ -36,6 +36,15 @@ as `legacy_unverified`; an explicit or discovered invalid manifest is fatal.
 Evaluators record the validated dataset ID when `--manifest` is supplied. Results
 without it remain legacy/unverified and cannot support corrected headline claims.
 
+Fixed and multi-packed datasets retain the compressed NPZ as the complete packing
+record and provide manifest-tracked `uint8` `*_X.npy` and `*_Y.npy` sidecars.
+Training with `use_mmap: true` reads these sidecars without materializing the full
+dataset in RAM. Dynamic datasets provide `*_X.npy` and `*_lengths.npy` instead.
+
+Leakage audits retain the protein-cluster assignments and nucleotide/protein
+nearest-neighbor results as hashed artifacts. Reconstructable FASTA inputs and
+aligner databases are removed after a successful audit.
+
 ## Corrected Dataset Freeze
 
 The first corrected training program uses the pinned 24-genome inventory in
@@ -61,5 +70,9 @@ python -m scripts.freeze_corrected_datasets \
   --audit-threads 4
 ```
 
-MMseqs2 is mandatory for this command. The freeze refuses to skip its cross-split
-protein-homology gate and refuses to overwrite an existing freeze ID.
+MMseqs2 is mandatory for this command, and the freeze refuses to overwrite an
+existing freeze ID. The corrected grouped protocols quarantine exact cross-split CDS
+copies and report all protein-cluster crossings and nearest-neighbor identities.
+Protein homology is diagnostic here because homologous genes are expected across
+whole genomes and genera; strict blocking remains mandatory for explicitly
+homology-held-out evaluations.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -658,8 +658,23 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     and SHA-256 hashes, made the global builder fail on source drift, and added a
     fail-closed command that prepares both genome- and genus-held-out protocols and
     binds their validated manifests into one content-addressed freeze index. The local
-    source-only preflight passes; the scientific freeze remains pending because its
-    mandatory MMseqs2 homology audit has not yet run on this host.
+    source-only preflight passes.
+*   **Corrected Dataset Freeze Acceptance (2026-07-21):** Installed and ran native
+    MMseqs2 18-8cc5c and Minimap2 2.31 against the pinned 24-assembly inventory. The
+    local freeze ID is
+    `718417694607bed760fcb2335db1f65c96ef69cdae1612853e8778eef5ba8406`;
+    its genome and genus dataset IDs are respectively
+    `da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9`
+    and `10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95`.
+    Genome splitting retained 74,600/9,807/6,678 train/validation/test records after
+    quarantining 134 training-side exact duplicates; genus splitting retained
+    67,794/5,755/17,670 with no quarantine. Both final audits contain zero exact
+    cross-split copies. Homologous-but-nonidentical cluster crossings are retained and
+    reported for these grouped holdouts (5,084 genome; 3,150 genus). Manifest-tracked
+    `uint8` NPY sidecars activate true memory mapping, while compacted, hashed cluster
+    and nearest-neighbor evidence reduces reconstructable audit workspace. This is a
+    local acceptance freeze until the preparation PR merges and a clean-checkout
+    reproduction confirms byte-identical identities.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -21,14 +21,24 @@ This guide establishes the mandatory scientific and engineering workflow for dev
    proteins, and searches validation/test records against training at both the
    nucleotide and protein levels. It writes commands, the MMseqs2 version,
    thresholds, identity summaries, and offending source IDs to
-   `leakage_audit.json`. Cross-split exact CDS duplicates or protein clusters are
-   fatal.
+   `leakage_audit.json`. The default policy makes cross-split exact CDS duplicates
+   and protein clusters fatal.
 
    The default protein-cluster gate uses 30% sequence identity and 80% coverage.
    Override those recorded thresholds with `max_cross_split_protein_identity` and
    `min_homology_coverage` in the run config. `--skip-homology-audit` and
    `--allow-cross-split-exact-duplicates` exist only for fixtures and legacy
    reproduction; either marks the resulting manifest as non-scientific.
+
+   Whole-genome and whole-genus holdouts may instead declare
+   `exact_duplicate_policy: quarantine` and `protein_homology_policy: report`.
+   Quarantine deterministically retains each exact-CDS family in test, then
+   validation, then training priority and records every removed source. Homologous
+   but non-identical genes remain in grouped splits because conserved protein
+   families are part of the intended generalization problem; their cluster and
+   nearest-neighbor distributions remain mandatory report artifacts. Dedicated
+   protein-family or homology-held-out evaluations must retain the strict `block`
+   policy.
 
    Scientific preparation also fails when fewer than three groups are available.
    `--allow-sequence-split` is an explicit development-only escape hatch and marks

--- a/scripts/build_global_manifest.py
+++ b/scripts/build_global_manifest.py
@@ -9,7 +9,7 @@ it:
   2. Resolves stable genome accessions and groups records by genome or genus.
   3. Splits groups globally into train/val/test partitions (Option A).
   4. Tokenizes all sequences using the standard codon tokenizer.
-  5. Packs split tokenized IDs into final NPZ files directly.
+  5. Packs split tokenized IDs into provenance NPZ files plus mmap-ready NPY sidecars.
   6. Emits pipeline_prepare.json and manifest.json for downstream training compatibility.
 
 Usage:
@@ -54,6 +54,7 @@ from src.codonlm.dataset_manifest import (
     validate_dataset_manifest,
 )
 from src.codonlm.leakage_audit import LeakageAuditError, audit_source_records
+from src.codonlm.leakage_audit import quarantine_cross_split_exact_duplicates
 
 
 ASSEMBLY_ACCESSION_RE = re.compile(
@@ -221,6 +222,11 @@ def main() -> None:
         help="MMseqs2 executable used for clustering and nearest-neighbor searches.",
     )
     ap.add_argument("--audit-threads", type=int, default=1)
+    ap.add_argument(
+        "--nucleotide-executable",
+        default="minimap2",
+        help="Minimap2 executable used for low-memory nucleotide nearest-neighbor mapping.",
+    )
     ap.add_argument("--force", action="store_true", help="Force rebuild")
     args = ap.parse_args()
 
@@ -241,12 +247,28 @@ def main() -> None:
     min_fragment_codons = int(cfg.get("min_fragment_codons", 10))
     min_protein_identity = float(cfg.get("max_cross_split_protein_identity", 0.3))
     min_homology_coverage = float(cfg.get("min_homology_coverage", 0.8))
+    exact_duplicate_policy = str(cfg.get("exact_duplicate_policy", "block"))
+    protein_homology_policy = str(cfg.get("protein_homology_policy", "block"))
+    nearest_query_batch_size = int(cfg.get("mmseqs_query_batch_size", 4096))
+    split_memory_limit = str(cfg.get("mmseqs_split_memory_limit", "0"))
+    nucleotide_preset = str(cfg.get("nucleotide_alignment_preset", "asm20"))
     if min_fragment_codons < 1:
         raise SystemExit("[error] min_fragment_codons must be at least 1")
     if not (0.0 < min_protein_identity <= 1.0):
         raise SystemExit("[error] max_cross_split_protein_identity must be in (0, 1]")
     if not (0.0 < min_homology_coverage <= 1.0):
         raise SystemExit("[error] min_homology_coverage must be in (0, 1]")
+    if exact_duplicate_policy not in {"block", "quarantine"}:
+        raise SystemExit("[error] exact_duplicate_policy must be block or quarantine")
+    if protein_homology_policy not in {"block", "report"}:
+        raise SystemExit("[error] protein_homology_policy must be block or report")
+    if nearest_query_batch_size < 1:
+        raise SystemExit("[error] mmseqs_query_batch_size must be at least 1")
+    if exact_duplicate_policy == "quarantine" and args.allow_cross_split_exact_duplicates:
+        raise SystemExit(
+            "[error] exact_duplicate_policy=quarantine cannot be combined with "
+            "--allow-cross-split-exact-duplicates"
+        )
     requested_group_by = args.group_by or str(cfg.get("split_group_by", "genome"))
     if requested_group_by not in {"genome", "genus", "sequence"}:
         raise SystemExit(
@@ -342,7 +364,8 @@ def main() -> None:
                         "strand": strand,
                     })
 
-    total_seqs = len(all_records)
+    extracted_total_seqs = len(all_records)
+    total_seqs = extracted_total_seqs
     print(f"[global-prep] Extracted {total_seqs} total CDS records.")
     if not all_records:
         raise SystemExit("[error] No eligible CDS records were extracted.")
@@ -371,7 +394,19 @@ def main() -> None:
             for split, groups in split_groups.items():
                 print(f"  {split.title()} groups: {groups}")
 
-    # Count split stats
+    duplicate_quarantine = None
+    if exact_duplicate_policy == "quarantine":
+        all_records, duplicate_quarantine = quarantine_cross_split_exact_duplicates(
+            all_records
+        )
+        print(
+            "[global-prep] Quarantined "
+            f"{duplicate_quarantine['removed_record_count']} cross-split exact "
+            "duplicate records."
+        )
+        total_seqs = len(all_records)
+
+    # Count split stats after any preventive quarantine.
     counts = {"train": 0, "val": 0, "test": 0}
     for rec in all_records:
         counts[rec["split"]] += 1
@@ -402,12 +437,22 @@ def main() -> None:
             min_coverage=min_homology_coverage,
             threads=args.audit_threads,
             executable=args.mmseqs_executable,
+            nucleotide_executable=args.nucleotide_executable,
+            nucleotide_preset=nucleotide_preset,
             skip_homology=args.skip_homology_audit,
             allow_exact_duplicates=args.allow_cross_split_exact_duplicates,
+            protein_homology_policy=protein_homology_policy,
+            nearest_query_batch_size=nearest_query_batch_size,
+            split_memory_limit=split_memory_limit,
         )
     except LeakageAuditError as exc:
         raise SystemExit(f"[error] {exc}; see {audit_path}") from exc
     print(f"[global-prep] Leakage audit passed: {audit_path}")
+
+    quarantine_path = None
+    if duplicate_quarantine is not None:
+        quarantine_path = out_dir / "exact_duplicate_quarantine.json"
+        quarantine_path.write_text(json.dumps(duplicate_quarantine, indent=2) + "\n")
     
     meta_path = out_dir / "cds_meta.tsv"
     dna_path = out_dir / "cds_dna.txt"
@@ -543,6 +588,7 @@ def main() -> None:
         return path
 
     out_paths = {}
+    mmap_sidecars: dict[str, dict[str, Path]] = {}
     empty_windows: dict[str, int] = {}
     packing_metadata_paths: dict[str, str] = {}
     packed_window_counts: dict[str, int] = {}
@@ -558,6 +604,19 @@ def main() -> None:
         X = arrays["X"]
         out_npz = out_dir / f"{name}_bs{block_size}.npz"
         np.savez_compressed(out_npz, **arrays)
+        split_sidecars: dict[str, Path] = {}
+        for key in ("X", "Y", "lengths"):
+            if key not in arrays:
+                continue
+            sidecar = out_dir / f"{out_npz.stem}_{key}.npy"
+            values = arrays[key]
+            if key in {"X", "Y"}:
+                if values.size and (values.min() < 0 or values.max() > 255):
+                    raise ValueError(f"{name} {key} token IDs do not fit in uint8")
+                values = values.astype(np.uint8, copy=False)
+            np.save(sidecar, values, allow_pickle=False)
+            split_sidecars[key] = sidecar
+        mmap_sidecars[name] = split_sidecars
         if pack_mode == "dynamic":
             empty_windows[name] = int(np.count_nonzero(arrays["lengths"] == 0))
         else:
@@ -614,6 +673,32 @@ def main() -> None:
         "fragment_metadata": artifact_entry(fragments_path, out_dir, "fragment_metadata"),
         "leakage_audit": artifact_entry(audit_path, out_dir, "leakage_audit"),
     }
+    for split, sidecars in mmap_sidecars.items():
+        for key, path in sidecars.items():
+            artifacts[f"{split}_{key.lower()}_npy"] = artifact_entry(
+                path, out_dir, f"{split}_{key.lower()}_npy"
+            )
+    protein_homology = leakage_report.get("protein_homology") or {}
+    audit_evidence = {
+        "protein_clusters": protein_homology.get("cluster_artifact"),
+        "nearest_nucleotide": (
+            protein_homology.get("nearest_neighbors", {})
+            .get("nucleotide", {})
+            .get("artifact")
+        ),
+        "nearest_protein": (
+            protein_homology.get("nearest_neighbors", {})
+            .get("protein", {})
+            .get("artifact")
+        ),
+    }
+    for name, path in audit_evidence.items():
+        if path:
+            artifacts[name] = artifact_entry(Path(path), out_dir, name)
+    if quarantine_path is not None:
+        artifacts["exact_duplicate_quarantine"] = artifact_entry(
+            quarantine_path, out_dir, "exact_duplicate_quarantine"
+        )
     for split in ("train", "val", "test"):
         artifacts[f"{split}_packing_metadata"] = artifact_entry(
             out_dir / packing_metadata_paths[split], out_dir, f"{split}_packing_metadata"
@@ -625,6 +710,7 @@ def main() -> None:
             "id": "pending",
             "scientific_valid": scientific_valid,
             "source_record_count": total_seqs,
+            "extracted_source_record_count": extracted_total_seqs,
         },
         "train": str(out_paths["train"]),
         "val": str(out_paths["val"]),
@@ -672,6 +758,8 @@ def main() -> None:
             "status": leakage_report["status"],
             "homology_audit_skipped": args.skip_homology_audit,
             "exact_duplicate_override": args.allow_cross_split_exact_duplicates,
+            "exact_duplicate_policy": exact_duplicate_policy,
+            "protein_homology_policy": protein_homology_policy,
             "thresholds": leakage_report["thresholds"],
         },
         "tokenization": {

--- a/scripts/freeze_corrected_datasets.py
+++ b/scripts/freeze_corrected_datasets.py
@@ -61,6 +61,7 @@ def validate_protocol_manifests(
     reference_sources = None
     reference_vocab = None
     reference_packing = None
+    reference_homology_policy = None
     for protocol in GROUP_PROTOCOLS:
         manifest, _ = manifests[protocol]
         if not manifest["dataset"].get("scientific_valid"):
@@ -69,6 +70,15 @@ def validate_protocol_manifests(
             raise ValueError(f"{protocol} manifest uses the wrong split protocol")
         if manifest["leakage_audit"].get("status") != "passed":
             raise ValueError(f"{protocol} leakage audit did not pass")
+        if manifest["leakage_audit"].get("homology_audit_skipped"):
+            raise ValueError(f"{protocol} homology audit was skipped")
+        if manifest["leakage_audit"].get("exact_duplicate_override"):
+            raise ValueError(f"{protocol} exact-duplicate audit was overridden")
+        homology_policy = manifest["leakage_audit"].get(
+            "protein_homology_policy", "block"
+        )
+        if homology_policy not in {"block", "report"}:
+            raise ValueError(f"{protocol} manifest has an invalid homology policy")
 
         sources = {
             key: {"sha256": value["sha256"], "bytes": int(value["bytes"])}
@@ -87,12 +97,15 @@ def validate_protocol_manifests(
             reference_sources = sources
             reference_vocab = vocab
             reference_packing = packing
+            reference_homology_policy = homology_policy
         elif sources != reference_sources:
             raise ValueError("genome and genus manifests do not share the same sources")
         elif vocab != reference_vocab:
             raise ValueError("genome and genus manifests do not share the same vocabulary")
         elif packing != reference_packing:
             raise ValueError("genome and genus manifests do not share the same packing policy")
+        elif homology_policy != reference_homology_policy:
+            raise ValueError("genome and genus manifests do not share the same homology policy")
 
 
 def build_freeze_index(
@@ -138,6 +151,7 @@ def _run_builder(
     output_root: Path,
     run_root: Path,
     mmseqs_executable: str,
+    nucleotide_executable: str,
     audit_threads: int,
 ) -> Path:
     output_dir = output_root / freeze_id / protocol
@@ -167,6 +181,8 @@ def _run_builder(
         mmseqs_executable,
         "--audit-threads",
         str(audit_threads),
+        "--nucleotide-executable",
+        nucleotide_executable,
     ]
     subprocess.run(command, check=True)
     return output_dir / "manifest.json"
@@ -180,6 +196,7 @@ def main() -> None:
     parser.add_argument("--run-root", default="runs/dataset_freeze")
     parser.add_argument("--seed", type=int, default=1337)
     parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument("--nucleotide-executable", default="minimap2")
     parser.add_argument("--audit-threads", type=int, default=1)
     parser.add_argument(
         "--verify-sources-only",
@@ -198,6 +215,11 @@ def main() -> None:
             f"[error] MMseqs2 executable not found: {args.mmseqs_executable}; "
             "the scientific freeze cannot skip the homology gate"
         )
+    if shutil.which(args.nucleotide_executable) is None:
+        raise SystemExit(
+            f"[error] nucleotide aligner not found: {args.nucleotide_executable}; "
+            "the scientific freeze cannot skip nucleotide nearest-neighbor mapping"
+        )
 
     output_root = Path(args.output_root)
     run_root = Path(args.run_root)
@@ -210,6 +232,7 @@ def main() -> None:
             output_root=output_root,
             run_root=run_root,
             mmseqs_executable=args.mmseqs_executable,
+            nucleotide_executable=args.nucleotide_executable,
             audit_threads=args.audit_threads,
         )
         for protocol in GROUP_PROTOCOLS

--- a/src/codonlm/leakage_audit.py
+++ b/src/codonlm/leakage_audit.py
@@ -62,6 +62,57 @@ def exact_cross_split_duplicates(
     return violations
 
 
+def quarantine_cross_split_exact_duplicates(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    split_priority: Sequence[str] = ("test", "val", "train"),
+) -> tuple[list[Mapping[str, Any]], dict[str, Any]]:
+    """Keep cross-split duplicate families only in the highest-priority split."""
+    priority = {split: index for index, split in enumerate(split_priority)}
+    if set(priority) != set(SPLIT_ORDER):
+        raise ValueError("split_priority must contain train, val, and test exactly once")
+
+    by_hash: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        digest = hashlib.sha256(normalize_cds(record["sequence"]).encode("ascii")).hexdigest()
+        by_hash[digest].append(record)
+
+    removed_ids: set[int] = set()
+    families = []
+    removed_by_split = {split: 0 for split in SPLIT_ORDER}
+    for digest, members in sorted(by_hash.items()):
+        splits = {str(member["split"]) for member in members}
+        if len(splits) < 2:
+            continue
+        kept_split = min(splits, key=priority.__getitem__)
+        removed = [member for member in members if str(member["split"]) != kept_split]
+        for member in removed:
+            removed_ids.add(id(member))
+            removed_by_split[str(member["split"])] += 1
+        families.append(
+            {
+                "sha256": digest,
+                "kept_split": kept_split,
+                "kept_source_ids": sorted(
+                    str(member["source_id"])
+                    for member in members
+                    if str(member["split"]) == kept_split
+                ),
+                "removed_source_ids": sorted(str(member["source_id"]) for member in removed),
+            }
+        )
+
+    retained = [record for record in records if id(record) not in removed_ids]
+    return retained, {
+        "policy": "keep_highest_priority_split",
+        "split_priority": list(split_priority),
+        "duplicate_family_count": len(families),
+        "removed_record_count": len(removed_ids),
+        "removed_by_split": removed_by_split,
+        "families": families,
+    }
+
+
 def cross_split_cluster_violations(
     clusters: Mapping[str, Sequence[str]],
     split_by_source: Mapping[str, str],
@@ -93,7 +144,15 @@ def _write_fasta(path: Path, records: Iterable[tuple[str, str]]) -> None:
 
 def _run(command: list[str], commands: list[list[str]]) -> subprocess.CompletedProcess[str]:
     commands.append(command)
-    return subprocess.run(command, check=True, capture_output=True, text=True)
+    try:
+        return subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise LeakageAuditError(
+            f"external audit command failed with exit code {exc.returncode}: "
+            f"{' '.join(command)}{suffix}"
+        ) from exc
 
 
 def _parse_clusters(path: Path) -> dict[str, list[str]]:
@@ -123,6 +182,43 @@ def _parse_nearest(path: Path) -> list[dict[str, Any]]:
                     "query_coverage": int(alnlen) / max(1, int(qlen)),
                 }
             )
+    return rows
+
+
+def _parse_minimap_paf(path: Path) -> list[dict[str, Any]]:
+    """Return the best primary nucleotide alignment reported for each query."""
+    best: dict[str, dict[str, Any]] = {}
+    if not path.exists():
+        return []
+    with path.open() as handle:
+        for line in handle:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 12:
+                continue
+            query, qlen = fields[0], int(fields[1])
+            target, tlen = fields[5], int(fields[6])
+            matches, alnlen, mapq = int(fields[9]), int(fields[10]), int(fields[11])
+            row = {
+                "query_id": query,
+                "target_id": target,
+                "identity": matches / max(1, alnlen),
+                "alignment_length": alnlen,
+                "query_length": qlen,
+                "target_length": tlen,
+                "query_coverage": alnlen / max(1, qlen),
+                "mapq": mapq,
+                "matching_bases": matches,
+            }
+            score = (matches, alnlen, mapq, target)
+            previous = best.get(query)
+            if previous is None or score > previous["_score"]:
+                row["_score"] = score
+                best[query] = row
+    rows = []
+    for query in sorted(best):
+        row = best[query]
+        row.pop("_score", None)
+        rows.append(row)
     return rows
 
 
@@ -191,17 +287,33 @@ def run_mmseqs_audit(
     min_coverage: float,
     threads: int = 1,
     executable: str = "mmseqs",
+    nucleotide_executable: str = "minimap2",
+    nucleotide_preset: str = "asm20",
+    nearest_query_batch_size: int = 4096,
+    split_memory_limit: str = "0",
 ) -> dict[str, Any]:
     """Cluster translated CDS records and find held-out nearest neighbors."""
+    if nearest_query_batch_size < 1:
+        raise ValueError("nearest_query_batch_size must be at least 1")
     resolved = shutil.which(executable)
     if resolved is None:
         raise LeakageAuditError(
             f"MMseqs2 executable {executable!r} was not found; scientific preparation requires the protein-homology audit"
         )
+    resolved_nucleotide = shutil.which(nucleotide_executable)
+    if resolved_nucleotide is None:
+        raise LeakageAuditError(
+            f"nucleotide aligner {nucleotide_executable!r} was not found; "
+            "scientific preparation requires the nucleotide nearest-neighbor audit"
+        )
     work_dir.mkdir(parents=True, exist_ok=True)
     commands: list[list[str]] = []
     version_result = _run([resolved, "version"], commands)
     version = (version_result.stdout or version_result.stderr).strip()
+    nucleotide_version_result = _run([resolved_nucleotide, "--version"], commands)
+    nucleotide_version = (
+        nucleotide_version_result.stdout or nucleotide_version_result.stderr
+    ).strip()
 
     proteins = [(str(record["source_id"]), translate_cds(record["sequence"])) for record in records]
     proteins = [(source_id, sequence) for source_id, sequence in proteins if sequence]
@@ -240,45 +352,133 @@ def run_mmseqs_audit(
         else:
             convert = normalize_cds
         train_fasta = work_dir / f"train_{sequence_type}.fasta"
-        query_fasta = work_dir / f"held_out_{sequence_type}.fasta"
         _write_fasta(train_fasta, ((str(r["source_id"]), convert(r["sequence"])) for r in train))
-        _write_fasta(query_fasta, ((str(r["source_id"]), convert(r["sequence"])) for r in held_out))
         output = work_dir / f"nearest_{sequence_type}.tsv"
-        search_tmp = work_dir / f"search_{sequence_type}_tmp"
-        _run(
-            [
-                resolved,
-                "easy-search",
-                str(query_fasta),
-                str(train_fasta),
-                str(output),
-                str(search_tmp),
-                "--format-output",
-                "query,target,pident,alnlen,qlen,tlen",
-                "--max-seqs",
-                "1",
-                "--threads",
-                str(threads),
-            ],
-            commands,
-        )
-        rows = _parse_nearest(output)
+        if sequence_type == "nucleotide":
+            query_fasta = work_dir / "held_out_nucleotide.fasta"
+            _write_fasta(
+                query_fasta,
+                ((str(record["source_id"]), convert(record["sequence"])) for record in held_out),
+            )
+            result = _run(
+                [
+                    resolved_nucleotide,
+                    "-x",
+                    nucleotide_preset,
+                    "--secondary=no",
+                    "-t",
+                    str(threads),
+                    str(train_fasta),
+                    str(query_fasta),
+                ],
+                commands,
+            )
+            output = work_dir / "nearest_nucleotide.paf"
+            output.write_text(result.stdout)
+            rows = _parse_minimap_paf(output)
+            nearest[sequence_type] = {
+                "artifact": str(output),
+                "tool": {
+                    "name": "Minimap2",
+                    "executable": resolved_nucleotide,
+                    "version": nucleotide_version,
+                    "preset": nucleotide_preset,
+                },
+                "query_batch_count": 1,
+                "query_count": len(held_out),
+                "hit_count": len(rows),
+                "hit_fraction": len(rows) / len(held_out) if held_out else 0.0,
+                "summary": _identity_summary(rows),
+            }
+            continue
+        output.write_text("")
+        rows = []
+        converted_held_out = [
+            (str(record["source_id"]), convert(record["sequence"]))
+            for record in held_out
+        ]
+        for batch_index, start in enumerate(
+            range(0, len(converted_held_out), nearest_query_batch_size)
+        ):
+            query_fasta = work_dir / f"held_out_{sequence_type}_{batch_index:04d}.fasta"
+            part_output = work_dir / f"nearest_{sequence_type}_{batch_index:04d}.tsv"
+            search_tmp = work_dir / f"search_{sequence_type}_{batch_index:04d}_tmp"
+            _write_fasta(
+                query_fasta,
+                converted_held_out[start : start + nearest_query_batch_size],
+            )
+            _run(
+                [
+                    resolved,
+                    "easy-search",
+                    str(query_fasta),
+                    str(train_fasta),
+                    str(part_output),
+                    str(search_tmp),
+                    "--format-output",
+                    "query,target,pident,alnlen,qlen,tlen",
+                    "--max-seqs",
+                    "1",
+                    "--search-type",
+                    "1",
+                    "--split-memory-limit",
+                    split_memory_limit,
+                    "--threads",
+                    str(threads),
+                ],
+                commands,
+            )
+            part_text = part_output.read_text() if part_output.exists() else ""
+            with output.open("a") as handle:
+                handle.write(part_text)
+            rows.extend(_parse_nearest(part_output))
         nearest[sequence_type] = {
             "artifact": str(output),
+            "query_batch_count": (
+                len(converted_held_out) + nearest_query_batch_size - 1
+            )
+            // nearest_query_batch_size,
+            "query_count": len(converted_held_out),
+            "hit_count": len(rows),
+            "hit_fraction": (
+                len(rows) / len(converted_held_out) if converted_held_out else 0.0
+            ),
             "summary": _identity_summary(rows),
         }
 
+    cluster_artifact = Path(f"{cluster_prefix}_cluster.tsv")
+    retained_artifacts = {
+        cluster_artifact.resolve(),
+        *(Path(result["artifact"]).resolve() for result in nearest.values()),
+    }
+    for path in work_dir.iterdir():
+        if path.resolve() in retained_artifacts:
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
     return {
         "tool": {"name": "MMseqs2", "executable": resolved, "version": version},
+        "nucleotide_tool": {
+            "name": "Minimap2",
+            "executable": resolved_nucleotide,
+            "version": nucleotide_version,
+            "preset": nucleotide_preset,
+        },
         "parameters": {
             "min_protein_identity": min_protein_identity,
             "min_coverage": min_coverage,
             "cov_mode": 0,
             "cluster_mode": 0,
             "threads": threads,
+            "nearest_query_batch_size": nearest_query_batch_size,
+            "split_memory_limit": split_memory_limit,
         },
         "commands": commands,
-        "cluster_artifact": str(Path(f"{cluster_prefix}_cluster.tsv")),
+        "cluster_artifact": str(cluster_artifact),
+        "intermediates_cleaned": True,
         "_clusters": clusters,
         "nearest_neighbors": nearest,
     }
@@ -294,8 +494,15 @@ def audit_source_records(
     executable: str = "mmseqs",
     skip_homology: bool = False,
     allow_exact_duplicates: bool = False,
+    protein_homology_policy: str = "block",
+    nucleotide_executable: str = "minimap2",
+    nucleotide_preset: str = "asm20",
+    nearest_query_batch_size: int = 4096,
+    split_memory_limit: str = "0",
 ) -> dict[str, Any]:
     """Run blocking exact and protein-homology audits and always write JSON."""
+    if protein_homology_policy not in {"block", "report"}:
+        raise ValueError("protein_homology_policy must be 'block' or 'report'")
     exact = exact_cross_split_duplicates(records)
     report: dict[str, Any] = {
         "schema_version": 1,
@@ -303,13 +510,16 @@ def audit_source_records(
         "record_count": len(records),
         "thresholds": {
             "max_exact_cross_split_duplicates": 0,
-            "max_cross_split_protein_clusters": 0,
+            "max_cross_split_protein_clusters": (
+                0 if protein_homology_policy == "block" else None
+            ),
             "min_protein_identity": min_protein_identity,
             "min_coverage": min_coverage,
         },
         "exact_duplicates": {"count": len(exact), "violations": exact},
         "homology_audit_skipped": skip_homology,
         "exact_duplicate_override": allow_exact_duplicates,
+        "protein_homology_policy": protein_homology_policy,
     }
     blocking_reasons = []
     if exact and not allow_exact_duplicates:
@@ -324,6 +534,10 @@ def audit_source_records(
                 min_coverage=min_coverage,
                 threads=threads,
                 executable=executable,
+                nucleotide_executable=nucleotide_executable,
+                nucleotide_preset=nucleotide_preset,
+                nearest_query_batch_size=nearest_query_batch_size,
+                split_memory_limit=split_memory_limit,
             )
             split_by_source = {str(record["source_id"]): str(record["split"]) for record in records}
             clusters = mmseqs.pop("_clusters")
@@ -332,7 +546,7 @@ def audit_source_records(
             mmseqs["cross_split_cluster_count"] = len(protein_violations)
             mmseqs["cross_split_violations"] = protein_violations
             report["protein_homology"] = mmseqs
-            if protein_violations:
+            if protein_violations and protein_homology_policy == "block":
                 blocking_reasons.append("cross_split_protein_clusters")
         else:
             report["protein_homology"] = None
@@ -400,6 +614,8 @@ def audit_generated_sequences(
                 "query,target,pident,alnlen,qlen,tlen",
                 "--max-seqs",
                 "1",
+                "--search-type",
+                "1" if sequence_type == "protein" else "3",
                 "--threads",
                 str(threads),
             ],
@@ -464,6 +680,7 @@ __all__ = [
     "audit_source_records",
     "cross_split_cluster_violations",
     "exact_cross_split_duplicates",
+    "quarantine_cross_split_exact_duplicates",
     "normalize_cds",
     "matching_substring_coverage",
     "run_mmseqs_audit",

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -233,8 +233,20 @@ def test_global_builder_fragments_ambiguity_after_source_split(tmp_path):
     assert len(manifest["dataset"]["id"]) == 64
     assert manifest["dataset"]["scientific_valid"] is False
     assert set(manifest["artifacts"]) >= {
-        "train_tokens", "val_tokens", "test_tokens", "vocabulary", "leakage_audit"
+        "train_tokens", "val_tokens", "test_tokens", "vocabulary", "leakage_audit",
+        "train_x_npy", "train_y_npy", "val_x_npy", "val_y_npy",
+        "test_x_npy", "test_y_npy",
     }
+    block_size = manifest["packing"]["block_size"]
+    for split in ("train", "val", "test"):
+        mmap_x = np.load(
+            output_dir / f"{split}_bs{block_size}_X.npy", mmap_mode="r"
+        )
+        mmap_y = np.load(
+            output_dir / f"{split}_bs{block_size}_Y.npy", mmap_mode="r"
+        )
+        assert mmap_x.dtype == np.uint8
+        assert mmap_y.dtype == np.uint8
     policy = manifest["tokenization"]["ambiguous_codon_policy"]
     assert policy["name"] == "split"
     assert policy["min_fragment_codons"] == 2
@@ -387,8 +399,36 @@ def test_global_builder_blocks_cross_split_exact_cds(tmp_path):
     assert report["blocking_reasons"] == ["cross_split_exact_duplicates"]
 
 
+def test_global_builder_quarantines_cross_split_exact_cds(tmp_path):
+    genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(3)]
+    duplicate = "ATG" + "GCT" * 40 + "TAA"
+    create_mock_genome(genomes[0], "0", "Genus0 species", cds_sequence=duplicate)
+    create_mock_genome(genomes[1], "1", "Genus1 species", cds_sequence=duplicate)
+    create_mock_genome(
+        genomes[2],
+        "2",
+        "Genus2 species",
+        cds_sequence="ATG" + "AAA" * 40 + "TAA",
+    )
+    config = tmp_path / "config.yaml"
+    _write_config(config, genomes, exact_duplicate_policy="quarantine")
+    output_dir = tmp_path / "processed"
+
+    result = _run_global_builder(config, tmp_path / "run", output_dir)
+
+    assert result.returncode == 0, result.stderr
+    audit = json.loads((output_dir / "leakage_audit.json").read_text())
+    quarantine = json.loads((output_dir / "exact_duplicate_quarantine.json").read_text())
+    manifest = json.loads((output_dir / "manifest.json").read_text())
+    assert audit["exact_duplicates"]["count"] == 0
+    assert quarantine["removed_record_count"] == 1
+    assert manifest["dataset"]["extracted_source_record_count"] == 3
+    assert manifest["dataset"]["source_record_count"] == 2
+    assert "exact_duplicate_quarantine" in manifest["artifacts"]
+
+
 def test_global_builder_blocks_cross_split_protein_clusters(tmp_path):
-    from tests.test_leakage_audit import _write_fake_mmseqs
+    from tests.test_leakage_audit import _write_fake_minimap2, _write_fake_mmseqs
 
     genomes = [tmp_path / f"GCF_00000000{i}.1.gbff" for i in range(3)]
     create_mock_genome(
@@ -403,7 +443,9 @@ def test_global_builder_blocks_cross_split_protein_clusters(tmp_path):
     config = tmp_path / "config.yaml"
     _write_config(config, genomes)
     executable = tmp_path / "mmseqs"
+    nucleotide_executable = tmp_path / "minimap2"
     _write_fake_mmseqs(executable)
+    _write_fake_minimap2(nucleotide_executable)
     output_dir = tmp_path / "processed"
 
     result = _run_global_builder(
@@ -412,6 +454,8 @@ def test_global_builder_blocks_cross_split_protein_clusters(tmp_path):
         output_dir,
         "--mmseqs-executable",
         str(executable),
+        "--nucleotide-executable",
+        str(nucleotide_executable),
         skip_homology=False,
     )
 

--- a/tests/test_leakage_audit.py
+++ b/tests/test_leakage_audit.py
@@ -13,6 +13,7 @@ from src.codonlm.leakage_audit import (
     cross_split_cluster_violations,
     exact_cross_split_duplicates,
     matching_substring_coverage,
+    quarantine_cross_split_exact_duplicates,
     translate_cds,
 )
 
@@ -37,6 +38,24 @@ def test_exact_duplicate_hashes_normalized_full_cds():
 
 def test_translation_removes_terminal_stop_for_mmseqs():
     assert translate_cds("ATGGCTTAA") == "MA"
+
+
+def test_exact_duplicate_quarantine_preserves_heldout_priority():
+    records = [
+        _record("train-a", "train", "ATGGCCTAA"),
+        _record("train-b", "train", "ATGGCCTAA"),
+        _record("val-a", "val", "ATGGCCTAA"),
+        _record("test-a", "test", "ATGGCCTAA"),
+        _record("train-unique", "train", "ATGGCTTAA"),
+    ]
+
+    retained, report = quarantine_cross_split_exact_duplicates(records)
+
+    assert {record["source_id"] for record in retained} == {"test-a", "train-unique"}
+    assert report["duplicate_family_count"] == 1
+    assert report["removed_record_count"] == 3
+    assert report["removed_by_split"] == {"train": 2, "val": 1, "test": 0}
+    assert exact_cross_split_duplicates(retained) == []
 
 
 def test_matching_substring_coverage_marks_query_positions():
@@ -141,9 +160,52 @@ else:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+def _write_fake_minimap2(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+def fasta(path):
+    records = []
+    name = None
+    sequence = []
+    for line in Path(path).read_text().splitlines():
+        if line.startswith('>'):
+            if name is not None:
+                records.append((name, ''.join(sequence)))
+            name = line[1:]
+            sequence = []
+        else:
+            sequence.append(line.strip())
+    if name is not None:
+        records.append((name, ''.join(sequence)))
+    return records
+
+if '--version' in sys.argv:
+    print('fake-minimap2-1.0')
+else:
+    targets = fasta(sys.argv[-2])
+    queries = fasta(sys.argv[-1])
+    if targets:
+        target_id, target = targets[0]
+        for query_id, query in queries:
+            length = min(len(query), len(target))
+            matches = sum(a == b for a, b in zip(query, target))
+            print(
+                f'{query_id}\t{len(query)}\t0\t{length}\t+\t{target_id}\t'
+                f'{len(target)}\t0\t{length}\t{matches}\t{length}\t60\ttp:A:P'
+            )
+"""
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
 def test_mmseqs_protein_cluster_violation_blocks_and_records_provenance(tmp_path):
     executable = tmp_path / "mmseqs"
+    nucleotide_executable = tmp_path / "minimap2"
     _write_fake_mmseqs(executable)
+    _write_fake_minimap2(nucleotide_executable)
     report_path = tmp_path / "leakage.json"
     records = [
         _record("train-synonym", "train", "ATGGCTGCTTAA"),
@@ -156,6 +218,7 @@ def test_mmseqs_protein_cluster_violation_blocks_and_records_provenance(tmp_path
             records,
             report_path,
             executable=str(executable),
+            nucleotide_executable=str(nucleotide_executable),
             min_protein_identity=0.3,
             min_coverage=0.8,
         )
@@ -171,6 +234,45 @@ def test_mmseqs_protein_cluster_violation_blocks_and_records_provenance(tmp_path
         "train-synonym",
     ]
     assert homology["nearest_neighbors"]["protein"]["summary"]["count"] == 2
+    search_commands = [command for command in homology["commands"] if command[1] == "easy-search"]
+    assert [command[command.index("--search-type") + 1] for command in search_commands] == ["1"]
+    assert homology["nearest_neighbors"]["nucleotide"]["tool"]["version"] == (
+        "fake-minimap2-1.0"
+    )
+    assert homology["intermediates_cleaned"] is True
+    work_dir = tmp_path / "leakage_audit_work"
+    assert sorted(path.name for path in work_dir.iterdir()) == [
+        "nearest_nucleotide.paf",
+        "nearest_protein.tsv",
+        "protein_clusters_cluster.tsv",
+    ]
+
+
+def test_mmseqs_protein_cluster_report_policy_is_nonblocking(tmp_path):
+    executable = tmp_path / "mmseqs"
+    nucleotide_executable = tmp_path / "minimap2"
+    _write_fake_mmseqs(executable)
+    _write_fake_minimap2(nucleotide_executable)
+    report_path = tmp_path / "leakage.json"
+    records = [
+        _record("train-synonym", "train", "ATGGCTGCTTAA"),
+        _record("test-synonym", "test", "ATGGCCGCCTAA"),
+        _record("val-unique", "val", "ATGAAACAATAA"),
+    ]
+
+    report = audit_source_records(
+        records,
+        report_path,
+        executable=str(executable),
+        nucleotide_executable=str(nucleotide_executable),
+        protein_homology_policy="report",
+    )
+
+    assert report["status"] == "passed"
+    assert report["blocking_reasons"] == []
+    assert report["protein_homology_policy"] == "report"
+    assert report["thresholds"]["max_cross_split_protein_clusters"] is None
+    assert report["protein_homology"]["cross_split_cluster_count"] == 1
 
 
 def test_generated_audit_reports_nearest_identity_and_match_coverage(tmp_path):


### PR DESCRIPTION
## Summary
- quarantine exact cross-split CDS copies while retaining grouped genome/genus holdouts
- report expected cross-split protein homology instead of making grouped protocols impossible to build
- use MMseqs2 for protein auditing and low-memory Minimap2 nucleotide nearest-neighbor mapping
- retain and hash compact audit evidence while deleting reconstructable tool scratch
- emit manifest-tracked uint8 NPY sidecars for true mmap training
- strengthen freeze validation and record the accepted local dataset identities

## Local freeze acceptance
- freeze: `718417694607bed760fcb2335db1f65c96ef69cdae1612853e8778eef5ba8406`
- genome dataset: `da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9`
- genus dataset: `10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95`
- both manifests validate with zero exact cross-split duplicates
- trainer loader reports `npy_mmap`

## Testing
- scoped Ruff checks passed
- full suite: 268 passed, 1 skipped, 1 xpassed
- focused post-freeze checks: 29 passed
- full native 24-source genome/genus freeze with MMseqs2 18-8cc5c and Minimap2 2.31

Advances #92. The local freeze becomes the formal pipeline freeze only after merge and clean-main reproduction.