### PR TITLE
Reduce mmap dataloader batch allocations

### DIFF
--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -675,6 +675,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     and nearest-neighbor evidence reduces reconstructable audit workspace. This is a
     local acceptance freeze until the preparation PR merges and a clean-checkout
     reproduction confirms byte-identical identities.
+*   **Corrected Dataset Freeze Merge Validation and Mmap Batch Fetching (2026-07-21):**
+    After PR #111 merged, updated `main` and validated both frozen corrected manifests
+    successfully (`genome` artifact count 23, scientific valid true; `genus` artifact
+    count 23, scientific valid true). Began issue #90 by teaching
+    `MmapPackedDataset` to fetch fixed and dynamic mmap-backed batches directly from
+    batch indices. Training DataLoaders now use an index dataset plus mmap-aware
+    collate function, so `uint8` NPY sidecars are converted to `torch.long` once per
+    batch instead of materializing a separate `int64` NumPy copy per sample. Direct
+    `dataset[i]` behavior remains unchanged for compatibility.
 
 ---
 *End of Log*

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -328,8 +328,11 @@ python -m scripts.convert_npz_to_npy path/to/dataset.npz
 This generates `_X.npy`, `_Y.npy` (and/or `_lengths.npy`) files in the same
 directory. Set `use_mmap: true` in the training YAML to select
 `MmapPackedDataset`; it will report `storage_mode=npy_mmap` when all required
-sidecars are present. If they are absent, it reports `storage_mode=npz_memory`
-and warns that compressed NPZ members are being loaded into memory.
+sidecars are present. Training DataLoaders batch indices first and convert each
+mmap-backed batch to `torch.long` once, avoiding persistent `int64` token storage
+and avoiding a separate `int64` allocation for every fetched sample. If sidecars
+are absent, the loader reports `storage_mode=npz_memory` and warns that compressed
+NPZ members are being loaded into memory.
 
 # Compare multiple runs and produce a table + plots
 python -m scripts.compare_runs

--- a/src/codonlm/data_loading.py
+++ b/src/codonlm/data_loading.py
@@ -241,6 +241,10 @@ class MmapPackedDataset(Dataset):
             return len(self._delegate)
         return self._total
 
+    @property
+    def supports_batched_fetch(self) -> bool:
+        return self._delegate is None
+
     def __getitem__(self, i):
         if self._delegate is not None:
             return self._delegate[i]
@@ -263,6 +267,52 @@ class MmapPackedDataset(Dataset):
         length = int(self._lengths[fi][li])
         seq = np.array(self._mmaps[fi][start : start + length], dtype=np.int64)
         return torch.from_numpy(seq)
+
+    def fetch_batch(self, indices) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._delegate is not None:
+            samples = [self._delegate[int(i)] for i in indices]
+            if getattr(self._delegate, "is_dynamic", False):
+                return dynamic_lm_collate_fn(samples)
+            xs, ys = zip(*samples, strict=True)
+            return torch.stack(list(xs)), torch.stack(list(ys))
+
+        indices = np.asarray(indices, dtype=np.int64)
+        if indices.size == 0:
+            return torch.empty((0, 0), dtype=torch.long), torch.empty((0, 0), dtype=torch.long)
+
+        file_ids = self._global_file[indices].astype(np.int64, copy=False)
+        local_ids = self._global_local[indices].astype(np.int64, copy=False)
+
+        if not self.is_dynamic:
+            seq_len = int(self._mmaps_X[0].shape[1])
+            x_batch = np.empty((len(indices), seq_len), dtype=np.int64)
+            y_batch = np.empty((len(indices), seq_len), dtype=np.int64)
+            for file_idx in np.unique(file_ids):
+                mask = file_ids == file_idx
+                rows = local_ids[mask]
+                x_batch[mask] = self._mmaps_X[int(file_idx)][rows]
+                y_batch[mask] = self._mmaps_Y[int(file_idx)][rows]
+            return torch.from_numpy(x_batch), torch.from_numpy(y_batch)
+
+        lengths = np.asarray(
+            [int(self._lengths[int(fi)][int(li)]) for fi, li in zip(file_ids, local_ids, strict=True)],
+            dtype=np.int64,
+        )
+        max_len = int(lengths.max())
+        target_len = max(0, max_len - 1)
+        x_batch = np.full((len(indices), target_len), PAD_ID, dtype=np.int64)
+        y_batch = np.full((len(indices), target_len), PAD_ID, dtype=np.int64)
+        source_arrays = self._mmaps_X if self.use_npy_mmap else self._mmaps
+        for row_idx, (file_idx, local_idx, length) in enumerate(
+            zip(file_ids, local_ids, lengths, strict=True)
+        ):
+            start = int(self._offsets[int(file_idx)][int(local_idx)])
+            seq = source_arrays[int(file_idx)][start : start + int(length)]
+            usable = max(0, int(length) - 1)
+            if usable:
+                x_batch[row_idx, :usable] = seq[:-1]
+                y_batch[row_idx, :usable] = seq[1:]
+        return torch.from_numpy(x_batch), torch.from_numpy(y_batch)
 
     @property
     def seq_lengths(self) -> np.ndarray:
@@ -361,9 +411,38 @@ def build_codon_lm_datasets(train_paths, val_paths, use_mmap: bool = False):
     return dataset_cls(train_paths), dataset_cls(val_paths)
 
 
+class _IndexDataset(Dataset):
+    def __init__(self, length: int) -> None:
+        self.length = int(length)
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, idx: int) -> int:
+        return int(idx)
+
+
+def _batched_mmap_collate(dataset: MmapPackedDataset):
+    def collate(indices):
+        return dataset.fetch_batch(indices)
+
+    return collate
+
+
 def build_codon_lm_dataloaders(train_ds, val_ds, cfg: dict[str, Any]):
     kwargs = dataloader_kwargs(cfg)
-    collate_fn = dynamic_lm_collate_fn if getattr(train_ds, "is_dynamic", False) else None
+    train_batched_fetch = bool(getattr(train_ds, "supports_batched_fetch", False))
+    val_batched_fetch = bool(getattr(val_ds, "supports_batched_fetch", False))
+    collate_fn = (
+        _batched_mmap_collate(train_ds)
+        if train_batched_fetch
+        else dynamic_lm_collate_fn if getattr(train_ds, "is_dynamic", False) else None
+    )
+    val_collate_fn = (
+        _batched_mmap_collate(val_ds)
+        if val_batched_fetch
+        else dynamic_lm_collate_fn if getattr(val_ds, "is_dynamic", False) else None
+    )
     bucket_batching = bool(cfg.get("bucket_batching", False))
     train_sampler = None
     train_shuffle = True
@@ -381,24 +460,27 @@ def build_codon_lm_dataloaders(train_ds, val_ds, cfg: dict[str, Any]):
         train_shuffle = False
 
     if train_sampler is not None:
-        train_loader = DataLoader(train_ds, batch_sampler=train_sampler, collate_fn=collate_fn, **kwargs)
+        loader_dataset = _IndexDataset(len(train_ds)) if train_batched_fetch else train_ds
+        train_loader = DataLoader(loader_dataset, batch_sampler=train_sampler, collate_fn=collate_fn, **kwargs)
     else:
         generator = None
         if dataloader_seed is not None:
             generator = torch.Generator()
             generator.manual_seed(int(dataloader_seed))
+        loader_dataset = _IndexDataset(len(train_ds)) if train_batched_fetch else train_ds
         train_loader = DataLoader(
-            train_ds,
+            loader_dataset,
             batch_size=int(cfg["batch_size"]),
             shuffle=train_shuffle,
             collate_fn=collate_fn,
             generator=generator,
             **kwargs,
         )
+    val_loader_dataset = _IndexDataset(len(val_ds)) if val_batched_fetch else val_ds
     val_loader = DataLoader(
-        val_ds,
+        val_loader_dataset,
         batch_size=int(cfg["batch_size"]),
-        collate_fn=collate_fn,
+        collate_fn=val_collate_fn,
         **kwargs,
     )
     return train_loader, val_loader, train_sampler, kwargs

--- a/tests/test_mmap_dataset.py
+++ b/tests/test_mmap_dataset.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from src.codonlm.data_loading import MmapPackedDataset
+from src.codonlm.data_loading import MmapPackedDataset, build_codon_lm_dataloaders
 
 
 def test_mmap_packed_dataset_npz_fallback(tmp_path: Path):
@@ -53,6 +53,37 @@ def test_mmap_packed_dataset_npy_fixed(tmp_path: Path):
     # Check seq_lengths
     assert np.array_equal(ds.seq_lengths, np.full(10, 8, dtype=np.int32))
 
+    xb, yb = ds.fetch_batch([5, 2, 7])
+    assert xb.dtype == torch.long
+    assert yb.dtype == torch.long
+    assert torch.equal(xb, torch.from_numpy(X[[5, 2, 7]]).long())
+    assert torch.equal(yb, torch.from_numpy(Y[[5, 2, 7]]).long())
+
+
+def test_mmap_dataloader_uses_batched_fixed_fetch(tmp_path: Path):
+    X = np.arange(40, dtype=np.uint8).reshape(5, 8)
+    Y = X + 1
+
+    npz_path = tmp_path / "train.npz"
+    np.savez(npz_path, X=X, Y=Y)
+    np.save(tmp_path / "train_X.npy", X)
+    np.save(tmp_path / "train_Y.npy", Y)
+
+    train_ds = MmapPackedDataset(npz_path)
+    val_ds = MmapPackedDataset(npz_path)
+    train_loader, val_loader, _, _ = build_codon_lm_dataloaders(
+        train_ds,
+        val_ds,
+        {"batch_size": 2, "dataloader_seed": 123},
+    )
+
+    xb, yb = next(iter(val_loader))
+    assert xb.dtype == torch.long
+    assert yb.dtype == torch.long
+    assert torch.equal(xb, torch.from_numpy(X[:2]).long())
+    assert torch.equal(yb, torch.from_numpy(Y[:2]).long())
+    assert len(train_loader) == 3
+
 
 def test_mmap_packed_dataset_npy_dynamic(tmp_path: Path):
     # Create mock dynamic-length NPZ and its NPY versions
@@ -80,3 +111,37 @@ def test_mmap_packed_dataset_npy_dynamic(tmp_path: Path):
     
     # Check seq_lengths
     assert np.array_equal(ds.seq_lengths, lengths)
+
+    xb, yb = ds.fetch_batch([1, 0])
+    assert xb.dtype == torch.long
+    assert yb.dtype == torch.long
+    assert torch.equal(xb[0], torch.tensor([X[4], X[5], X[6], X[7], X[8]], dtype=torch.long))
+    assert torch.equal(yb[0], torch.tensor([X[5], X[6], X[7], X[8], X[9]], dtype=torch.long))
+    assert torch.equal(xb[1], torch.tensor([X[0], X[1], X[2], 0, 0], dtype=torch.long))
+    assert torch.equal(yb[1], torch.tensor([X[1], X[2], X[3], 0, 0], dtype=torch.long))
+
+
+def test_mmap_dataloader_uses_batched_dynamic_fetch(tmp_path: Path):
+    seq1 = np.array([1, 10, 20, 2], dtype=np.uint8)
+    seq2 = np.array([1, 15, 25, 35, 45, 2], dtype=np.uint8)
+    X = np.concatenate([seq1, seq2])
+    lengths = np.array([len(seq1), len(seq2)], dtype=np.int32)
+
+    npz_path = tmp_path / "train_dyn.npz"
+    np.savez(npz_path, X=X, lengths=lengths)
+    np.save(tmp_path / "train_dyn_X.npy", X)
+    np.save(tmp_path / "train_dyn_lengths.npy", lengths)
+
+    train_ds = MmapPackedDataset(npz_path)
+    val_ds = MmapPackedDataset(npz_path)
+    _, val_loader, _, _ = build_codon_lm_dataloaders(
+        train_ds,
+        val_ds,
+        {"batch_size": 2},
+    )
+
+    xb, yb = next(iter(val_loader))
+    assert torch.equal(xb[0], torch.tensor([1, 10, 20, 0, 0], dtype=torch.long))
+    assert torch.equal(yb[0], torch.tensor([10, 20, 2, 0, 0], dtype=torch.long))
+    assert torch.equal(xb[1], torch.tensor([1, 15, 25, 35, 45], dtype=torch.long))
+    assert torch.equal(yb[1], torch.tensor([15, 25, 35, 45, 2], dtype=torch.long))


### PR DESCRIPTION
## Summary
- add batch-level fetch support for mmap-backed fixed and dynamic CodonLM datasets
- route training DataLoaders through index batches plus a mmap-aware collate function
- document the batch conversion behavior and record the post-#111 manifest validation

Closes #90.

## Validation
- python -m scripts.validate_dataset_manifest data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
- python -m scripts.validate_dataset_manifest data/processed/corrected/corrected-codonlm-v1/genus/manifest.json
- pytest -q tests/test_mmap_dataset.py tests/test_dynamic_dataset.py tests/test_trainer_utils.py tests/test_ppl_baselines.py
- pytest -q tests/test_global_split_and_baselines.py tests/test_vocabulary_contract.py tests/test_batch_optimizer.py
- pytest -q
- ruff check src/codonlm/data_loading.py tests/test_mmap_dataset.py
- real frozen genome mmap smoke read: train/val storage=npy_mmap, batch shape=(8, 512), dtype=torch.int64

## Note
- Full F401 [*] `os` imported but unused
  --> scripts/benchmark_essentiality_baselines.py:10:8
   |
 9 | import argparse
10 | import os
   |        ^^
11 | import json
12 | import numpy as np
   |
help: Remove unused import: `os`

F401 [*] `json` imported but unused
  --> scripts/benchmark_essentiality_baselines.py:11:8
   |
 9 | import argparse
10 | import os
11 | import json
   |        ^^^^
12 | import numpy as np
13 | import pandas as pd
   |
help: Remove unused import: `json`

F401 [*] `os` imported but unused
  --> scripts/benchmark_gene_essentiality.py:13:8
   |
11 | import argparse
12 | import json
13 | import os
   |        ^^
14 | import pandas as pd
15 | import numpy as np
   |
help: Remove unused import: `os`

F401 [*] `src.codonlm.codon_tokenize.to_ids` imported but unused
  --> scripts/benchmark_gene_essentiality.py:24:40
   |
22 | # Import shared helpers
23 | from scripts._shared import resolve_run, load_model
24 | from src.codonlm.codon_tokenize import to_ids
   |                                        ^^^^^^
25 | from scripts.extract_embeddings import _pool_hidden, _dna_to_codon_tokens
   |
help: Remove unused import: `src.codonlm.codon_tokenize.to_ids`

F541 [*] f-string without any placeholders
   --> scripts/benchmark_gene_essentiality.py:139:15
    |
137 |     lambda_metrics = {"acc": 0.0, "f1": 0.0, "mcc": 0.0}
138 |     if lambda_path.exists():
139 |         print(f"[*] Extracting embeddings for Lambda Phage essentiality...")
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
140 |         df_lambda = pd.read_csv(lambda_path)
141 |         X_lambda = extract_embeddings_for_seqs(
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/benchmark_gene_essentiality.py:146:15
    |
144 |         y_lambda = df_lambda["essential"].to_numpy()
145 |         lambda_metrics = run_linear_probe(X_lambda, y_lambda)
146 |         print(f"  - Lambda Phage Essentiality (5-fold CV):")
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
147 |         print(f"    Accuracy: {lambda_metrics['acc']:.4f}")
148 |         print(f"    F1 Score: {lambda_metrics['f1']:.4f}")
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/benchmark_gene_essentiality.py:157:15
    |
155 |     pa_metrics = {"acc": 0.0, "f1": 0.0, "mcc": 0.0}
156 |     if pa_path.exists():
157 |         print(f"[*] Extracting embeddings for Pseudomonas aeruginosa essentiality...")
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
158 |         df_pa = pd.read_csv(pa_path)
159 |         X_pa = extract_embeddings_for_seqs(
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/benchmark_gene_essentiality.py:164:15
    |
162 |         y_pa = df_pa["essential"].to_numpy()
163 |         pa_metrics = run_linear_probe(X_pa, y_pa)
164 |         print(f"  - Pseudomonas aeruginosa Essentiality (5-fold CV):")
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
165 |         print(f"    Accuracy: {pa_metrics['acc']:.4f}")
166 |         print(f"    F1 Score: {pa_metrics['f1']:.4f}")
    |
help: Remove extraneous `f` prefix

F401 [*] `os` imported but unused
  --> scripts/benchmark_hybrid_critic.py:9:8
   |
 8 | import time
 9 | import os
   |        ^^
10 | import sys
11 | import torch
   |
help: Remove unused import: `os`

F401 [*] `src.protein_lm.tokenizer.ProteinTokenizer` imported but unused
  --> scripts/benchmark_hybrid_critic.py:20:38
   |
18 | sys.path.append(str(Path(__file__).parent.parent))
19 |
20 | from src.protein_lm.tokenizer import ProteinTokenizer
   |                                      ^^^^^^^^^^^^^^^^
21 | from src.protein_lm.ebm import ProteinLatentEBM
22 | from src.codonlm.generate import generate_cds_critic_guided
   |
help: Remove unused import: `src.protein_lm.tokenizer.ProteinTokenizer`

F841 Local variable `raw_seq` is assigned to but never used
   --> scripts/benchmark_hybrid_critic.py:106:13
    |
104 |             # Decode codons
105 |             codon_list = [itos[i] for i in gen_ids if len(itos[i]) == 3 and not (itos[i].startswith("<") or itos[i].endswith(">"))]
106 |             raw_seq = "".join(codon_list)
    |             ^^^^^^^
107 |             aa_seq = translate_codons_to_aa(codon_list)
    |
help: Remove assignment to unused variable `raw_seq`

F401 [*] `os` imported but unused
  --> scripts/benchmark_zero_shot_mutations.py:15:8
   |
13 | import argparse
14 | import json
15 | import os
   |        ^^
16 | import pandas as pd
17 | import torch
   |
help: Remove unused import: `os`

F401 [*] `scripts._shared.stoi` imported but unused
  --> scripts/benchmark_zero_shot_mutations.py:22:62
   |
21 | # Import our shared helpers
22 | from scripts._shared import resolve_run, load_model, stoi as shared_stoi
   |                                                              ^^^^^^^^^^^
23 | from src.codonlm.codon_tokenize import to_ids, stoi as token_stoi
   |
help: Remove unused import: `scripts._shared.stoi`

F401 [*] `src.codonlm.codon_tokenize.stoi` imported but unused
  --> scripts/benchmark_zero_shot_mutations.py:23:56
   |
21 | # Import our shared helpers
22 | from scripts._shared import resolve_run, load_model, stoi as shared_stoi
23 | from src.codonlm.codon_tokenize import to_ids, stoi as token_stoi
   |                                                        ^^^^^^^^^^
24 |
25 | def score_sequence(model, token_ids, device):
   |
help: Remove unused import: `src.codonlm.codon_tokenize.stoi`

F401 [*] `sys` imported but unused
  --> scripts/check_termination_motifs.py:8:8
   |
 7 | import argparse
 8 | import sys
   |        ^^^
 9 | from pathlib import Path
10 | import numpy as np
   |
help: Remove unused import: `sys`

F401 [*] `scripts._shared.load_model` imported but unused
  --> scripts/check_termination_motifs.py:13:29
   |
11 | import torch
12 |
13 | from scripts._shared import load_model, resolve_run, load_token_list, stoi
   |                             ^^^^^^^^^^
14 | from src.codonlm.generate import generate_cds_constrained
15 | from scripts.probe_structural_awareness import get_theoretical_shape
   |
help: Remove unused import: `scripts._shared.load_model`

F541 [*] f-string without any placeholders
   --> scripts/check_termination_motifs.py:173:11
    |
171 |             hard_capped_seqs.append(analysis_window)
172 |             
173 |     print(f"\n[*] Generation complete:")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
174 |     print(f"    - Early terminated: {len(early_term_seqs)} ({len(early_term_seqs)/(len(early_term_seqs)+len(hard_capped_seqs)+1e-9)*1…
175 |     print(f"    - Hard capped (reached target): {len(hard_capped_seqs)}")
    |
help: Remove extraneous `f` prefix

F401 [*] `shutil` imported but unused
  --> scripts/cleanup_runs.py:11:8
   |
 9 | import argparse
10 | from pathlib import Path
11 | import shutil
   |        ^^^^^^
12 | import sys
13 | import time
   |
help: Remove unused import: `shutil`

F401 [*] `sys` imported but unused
  --> scripts/cleanup_runs.py:12:8
   |
10 | from pathlib import Path
11 | import shutil
12 | import sys
   |        ^^^
13 | import time
   |
help: Remove unused import: `sys`

F401 [*] `time` imported but unused
  --> scripts/cleanup_runs.py:13:8
   |
11 | import shutil
12 | import sys
13 | import time
   |        ^^^^
14 |
15 | # Keep important/final checkpoint files by default
   |
help: Remove unused import: `time`

F841 [*] Local variable `err` is assigned to but never used
  --> scripts/compare_checkpoints.py:28:45
   |
26 |         subprocess.run(cmd, check=True, env=current_env)
27 |         return True
28 |     except subprocess.CalledProcessError as err:
   |                                             ^^^
29 |         print(f"[!] Command failed: {' '.join(cmd)}")
30 |         return False
   |
help: Remove assignment to unused variable `err`

F401 [*] `json` imported but unused
  --> scripts/compare_generators.py:8:8
   |
 7 | import argparse
 8 | import json
   |        ^^^^
 9 | from pathlib import Path
10 | import numpy as np
   |
help: Remove unused import: `json`

F401 [*] `matplotlib.gridspec` imported but unused
  --> scripts/conference_attention.py:28:31
   |
26 | matplotlib.use("Agg")
27 | import matplotlib.pyplot as plt
28 | import matplotlib.gridspec as gridspec
   |                               ^^^^^^^^
29 | import numpy as np
   |
help: Remove unused import: `matplotlib.gridspec`

E741 Ambiguous variable name: `l`
  --> scripts/conference_attention.py:57:9
   |
56 |     stats = np.zeros((L, H, 3))
57 |     for l in range(L):
   |         ^
58 |         for h in range(H):
59 |             head = attn[l, 0, h]  # (T, T) — use first batch item
   |

E741 Ambiguous variable name: `l`
   --> scripts/conference_attention.py:189:37
    |
187 |     """Bar chart of start-codon and stop-codon attention bias for all L×H heads."""
188 |     L, H = stats.shape[:2]
189 |     head_labels = [f"L{l}·H{h}" for l in range(L) for h in range(H)]
    |                                     ^
190 |     start_scores = stats[:, :, 1].ravel()
191 |     stop_scores = stats[:, :, 2].ravel()
    |

E741 Ambiguous variable name: `l`
   --> scripts/conference_attention.py:313:9
    |
311 |     plotted = 0
312 |     for rank, flat_idx in enumerate(flat_order[:6]):
313 |         l, h = np.unravel_index(flat_idx, (L, H))
    |         ^
314 |         matrix = attn[l, 0, h]  # (T, T) first sample
315 |         fname = charts_dir / f"conference_attn_L{l}_H{h}_focused.png"
    |

F541 [*] f-string without any placeholders
   --> scripts/conference_attention.py:349:11
    |
348 |     print(f"\n[attn] ✅ All figures saved to {charts_dir} and {conf_dir}")
349 |     print(f"[attn] Summary:")
    |           ^^^^^^^^^^^^^^^^^^
350 |     print(f"  Most focused head:    L{np.unravel_index(np.argmin(entropy), (L,H))[0]}·H{np.unravel_index(np.argmin(entropy), (L,H))[1…
351 |     print(f"  Best ATG specialist:  L{best_l}·H{best_h}  (bias={start_bias[best_l,best_h]:.4f})")
    |
help: Remove extraneous `f` prefix

F401 [*] `os` imported but unused
 --> scripts/download_genomes.py:7:8
  |
5 | """
6 |
7 | import os
  |        ^^
8 | import urllib.request
9 | import re
  |
help: Remove unused import: `os`

F541 [*] f-string without any placeholders
   --> scripts/download_genomes.py:99:11
    |
 97 |     dest_dir.mkdir(parents=True, exist_ok=True)
 98 |
 99 |     print(f"===========================================================")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
100 |     print(f"Starting Download of {len(GENOMES)} Diverse Reference Genomes")
101 |     print(f"Target Directory: {dest_dir}")
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/download_genomes.py:102:11
    |
100 |     print(f"Starting Download of {len(GENOMES)} Diverse Reference Genomes")
101 |     print(f"Target Directory: {dest_dir}")
102 |     print(f"===========================================================")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
103 |
104 |     success_count = 0
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/download_genomes.py:110:11
    |
108 |             success_count += 1
109 |
110 |     print(f"\n===========================================================")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
111 |     print(f"Download completed: {success_count}/{len(GENOMES)} genomes downloaded.")
112 |     print(f"===========================================================")
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/download_genomes.py:112:11
    |
110 |     print(f"\n===========================================================")
111 |     print(f"Download completed: {success_count}/{len(GENOMES)} genomes downloaded.")
112 |     print(f"===========================================================")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
113 |
114 | if __name__ == "__main__":
    |
help: Remove extraneous `f` prefix

F401 [*] `os` imported but unused
  --> scripts/expand_model.py:10:8
   |
 9 | import argparse
10 | import os
   |        ^^
11 | import yaml
12 | import torch
   |
help: Remove unused import: `os`

F541 [*] f-string without any placeholders
  --> scripts/expand_model.py:64:11
   |
62 |     multi_offset_targets = dst_cfg.get("multi_offset_targets", [])
63 |
64 |     print(f"[expand] Creating target TinyGPT model with:")
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
65 |     print(f"  n_layer={n_layer}, n_head={n_head}, n_embd={n_embd}, use_swiglu={use_swiglu}, use_rope={use_rope}")
66 |     target_model = TinyGPT(
   |
help: Remove extraneous `f` prefix

F401 [*] `json` imported but unused
 --> scripts/fold_top_designs.py:7:8
  |
6 | import csv
7 | import json
  |        ^^^^
8 | import requests
9 | from pathlib import Path
  |
help: Remove unused import: `json`

F401 [*] `os` imported but unused
 --> scripts/generate_run_summaries.py:7:8
  |
5 | """
6 |
7 | import os
  |        ^^
8 | import sys
9 | import json
  |
help: Remove unused import: `os`

F401 [*] `os` imported but unused
  --> scripts/generate_sota_report.py:13:8
   |
11 | import argparse
12 | import json
13 | import os
   |        ^^
14 | from pathlib import Path
15 | from scripts._shared import resolve_run
   |
help: Remove unused import: `os`

F401 [*] `pathlib.Path` imported but unused
  --> scripts/generate_sota_report.py:14:21
   |
12 | import json
13 | import os
14 | from pathlib import Path
   |                     ^^^^
15 | from scripts._shared import resolve_run
   |
help: Remove unused import: `pathlib.Path`

F841 Local variable `val_ppl` is assigned to but never used
  --> scripts/generate_sota_report.py:71:17
   |
69 |                 n_params_m = (12 * n_layer * (n_embd ** 2)) / 1e6
70 |                 # Pre-training time estimate (can check run logs or use fallback)
71 |                 val_ppl = meta.get("val_ppl", 0.0)
   |                 ^^^^^^^
72 |         except Exception:
73 |             pass
   |
help: Remove assignment to unused variable `val_ppl`

F541 [*] f-string without any placeholders
   --> scripts/generate_sota_report.py:118:23
    |
116 |     # Generate Markdown Output
117 |     md_content = []
118 |     md_content.append(f"# SOTA Prokaryotic Benchmarking & Efficiency Report")
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
119 |     md_content.append(f"**Target Run:** `{run_id}`")
120 |     md_content.append(f"**Hardware Platform:** Apple Silicon M2 Mac (MPS GPU)")
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generate_sota_report.py:120:23
    |
118 |     md_content.append(f"# SOTA Prokaryotic Benchmarking & Efficiency Report")
119 |     md_content.append(f"**Target Run:** `{run_id}`")
120 |     md_content.append(f"**Hardware Platform:** Apple Silicon M2 Mac (MPS GPU)")
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
121 |     md_content.append("")
122 |     md_content.append("## 1. Prokaryotic Evaluation Suite Comparison")
    |
help: Remove extraneous `f` prefix

F401 [*] `torch.nn.functional` imported but unused
  --> scripts/generative_design_loop.py:42:31
   |
40 | import numpy as np
41 | import torch
42 | import torch.nn.functional as F
   |                               ^
43 | import yaml
   |
help: Remove unused import: `torch.nn.functional`

E402 Module level import not at top of file
   --> scripts/generative_design_loop.py:370:1
    |
368 |   # Diversity metrics
369 |   # ────────────────────────────────────────────────────────────────────────────
370 | / from src.eval.diversity import (
371 | |     pairwise_identity,
372 | |     kmer_diversity,
373 | |     gc_content,
374 | | )
    | |_^
    |

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:636:23
    |
634 |                 print(f"    pLDDT={fold['plddt_mean']:.1f}  →  saved {pdb_path.name}")
635 |             else:
636 |                 print(f"    ESMFold failed or unavailable")
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
637 |             esm_results.append(esm_result)
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:718:9
    |
716 |         "## 1. Termination (ReD Sampling)",
717 |         "",
718 |         f"| Metric | Value |",
    |         ^^^^^^^^^^^^^^^^^^^^^
719 |         f"|---|---|",
720 |         f"| Sequences requested | {n_sequences} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:719:9
    |
717 |         "",
718 |         f"| Metric | Value |",
719 |         f"|---|---|",
    |         ^^^^^^^^^^^^
720 |         f"| Sequences requested | {n_sequences} |",
721 |         f"| Properly terminated | {int(termination_rate * n_sequences)} "
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:734:9
    |
732 |         "## 2. Sequence Statistics",
733 |         "",
734 |         f"| Metric | Value |",
    |         ^^^^^^^^^^^^^^^^^^^^^
735 |         f"|---|---|",
736 |         f"| Mean AA length | {np.mean(lengths):.1f} ± {np.std(lengths):.1f} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:735:9
    |
733 |         "",
734 |         f"| Metric | Value |",
735 |         f"|---|---|",
    |         ^^^^^^^^^^^^
736 |         f"| Mean AA length | {np.mean(lengths):.1f} ± {np.std(lengths):.1f} |",
737 |         f"| Min / Max AA length | {np.min(lengths)} / {np.max(lengths)} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:749:13
    |
747 |         high_stab = sum(1 for p in stab_probs if p > 0.7)
748 |         lines += [
749 |             f"### Stability",
    |             ^^^^^^^^^^^^^^^^
750 |             f"| Metric | Value |",
751 |             f"|---|---|",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:750:13
    |
748 |         lines += [
749 |             f"### Stability",
750 |             f"| Metric | Value |",
    |             ^^^^^^^^^^^^^^^^^^^^^
751 |             f"|---|---|",
752 |             f"| Mean stability probability | {np.mean(stab_probs):.3f} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:751:13
    |
749 |             f"### Stability",
750 |             f"| Metric | Value |",
751 |             f"|---|---|",
    |             ^^^^^^^^^^^^
752 |             f"| Mean stability probability | {np.mean(stab_probs):.3f} |",
753 |             f"| Sequences with P(stable) > 0.7 | {high_stab} / {len(stab_probs)} "
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:762:13
    |
760 |     if fam_confs:
761 |         lines += [
762 |             f"### Pfam Family",
    |             ^^^^^^^^^^^^^^^^^^
763 |             f"| Metric | Value |",
764 |             f"|---|---|",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:763:13
    |
761 |         lines += [
762 |             f"### Pfam Family",
763 |             f"| Metric | Value |",
    |             ^^^^^^^^^^^^^^^^^^^^^
764 |             f"|---|---|",
765 |             f"| Mean top-1 confidence | {np.mean(fam_confs):.4f} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:764:13
    |
762 |             f"### Pfam Family",
763 |             f"| Metric | Value |",
764 |             f"|---|---|",
    |             ^^^^^^^^^^^^
765 |             f"| Mean top-1 confidence | {np.mean(fam_confs):.4f} |",
766 |             f"| Sequences with conf > 0.5 | "
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:773:13
    |
771 |     if fn_confs:
772 |         lines += [
773 |             f"### EC Function",
    |             ^^^^^^^^^^^^^^^^^^
774 |             f"| Metric | Value |",
775 |             f"|---|---|",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:774:13
    |
772 |         lines += [
773 |             f"### EC Function",
774 |             f"| Metric | Value |",
    |             ^^^^^^^^^^^^^^^^^^^^^
775 |             f"|---|---|",
776 |             f"| Mean top-1 confidence | {np.mean(fn_confs):.4f} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:775:13
    |
773 |             f"### EC Function",
774 |             f"| Metric | Value |",
775 |             f"|---|---|",
    |             ^^^^^^^^^^^^
776 |             f"| Mean top-1 confidence | {np.mean(fn_confs):.4f} |",
777 |             f"| Sequences with conf > 0.5 | "
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:846:9
    |
844 |         "## 4. Diversity",
845 |         "",
846 |         f"| Metric | Value | Interpretation |",
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
847 |         f"|---|---|---|",
848 |         f"| Mean pairwise AA identity | {pairwise_id*100:.1f}% | "
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:847:9
    |
845 |         "",
846 |         f"| Metric | Value | Interpretation |",
847 |         f"|---|---|---|",
    |         ^^^^^^^^^^^^^^^^
848 |         f"| Mean pairwise AA identity | {pairwise_id*100:.1f}% | "
849 |         f"{'Diverse (< 70%)' if pairwise_id < 0.7 else 'Redundant (> 70%)'} |",
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:865:13
    |
863 |             "## 5. ESMFold Structure Predictions (Top Sequences)",
864 |             "",
865 |             f"| Rank | Seq ID | pLDDT (mean) | pLDDT (min) | Confidence |",
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
866 |             f"|---|---|---|---|---|",
867 |         ]
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/generative_design_loop.py:866:13
    |
864 |             "",
865 |             f"| Rank | Seq ID | pLDDT (mean) | pLDDT (min) | Confidence |",
866 |             f"|---|---|---|---|---|",
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
867 |         ]
868 |         for r in esm_results:
    |
help: Remove extraneous `f` prefix

F401 [*] `src.protein_lm.tokenizer.ProteinTokenizer` imported but unused
  --> scripts/optimize_designs_langevin.py:14:38
   |
12 | sys.path.append(str(Path(__file__).parent.parent))
13 |
14 | from src.protein_lm.tokenizer import ProteinTokenizer
   |                                      ^^^^^^^^^^^^^^^^
15 | from src.protein_lm.ebm import ProteinLatentEBM
16 | from src.protein_lm.sampler import latent_langevin_sample
   |
help: Remove unused import: `src.protein_lm.tokenizer.ProteinTokenizer`

E402 Module level import not at top of file
  --> scripts/optimize_designs_langevin.py:33:1
   |
31 |     return sorted_recs[0]
32 |
33 | import torch.nn as nn
   | ^^^^^^^^^^^^^^^^^^^^^
34 |
35 | def main():
   |

F401 [*] `torch.nn` imported but unused
  --> scripts/optimize_designs_langevin.py:33:20
   |
31 |     return sorted_recs[0]
32 |
33 | import torch.nn as nn
   |                    ^^
34 |
35 | def main():
   |
help: Remove unused import: `torch.nn`

F541 [*] f-string without any placeholders
   --> scripts/optimize_designs_langevin.py:115:11
    |
113 |         avg_vocab_dist = sum(vocab_distances) / len(vocab_distances)
114 |         
115 |     print(f"\n[+] Embedding space statistics:")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
116 |     print(f"    Average distance between amino acid embeddings in vocab: {avg_vocab_dist:.4f}")
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/optimize_designs_langevin.py:140:11
    |
138 |     # Compare
139 |     print("\n=== LANGEVIN EMBEDDING OPTIMIZATION RESULTS ===")
140 |     print(f"Metric                       | Initial Sequence    | Optimized Sequence  | Delta")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
141 |     print("-" * 85)
142 |     print(f"EBM Energy Score             | {energy_history[0]:<19.4f} | {energy_history[-1]:<19.4f} | {energy_history[-1] - energy_hi…
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/prepare_ec_dataset.py:116:11
    |
114 |     test_df[["id", "seq"]].to_csv(test_seqs_csv, index=False)
115 |
116 |     print(f"[success] Created EC classification splits:")
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
117 |     print(f"  - Train: {len(train_df)} samples -> {train_labels_csv} & {train_seqs_csv}")
118 |     print(f"  - Test:  {len(test_df)} samples -> {test_labels_csv} & {test_seqs_csv}")
    |
help: Remove extraneous `f` prefix

F401 [*] `os` imported but unused
  --> scripts/prepare_sota_benchmarks.py:14:8
   |
12 | """
13 |
14 | import os
   |        ^^
15 | import random
16 | import csv
   |
help: Remove unused import: `os`

F401 [*] `json` imported but unused
  --> scripts/probe_structural_regression.py:9:8
   |
 8 | import argparse
 9 | import json
   |        ^^^^
10 | import os
11 | import random
   |
help: Remove unused import: `json`

F401 [*] `pathlib.Path` imported but unused
  --> scripts/probe_structural_regression.py:12:21
   |
10 | import os
11 | import random
12 | from pathlib import Path
   |                     ^^^^
13 | import numpy as np
14 | import torch
   |
help: Remove unused import: `pathlib.Path`

F541 [*] f-string without any placeholders
  --> scripts/run_ablation_sweep.py:83:11
   |
81 |     ] + config["flags"]
82 |     
83 |     print(f"\n==================================================")
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
84 |     print(f"[{cfg_idx + 1}/8] Running: {name}")
85 |     print(f"Command: {' '.join(cmd)}")
   |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
  --> scripts/run_ablation_sweep.py:86:11
   |
84 |     print(f"[{cfg_idx + 1}/8] Running: {name}")
85 |     print(f"Command: {' '.join(cmd)}")
86 |     print(f"==================================================")
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
87 |     
88 |     subprocess.run(cmd, check=True)
   |
help: Remove extraneous `f` prefix

F401 [*] `json` imported but unused
  --> scripts/run_guidance_ablation.py:8:8
   |
 6 | import subprocess
 7 | import csv
 8 | import json
   |        ^^^^
 9 | import time
10 | from pathlib import Path
   |
help: Remove unused import: `json`

F401 [*] `os` imported but unused
 --> scripts/train_biophysics_fusion.py:7:8
  |
5 | """
6 |
7 | import os
  |        ^^
8 | import sys
9 | import torch
  |
help: Remove unused import: `os`

F401 [*] `yaml` imported but unused
  --> scripts/train_biophysics_fusion.py:11:8
   |
 9 | import torch
10 | import torch.nn as nn
11 | import yaml
   |        ^^^^
12 | from pathlib import Path
   |
help: Remove unused import: `yaml`

F401 [*] `src.eval.inference_playground.load_codon_model` imported but unused
  --> scripts/train_biophysics_fusion.py:19:43
   |
17 | from src.codonlm.biophysics import NucleotideEncoder, generate_shape_training_data
18 | from src.codonlm.model_tiny_gpt import TinyGPT
19 | from src.eval.inference_playground import load_codon_model
   |                                           ^^^^^^^^^^^^^^^^
20 |
21 | def build_one_hot_lookup(itos: list, device: torch.device) -> torch.Tensor:
   |
help: Remove unused import: `src.eval.inference_playground.load_codon_model`

F401 [*] `os` imported but unused
 --> scripts/verify_saliency_contrast.py:4:8
  |
2 | import numpy as np
3 | import yaml
4 | import os
  |        ^^
5 | from src.protein_lm.tokenizer import ProteinTokenizer
6 | from src.protein_lm.models_multi import MultiTaskProteinClassifier
  |
help: Remove unused import: `os`

F541 [*] f-string without any placeholders
   --> scripts/web_dashboard.py:867:44
    |
865 | …                         st.write(f"- Variant translates to: `{aa_var}`")
866 | …                     else:
867 | …                         st.success(f"Success: Sequences are Synonymous! Both translate to:")
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
868 | …                         st.code(aa_wt)
    |
help: Remove extraneous `f` prefix

F401 [*] `typing.List` imported but unused
 --> src/codonlm/biophysics.py:4:20
  |
2 | import torch.nn as nn
3 | import random
4 | from typing import List, Tuple
  |                    ^^^^
5 | from scripts.probe_structural_awareness import get_theoretical_shape
  |
help: Remove unused import: `typing.List`

F401 [*] `.data_loading.PackedDataset` imported but unused
  --> src/codonlm/eval_perplexity.py:9:27
   |
 7 | import torch
 8 | from .model_tiny_gpt import TinyGPT
 9 | from .data_loading import PackedDataset
   |                           ^^^^^^^^^^^^^
10 |
11 | def dev():
   |
help: Remove unused import: `.data_loading.PackedDataset`

E402 Module level import not at top of file
   --> src/codonlm/generate.py:342:1
    |
340 | ]
341 |
342 | import torch.nn as nn
    | ^^^^^^^^^^^^^^^^^^^^^
343 |
344 | @torch.no_grad()
    |

E402 Module level import not at top of file
   --> src/codonlm/generate.py:562:1
    |
560 | }
561 |
562 | from collections import defaultdict
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
563 | AA_TO_CODONS = defaultdict(list)
564 | for codon, aa in CODON_TABLE.items():
    |

F841 Local variable `had_terminal_stop` is assigned to but never used
   --> src/codonlm/generate.py:661:5
    |
659 |     ids.append(next_id)
660 |     new_codons += 1
661 |     had_terminal_stop = True
    |     ^^^^^^^^^^^^^^^^^
662 |
663 |     # 3. Append UTR boundary token (EOS)
    |
help: Remove assignment to unused variable `had_terminal_stop`

F401 [*] `typing.Dict` imported but unused
 --> src/codonlm/hybrid_tokenizer.py:2:20
  |
1 | from __future__ import annotations
2 | from typing import Dict, List, Tuple, Optional
  |                    ^^^^
3 |
4 | # Special token constants
  |
help: Remove unused import: `typing.Dict`

F401 [*] `src.codonlm.training.config.write_meta` imported but unused
  --> src/codonlm/train_codon_lm.py:13:5
   |
12 | from src.codonlm.training.config import (
13 |     write_meta,
   |     ^^^^^^^^^^
14 |     _ensure_path_list,
15 |     _normalize_run_id,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.config._ensure_path_list` imported but unused
  --> src/codonlm/train_codon_lm.py:14:5
   |
12 | from src.codonlm.training.config import (
13 |     write_meta,
14 |     _ensure_path_list,
   |     ^^^^^^^^^^^^^^^^^
15 |     _normalize_run_id,
16 |     _auto_run_id,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.config._normalize_run_id` imported but unused
  --> src/codonlm/train_codon_lm.py:15:5
   |
13 |     write_meta,
14 |     _ensure_path_list,
15 |     _normalize_run_id,
   |     ^^^^^^^^^^^^^^^^^
16 |     _auto_run_id,
17 |     _prepare_output_dirs,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.config._auto_run_id` imported but unused
  --> src/codonlm/train_codon_lm.py:16:5
   |
14 |     _ensure_path_list,
15 |     _normalize_run_id,
16 |     _auto_run_id,
   |     ^^^^^^^^^^^^
17 |     _prepare_output_dirs,
18 |     _normalize_offset_weights,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.config._prepare_output_dirs` imported but unused
  --> src/codonlm/train_codon_lm.py:17:5
   |
15 |     _normalize_run_id,
16 |     _auto_run_id,
17 |     _prepare_output_dirs,
   |     ^^^^^^^^^^^^^^^^^^^^
18 |     _normalize_offset_weights,
19 | )
   |
help: Remove unused import

F401 [*] `src.codonlm.training.config._normalize_offset_weights` imported but unused
  --> src/codonlm/train_codon_lm.py:18:5
   |
16 |     _auto_run_id,
17 |     _prepare_output_dirs,
18 |     _normalize_offset_weights,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
19 | )
20 | from src.codonlm.training.checkpoint import _read_itos, _load_transfer_state_dict
   |
help: Remove unused import

F401 [*] `src.codonlm.training.checkpoint._read_itos` imported but unused
  --> src/codonlm/train_codon_lm.py:20:45
   |
18 |     _normalize_offset_weights,
19 | )
20 | from src.codonlm.training.checkpoint import _read_itos, _load_transfer_state_dict
   |                                             ^^^^^^^^^^
21 | from src.codonlm.training.objectives import (
22 |     multi_offset_lm_loss,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.checkpoint._load_transfer_state_dict` imported but unused
  --> src/codonlm/train_codon_lm.py:20:57
   |
18 |     _normalize_offset_weights,
19 | )
20 | from src.codonlm.training.checkpoint import _read_itos, _load_transfer_state_dict
   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
21 | from src.codonlm.training.objectives import (
22 |     multi_offset_lm_loss,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.objectives.multi_offset_lm_loss` imported but unused
  --> src/codonlm/train_codon_lm.py:22:5
   |
20 | from src.codonlm.training.checkpoint import _read_itos, _load_transfer_state_dict
21 | from src.codonlm.training.objectives import (
22 |     multi_offset_lm_loss,
   |     ^^^^^^^^^^^^^^^^^^^^
23 |     offset_target_mask,
24 |     termination_aux_loss,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.objectives.offset_target_mask` imported but unused
  --> src/codonlm/train_codon_lm.py:23:5
   |
21 | from src.codonlm.training.objectives import (
22 |     multi_offset_lm_loss,
23 |     offset_target_mask,
   |     ^^^^^^^^^^^^^^^^^^
24 |     termination_aux_loss,
25 |     termination_distance_bucket_labels,
   |
help: Remove unused import

F401 [*] `src.codonlm.training.objectives.termination_aux_loss` imported but unused
  --> src/codonlm/train_codon_lm.py:24:5
   |
22 |     multi_offset_lm_loss,
23 |     offset_target_mask,
24 |     termination_aux_loss,
   |     ^^^^^^^^^^^^^^^^^^^^
25 |     termination_distance_bucket_labels,
26 | )
   |
help: Remove unused import

F401 [*] `src.codonlm.training.objectives.termination_distance_bucket_labels` imported but unused
  --> src/codonlm/train_codon_lm.py:25:5
   |
23 |     offset_target_mask,
24 |     termination_aux_loss,
25 |     termination_distance_bucket_labels,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
26 | )
27 | from src.codonlm.training.loop import dev, run_training
   |
help: Remove unused import

F401 [*] `src.codonlm.training.loop.dev` imported but unused
  --> src/codonlm/train_codon_lm.py:27:39
   |
25 |     termination_distance_bucket_labels,
26 | )
27 | from src.codonlm.training.loop import dev, run_training
   |                                       ^^^
28 | from src.codonlm.data_loading import PackedDataset, dataset_length_audit
   |
help: Remove unused import: `src.codonlm.training.loop.dev`

F401 [*] `src.codonlm.data_loading.PackedDataset` imported but unused
  --> src/codonlm/train_codon_lm.py:28:38
   |
26 | )
27 | from src.codonlm.training.loop import dev, run_training
28 | from src.codonlm.data_loading import PackedDataset, dataset_length_audit
   |                                      ^^^^^^^^^^^^^
29 |
30 | # Re-export variables for backwards-compatibility
   |
help: Remove unused import

F401 [*] `src.codonlm.data_loading.dataset_length_audit` imported but unused
  --> src/codonlm/train_codon_lm.py:28:53
   |
26 | )
27 | from src.codonlm.training.loop import dev, run_training
28 | from src.codonlm.data_loading import PackedDataset, dataset_length_audit
   |                                                     ^^^^^^^^^^^^^^^^^^^^
29 |
30 | # Re-export variables for backwards-compatibility
   |
help: Remove unused import

F541 [*] f-string without any placeholders
  --> src/codonlm/train_codon_lm.py:39:52
   |
37 |     ap = argparse.ArgumentParser()
38 |     ap.add_argument("--config", required=True)
39 |     ap.add_argument("--run_id", default=None, help=f"Unique run id; falls back to $RUN_ID or config.run_id")
   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
40 |     ap.add_argument("--resume", default=None, help="Path to checkpoint to resume training from")
41 |     ap.add_argument("--transfer_from", default=None, help="Path to pre-trained weights to initialize model from (ignores optimizer/ste…
   |
help: Remove extraneous `f` prefix

F401 [*] `time` imported but unused
  --> src/codonlm/train_noprop.py:9:8
   |
 7 | import argparse
 8 | import yaml
 9 | import time
   |        ^^^^
10 | import json
11 | import torch
   |
help: Remove unused import: `time`

F401 [*] `json` imported but unused
  --> src/codonlm/train_noprop.py:10:8
   |
 8 | import yaml
 9 | import time
10 | import json
   |        ^^^^
11 | import torch
12 | import torch.nn as nn
   |
help: Remove unused import: `json`

F401 [*] `torch.nn` imported but unused
  --> src/codonlm/train_noprop.py:12:20
   |
10 | import json
11 | import torch
12 | import torch.nn as nn
   |                    ^^
13 | import torch.nn.functional as F
14 | import numpy as np
   |
help: Remove unused import: `torch.nn`

F401 [*] `numpy` imported but unused
  --> src/codonlm/train_noprop.py:14:17
   |
12 | import torch.nn as nn
13 | import torch.nn.functional as F
14 | import numpy as np
   |                 ^^
15 | from pathlib import Path
16 | from torch.utils.data import DataLoader
   |
help: Remove unused import: `numpy`

F401 [*] `pathlib.Path` imported but unused
  --> src/codonlm/train_noprop.py:15:21
   |
13 | import torch.nn.functional as F
14 | import numpy as np
15 | from pathlib import Path
   |                     ^^^^
16 | from torch.utils.data import DataLoader
   |
help: Remove unused import: `pathlib.Path`

E741 Ambiguous variable name: `l`
   --> src/codonlm/train_noprop.py:138:17
    |
137 |             # Step-by-step block-wise training
138 |             for l, block in enumerate(model.blocks):
    |                 ^
139 |                 # Detach context input from graph to stop gradient propagation
140 |                 h_in = h_prev.detach() if l > 0 else h_prev
    |

E741 Ambiguous variable name: `l`
   --> src/codonlm/train_noprop.py:193:21
    |
192 |                 h_prev = h
193 |                 for l, block in enumerate(model.blocks):
    |                     ^
194 |                     h_out, pred_y = block(h_prev, noisy_targets=y_clean, attn_mask=attn_mask)
195 |                     loss_mse_elementwise = F.mse_loss(pred_y, y_clean, reduction="none")
    |

F841 Local variable `length` is assigned to but never used
  --> src/eval/remote_bio.py:65:5
   |
63 |     """Generates a mock BLAST result locally for fast offline testing."""
64 |     # Compute deterministic mock hits based on the sequence string length
65 |     length = len(seq)
   |     ^^^^^^
66 |     mock_hits = [
67 |         {
   |
help: Remove assignment to unused variable `length`

F841 [*] Local variable `e` is assigned to but never used
   --> src/eval/remote_bio.py:163:25
    |
161 |                 save_to_cache(seq, result)
162 |                 return result
163 |     except Exception as e:
    |                         ^
164 |         # Fall back to mock on network error
165 |         pass
    |
help: Remove assignment to unused variable `e`

F401 [*] `torch.nn.functional` imported but unused
 --> src/protein_lm/sampler.py:3:31
  |
1 | import torch
2 | import torch.nn as nn
3 | import torch.nn.functional as F
  |                               ^
4 |
5 | from src.protein_lm.tokenizer import ProteinTokenizer
  |
help: Remove unused import: `torch.nn.functional`

F401 [*] `torch.nn` imported but unused
  --> src/protein_lm/train_ebm.py:12:20
   |
10 | import yaml
11 | import torch
12 | import torch.nn as nn
   |                    ^^
13 | import torch.nn.functional as F
14 | from torch.utils.data import DataLoader
   |
help: Remove unused import: `torch.nn`

F541 [*] f-string without any placeholders
  --> src/protein_lm/train_ebm.py:64:11
   |
62 |     # Initialize tokenizer and datasets
63 |     tokenizer = ProteinTokenizer()
64 |     print(f"[ebm-train] loading dataset paths from config")
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
65 |     train_dataset = MultiTaskProteinDataset(cfg["train_data"], tokenizer, max_length=cfg.get("block_size", 512))
66 |     val_dataset = MultiTaskProteinDataset(cfg["val_data"], tokenizer, max_length=cfg.get("block_size", 512))
   |
help: Remove extraneous `f` prefix

E731 Do not assign a `lambda` expression, use a `def`
  --> src/protein_lm/train_ebm.py:72:5
   |
70 |     val_sampler = LengthBucketBatchSampler(val_dataset, batch_size=batch_size, shuffle=False)
71 |
72 |     collate_fn = lambda b: collate_protein_batch(b, pad_token_id=tokenizer.pad_token_id)
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
73 |     train_loader = DataLoader(train_dataset, batch_sampler=train_sampler, collate_fn=collate_fn)
74 |     val_loader = DataLoader(val_dataset, batch_sampler=val_sampler, collate_fn=collate_fn)
   |
help: Rewrite `collate_fn` as a `def`

F401 [*] `pathlib.Path` imported but unused
 --> tests/test_audit_duplicates.py:4:21
  |
2 | import json
3 | import subprocess
4 | from pathlib import Path
  |                     ^^^^
5 |
6 | def test_audit_duplicates_logic(tmp_path):
  |
help: Remove unused import: `pathlib.Path`

F401 [*] `pytest` imported but unused
 --> tests/test_biophysics_fusion.py:2:8
  |
1 | import torch
2 | import pytest
  |        ^^^^^^
3 | from src.codonlm.biophysics import NucleotideEncoder, generate_shape_training_data
4 | from src.codonlm.model_tiny_gpt import TinyGPT
  |
help: Remove unused import: `pytest`

F401 [*] `os` imported but unused
 --> tests/test_cleanup_runs.py:1:8
  |
1 | import os
  |        ^^
2 | import time
3 | from pathlib import Path
  |
help: Remove unused import: `os`

F401 [*] `time` imported but unused
 --> tests/test_cleanup_runs.py:2:8
  |
1 | import os
2 | import time
  |        ^^^^
3 | from pathlib import Path
4 | from unittest.mock import patch, MagicMock
  |
help: Remove unused import: `time`

F401 [*] `pytest` imported but unused
 --> tests/test_cleanup_runs.py:5:8
  |
3 | from pathlib import Path
4 | from unittest.mock import patch, MagicMock
5 | import pytest
  |        ^^^^^^
6 |
7 | from scripts.cleanup_runs import main, PROTECTED_FILENAMES
  |
help: Remove unused import: `pytest`

F401 [*] `scripts.cleanup_runs.PROTECTED_FILENAMES` imported but unused
 --> tests/test_cleanup_runs.py:7:40
  |
5 | import pytest
6 |
7 | from scripts.cleanup_runs import main, PROTECTED_FILENAMES
  |                                        ^^^^^^^^^^^^^^^^^^^
  |
help: Remove unused import: `scripts.cleanup_runs.PROTECTED_FILENAMES`

F401 [*] `os` imported but unused
 --> tests/test_data_consolidation.py:1:8
  |
1 | import os
  |        ^^
2 | import json
3 | import pytest
  |
help: Remove unused import: `os`

F401 [*] `pytest` imported but unused
 --> tests/test_data_consolidation.py:3:8
  |
1 | import os
2 | import json
3 | import pytest
  |        ^^^^^^
4 | import numpy as np
5 | import shutil
  |
help: Remove unused import: `pytest`

F401 [*] `shutil` imported but unused
 --> tests/test_data_consolidation.py:5:8
  |
3 | import pytest
4 | import numpy as np
5 | import shutil
  |        ^^^^^^
6 | from pathlib import Path
7 | from src.eval.aggregator import ResultsAggregator
  |
help: Remove unused import: `shutil`

F401 [*] `pathlib.Path` imported but unused
 --> tests/test_data_consolidation.py:6:21
  |
4 | import numpy as np
5 | import shutil
6 | from pathlib import Path
  |                     ^^^^
7 | from src.eval.aggregator import ResultsAggregator
  |
help: Remove unused import: `pathlib.Path`

F401 [*] `math` imported but unused
  --> tests/test_generative_design.py:8:8
   |
 6 | """
 7 |
 8 | import math
   |        ^^^^
 9 | import unittest
10 | from unittest.mock import MagicMock, patch
   |
help: Remove unused import: `math`

F401 [*] `unittest.mock.patch` imported but unused
  --> tests/test_generative_design.py:10:38
   |
 8 | import math
 9 | import unittest
10 | from unittest.mock import MagicMock, patch
   |                                      ^^^^^
11 |
12 | import torch
   |
help: Remove unused import: `unittest.mock.patch`

F401 [*] `pytest` imported but unused
 --> tests/test_hybrid_critic.py:2:8
  |
1 | import torch
2 | import pytest
  |        ^^^^^^
3 | from src.codonlm.model_tiny_gpt import TinyGPT
4 | from src.protein_lm.tokenizer import ProteinTokenizer
  |
help: Remove unused import: `pytest`

F401 [*] `pytest` imported but unused
 --> tests/test_hybrid_pipeline.py:7:8
  |
5 | from pathlib import Path
6 | import numpy as np
7 | import pytest
  |        ^^^^^^
8 | import yaml
9 | from Bio import SeqIO
  |
help: Remove unused import: `pytest`

F401 [*] `os` imported but unused
 --> tests/test_model_expansion.py:1:8
  |
1 | import os
  |        ^^
2 | import yaml
3 | import torch
  |
help: Remove unused import: `os`

F401 [*] `numpy` imported but unused
 --> tests/test_model_expansion.py:4:17
  |
2 | import yaml
3 | import torch
4 | import numpy as np
  |                 ^^
5 | from pathlib import Path
  |
help: Remove unused import: `numpy`

F401 [*] `pathlib.Path` imported but unused
 --> tests/test_model_expansion.py:5:21
  |
3 | import torch
4 | import numpy as np
5 | from pathlib import Path
  |                     ^^^^
6 |
7 | from src.codonlm.model_tiny_gpt import TinyGPT
  |
help: Remove unused import: `pathlib.Path`

F401 [*] `os` imported but unused
 --> tests/test_multi_task_wall_time.py:1:8
  |
1 | import os
  |        ^^
2 | import sys
3 | import yaml
  |
help: Remove unused import: `os`

F401 [*] `pytest` imported but unused
 --> tests/test_multi_task_wall_time.py:4:8
  |
2 | import sys
3 | import yaml
4 | import pytest
  |        ^^^^^^
5 | import subprocess
6 | import json
  |
help: Remove unused import: `pytest`

F401 [*] `pytest` imported but unused
 --> tests/test_noprop.py:3:8
  |
1 | import torch
2 | import torch.nn.functional as F
3 | import pytest
  |        ^^^^^^
4 | from src.codonlm.model_tiny_gpt import NoPropTinyGPT, NoPropBlock
  |
help: Remove unused import: `pytest`

F401 [*] `numpy` imported but unused
 --> tests/test_protein_ebm.py:2:17
  |
1 | import torch
2 | import numpy as np
  |                 ^^
3 | from pathlib import Path
  |
help: Remove unused import: `numpy`

F401 [*] `pathlib.Path` imported but unused
 --> tests/test_protein_ebm.py:3:21
  |
1 | import torch
2 | import numpy as np
3 | from pathlib import Path
  |                     ^^^^
4 |
5 | from src.protein_lm.tokenizer import ProteinTokenizer
  |
help: Remove unused import: `pathlib.Path`

F401 [*] `os` imported but unused
 --> tests/test_remote_bio.py:1:8
  |
1 | import os
  |        ^^
2 | import shutil
3 | import pytest
  |
help: Remove unused import: `os`

F401 [*] `shutil` imported but unused
 --> tests/test_remote_bio.py:2:8
  |
1 | import os
2 | import shutil
  |        ^^^^^^
3 | import pytest
4 | from src.eval import remote_bio
  |
help: Remove unused import: `shutil`

F401 [*] `pytest` imported but unused
 --> tests/test_remote_bio.py:3:8
  |
1 | import os
2 | import shutil
3 | import pytest
  |        ^^^^^^
4 | from src.eval import remote_bio
  |
help: Remove unused import: `pytest`

F401 [*] `scripts.prepare_sota_benchmarks.main` imported but unused
 --> tests/test_sota_benchmarking.py:4:53
  |
2 | from pathlib import Path
3 | import pytest
4 | from scripts.prepare_sota_benchmarks import main as prepare_benchmarks
  |                                                     ^^^^^^^^^^^^^^^^^^
5 | from scripts.benchmark_zero_shot_mutations import main as run_zero_shot
6 | from scripts.benchmark_gene_essentiality import main as run_essentiality
  |
help: Remove unused import: `scripts.prepare_sota_benchmarks.main`

F401 [*] `pytest` imported but unused
 --> tests/test_synonymous_generation.py:2:8
  |
1 | import torch
2 | import pytest
  |        ^^^^^^
3 | from src.codonlm.generate import generate_cds_synonymous, AA_TO_CODONS, CODON_TABLE
  |
help: Remove unused import: `pytest`

F401 [*] `os` imported but unused
 --> tests/test_wall_time.py:1:8
  |
1 | import os
  |        ^^
2 | import sys
3 | import yaml
  |
help: Remove unused import: `os`

F401 [*] `pytest` imported but unused
 --> tests/test_wall_time.py:5:8
  |
3 | import yaml
4 | import numpy as np
5 | import pytest
  |        ^^^^^^
6 | import subprocess
7 | import json
  |
help: Remove unused import: `pytest`

Found 142 errors.
[*] 128 fixable with the `--fix` option (5 hidden fixes can be enabled with the `--unsafe-fixes` option). still reports pre-existing unrelated lint debt across legacy scripts/tests; scoped Ruff for this PR passes.