### PR TITLE
Freeze corrected evaluator contracts

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-In progress. The corrected datasets have passed the local freeze and the generation
-protocol separation is implemented. The program remains blocked on evaluator
-fixtures, immutable training configs, and the MPS policy gate.
+In progress. The corrected datasets, evaluator contracts, and generation protocol
+separation are complete. The program remains blocked on the formal pipeline freeze,
+immutable training configs, and the MPS policy gate.
 
 ## Phase 0: Close Pre-Training Gates
 
@@ -17,7 +17,7 @@ fixtures, immutable training configs, and the MPS policy gate.
   genome-held-out and genus-held-out datasets.
 - [x] Record source, split, fragment, chunk, packed-array, vocabulary, and audit
   hashes plus count summaries.
-- [ ] Complete frozen-manifest evaluator fixtures and provenance validation.
+- [x] Complete frozen-manifest evaluator fixtures and provenance validation.
 - [x] Resolve generation protocol issue #85 before generation comparisons.
 - [x] Implement and merge batch-aware memmap conversion with fixed/dynamic parity
   tests (#90).

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -1,9 +1,9 @@
 # Leakage-Controlled CodonLM Revalidation Plan
 
 ## Status
-In progress. Engineering gates and the local corrected dataset freeze are complete;
-full retraining remains blocked on evaluator-fixture validation and the immutable
-training configuration gate.
+In progress. Engineering gates, the local corrected dataset freeze, and evaluator
+contracts are complete; full retraining remains blocked on the formal pipeline
+freeze, runtime-policy selection, and immutable training configuration gate.
 
 ## Phase 1: Governance and CI
 - [x] Relabel legacy results and unsupported claims (#87).
@@ -64,7 +64,7 @@ audits pass. Any later semantic change creates a new dataset version.
   7-mer controls (#88).
 - [x] Add protein-cluster-held-out AMR splits, class reporting, stratified bootstrap,
   and output isolation (#89).
-- [ ] Validate every evaluator on fixtures derived from the frozen manifest schema.
+- [x] Validate every evaluator on fixtures derived from the frozen manifest schema.
 
 Exit gate: all evaluators consume explicit frozen artifacts, reject incompatible
 inputs, preserve grouping, and emit machine-readable provenance.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -20,6 +20,20 @@ This document captures the end-to-end journey of Genomics-LM. It details how we 
   protocol-level metadata, and bootstrap confidence intervals while retaining the
   existing CSV outputs for compatibility.
 
+## 2026-07-21: Frozen Evaluator Contracts
+
+* Added a shared fail-closed evaluation provenance contract binding corrected
+  checkpoints to a scientific dataset manifest, vocabulary, and declared artifacts.
+* Applied the contract to CodonLM test perplexity, simple PPL baselines, causal
+  embedding extraction, grouped DNA-shape controls, classifier probes, and generated
+  novelty audits. Corrected probe inputs must share checkpoint, dataset, and
+  vocabulary provenance.
+* Generated-sequence audits now derive train-only records from the manifest-aligned
+  source metadata and DNA artifacts instead of relying on a manually selected FASTA.
+* Synonymous and shuffled controls now use the frozen vocabulary, preserve packed
+  next-token alignment and CDS boundaries, and emit hash-bound derivation sidecars
+  that corrected test evaluation verifies before scoring.
+
 ---
 
 ## 1. Stage 1: Toy Scale (The Grammar School)

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -303,19 +303,31 @@ python -m scripts.sanity_kpis --run_dir runs/<RUN_ID>/checkpoints
 # exact and MMseqs2 protein-cluster leakage before packing and writes leakage_audit.json.
 python -m scripts.audit_duplicates --train_npz data/processed/train_bs256.npz --test_npz data/processed/test_bs256.npz
 
-# Generated-sequence nucleotide/protein nearest neighbors and training-match coverage
-python -m scripts.audit_generated_sequences --train-fasta data/frozen/train_cds.fasta --generated-fasta runs/<RUN_ID>/generated.fasta --output runs/<RUN_ID>/scores/generated_leakage_audit.json
+# Generated-sequence nucleotide/protein nearest neighbors and training-match coverage.
+# The corrected route derives train-only source records from the frozen manifest.
+python -m scripts.audit_generated_sequences --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json --generated-fasta runs/<RUN_ID>/generated.fasta --output runs/<RUN_ID>/scores/generated_leakage_audit.json
 
 # Calculate baseline perplexities (Uniform, Unigram, Bigram, Trigram Markov baselines)
 python -m scripts.eval_ppl_baselines --test data/processed/test_bs256.npz --train data/processed/train_bs256.npz
 
-# Generate synonymous recoding and shuffled sequence controls for perplexity evaluation
-python -m scripts.generate_synonymous_controls --test_npz data/processed/test_bs256.npz --out_dir data/processed/controls
+# Generate manifest-bound controls without breaking packed X/Y target alignment.
+python -m scripts.generate_synonymous_controls \
+  --test_npz data/processed/corrected/<FREEZE_ID>/genome/test_bs256.npz \
+  --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json \
+  --out_dir runs/<RUN_ID>/controls
+
+# Evaluate a derived control; repeat with each generated control and sidecar.
+python -m scripts.evaluate_test \
+  --run_dir runs/<RUN_ID> \
+  --test_npz runs/<RUN_ID>/controls/test_control_synonymous_bs256.npz \
+  --derived_provenance runs/<RUN_ID>/controls/test_control_synonymous_bs256.npz.provenance.json \
+  --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json
 
 # Compare DNA-shape regression prediction performance against one-hot and random model baselines
 python -m scripts.eval_shape_baselines \
   --run_dir runs/<RUN_ID> --ckpt best.pt \
   --test_npz data/processed/global/<DATASET_ID>/test_bs256.npz \
+  --manifest data/processed/global/<DATASET_ID>/manifest.json \
   --packing-metadata data/processed/global/<DATASET_ID>/test_packing.tsv \
   --cds-metadata data/processed/global/<DATASET_ID>/cds_meta.tsv \
   --group-by genome --output-prefix runs/<RUN_ID>/scores/shape_genome_grouped

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -93,6 +93,17 @@ For every test evaluation, calculate and compare model performance against Unifo
    genus-held-out dataset and a distinct output prefix.
 2. Report the **excess bits per codon** ($\Delta H$) and the perplexity drop over the 2nd-order Markov (Trigram) baseline.
 
+Evaluate the corrected model on the same manifest-bound test artifact:
+
+```bash
+python -m scripts.evaluate_test \
+  --run_dir runs/<RUN_ID> \
+  --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json
+```
+
+Corrected checkpoints fail if the explicit manifest is missing or if its dataset or
+vocabulary identity differs from the checkpoint.
+
 ---
 
 ## 3. Synonymous and Shuffling Controls
@@ -103,13 +114,25 @@ For every test evaluation, calculate and compare model performance against Unifo
 ### Mandatory Workflow
 1. Generate control datasets from your test split:
    ```bash
-   python -m scripts.generate_synonymous_controls --test_npz data/processed/global/<RUN_ID>/test_bs256.npz
+   python -m scripts.generate_synonymous_controls \
+     --test_npz data/processed/corrected/<FREEZE_ID>/genome/test_bs256.npz \
+     --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json \
+     --out_dir runs/<RUN_ID>/controls
    ```
    This outputs:
    - `test_control_synonymous_bs256.npz` (random synonymous codons, same protein).
-   - `test_control_codon_shuffle_bs256.npz` (shuffled codons, same composition).
-   - `test_control_protein_shuffle_bs256.npz` (shuffled protein, same codon counts).
-2. Run [`evaluate_test.py`](file:///Users/User/github/genomics-lm/scripts/evaluate_test.py) on each of these control NPZs.
+   - `test_control_codon_shuffle_bs256.npz` (codons shuffled within each CDS, same codon composition).
+   - `test_control_protein_shuffle_bs256.npz` (amino acids shuffled within each CDS, same amino-acid composition).
+2. Run `evaluate_test.py` on each control with its generated provenance sidecar:
+   ```bash
+   python -m scripts.evaluate_test \
+     --run_dir runs/<RUN_ID> \
+     --test_npz runs/<RUN_ID>/controls/test_control_synonymous_bs256.npz \
+     --derived_provenance runs/<RUN_ID>/controls/test_control_synonymous_bs256.npz.provenance.json \
+     --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json
+   ```
+   Corrected evaluation fails if the control, source test artifact, vocabulary, or
+   dataset identity differs from the recorded derivation.
 3. Assert that the model's perplexity is significantly better (lower) on the natural test set compared to the synonymous recoding set.
 
 ---
@@ -126,6 +149,7 @@ Regenerate embeddings from the corrected checkpoint before running any probe:
 python -m scripts.extract_embeddings \
   --run_dir runs/<RUN_ID> \
   --fasta data/frozen/test_cds.fasta \
+  --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json \
   --out runs/<RUN_ID>/embeddings/test_causal.npz
 ```
 
@@ -135,6 +159,10 @@ shape encoder. The adjacent `.npz.metadata.json` sidecar records checkpoint,
 vocabulary, input, masking, pooling, truncation, and code provenance. Embedding
 files without this sidecar are legacy/unverified and must not be used for
 corrected headline results.
+
+Corrected probe configs must set `require_verified_embeddings: true`. The classifier
+then rejects train/test embeddings produced by different checkpoints, dataset
+manifests, or vocabularies and writes `provenance.json` beside `metrics.json`.
 
 When training linear probes (e.g. for DNA-shape or EC level classification), compare your pretrained embeddings against:
 1. **One-Hot Codon Identity vectors** (proves learning beyond local codon lookup).

--- a/scripts/audit_generated_sequences.py
+++ b/scripts/audit_generated_sequences.py
@@ -4,11 +4,19 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import json
+from itertools import zip_longest
 from pathlib import Path
 
 from Bio import SeqIO
 
 from src.codonlm.leakage_audit import audit_generated_sequences
+from src.codonlm.dataset_manifest import manifest_artifact_path
+from src.codonlm.evaluation_provenance import (
+    artifact_provenance,
+    bind_dataset_manifest,
+)
 
 
 def _read_fasta(path: Path) -> list[dict[str, str]]:
@@ -18,9 +26,48 @@ def _read_fasta(path: Path) -> list[dict[str, str]]:
     ]
 
 
+def _read_manifest_training(manifest_path: Path) -> tuple[list[dict[str, str]], dict]:
+    manifest, provenance = bind_dataset_manifest(manifest_path)
+    resolved_manifest = manifest_path.expanduser().resolve()
+    metadata_path = manifest_artifact_path(
+        manifest, resolved_manifest, "source_metadata"
+    )
+    dna_path = manifest_artifact_path(manifest, resolved_manifest, "source_dna")
+    records = []
+    with metadata_path.open(newline="") as metadata_handle, dna_path.open() as dna_handle:
+        metadata_rows = csv.DictReader(metadata_handle, delimiter="\t")
+        for index, pair in enumerate(zip_longest(metadata_rows, dna_handle)):
+            row, sequence = pair
+            if row is None or sequence is None:
+                raise ValueError("source metadata and DNA artifacts have different row counts")
+            if int(row["line_idx"]) != index:
+                raise ValueError(
+                    f"source metadata line_idx mismatch at row {index}: {row['line_idx']}"
+                )
+            if row["split"] == "train":
+                records.append(
+                    {"source_id": row["source_id"], "sequence": sequence.strip()}
+                )
+    if not records:
+        raise ValueError("frozen manifest contains no training source records")
+    provenance["training_source"] = {
+        "selection": "source_metadata.split == train",
+        "record_count": len(records),
+        "source_metadata": artifact_provenance(metadata_path),
+        "source_dna": artifact_provenance(dna_path),
+    }
+    return records, provenance
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--train-fasta", type=Path, required=True)
+    training = parser.add_mutually_exclusive_group(required=True)
+    training.add_argument("--train-fasta", type=Path)
+    training.add_argument(
+        "--manifest",
+        type=Path,
+        help="Frozen manifest from which train-only source records are derived.",
+    )
     parser.add_argument("--generated-fasta", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--nucleotide-window", type=int, default=30)
@@ -29,8 +76,13 @@ def main() -> None:
     parser.add_argument("--mmseqs-executable", default="mmseqs")
     args = parser.parse_args()
 
+    if args.manifest is not None:
+        training_records, manifest_provenance = _read_manifest_training(args.manifest)
+    else:
+        training_records = _read_fasta(args.train_fasta)
+        manifest_provenance = {"status": "legacy_unverified"}
     report = audit_generated_sequences(
-        _read_fasta(args.train_fasta),
+        training_records,
         _read_fasta(args.generated_fasta),
         args.output,
         nucleotide_window=args.nucleotide_window,
@@ -38,6 +90,8 @@ def main() -> None:
         threads=args.threads,
         executable=args.mmseqs_executable,
     )
+    report["dataset_manifest"] = manifest_provenance
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     print(
         f"[generated-audit] wrote {report['generated_record_count']} records to {args.output}"
     )

--- a/scripts/eval_ppl_baselines.py
+++ b/scripts/eval_ppl_baselines.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import numpy as np
 
 from src.codonlm.data_loading import MmapPackedDataset
-from src.codonlm.dataset_manifest import load_dataset_manifest, manifest_artifact_path
+from src.codonlm.evaluation_provenance import bind_dataset_manifest
 from src.codonlm.training.vocabulary import resolve_vocabulary_contract
 
 PAD_ID = 0
@@ -143,21 +143,11 @@ def main() -> None:
     train, test = Path(args.train), Path(args.test)
     manifest_provenance = {"status": "legacy_unverified"}
     if args.manifest is not None:
-        manifest = load_dataset_manifest(args.manifest)
-        for split, selected in (("train", train), ("test", test)):
-            declared = manifest_artifact_path(
-                manifest, args.manifest.resolve(), f"{split}_tokens"
-            ).resolve()
-            if selected.resolve() != declared:
-                raise ValueError(
-                    f"{split} dataset {selected.resolve()} does not match manifest artifact {declared}"
-                )
-        manifest_provenance = {
-            "path": str(args.manifest.resolve()),
-            "dataset_id": manifest["dataset"]["id"],
-            "scientific_valid": manifest["dataset"]["scientific_valid"],
-            "schema": manifest["schema"],
-        }
+        _, manifest_provenance = bind_dataset_manifest(
+            args.manifest,
+            expected_artifacts={"train_tokens": train, "test_tokens": test},
+            require_scientific=False,
+        )
     contract = resolve_vocabulary_contract(
         [train, test], configured_path=args.itos, configured_size=None
     )

--- a/scripts/eval_shape_baselines.py
+++ b/scripts/eval_shape_baselines.py
@@ -19,7 +19,11 @@ from sklearn.metrics import r2_score
 
 from scripts._shared import build_model, load_model, load_token_list, resolve_run
 from scripts.probe_structural_awareness import get_theoretical_shape
-from src.codonlm.dataset_manifest import load_dataset_manifest, manifest_artifact_path
+from src.codonlm.checkpoints import load_codon_checkpoint
+from src.codonlm.evaluation_provenance import (
+    bind_checkpoint_dataset,
+    bind_dataset_manifest,
+)
 
 PROPERTIES = (
     "MGW", "Roll", "EP", "ProT", "HelT", "Slide", "Rise", "Shift", "Tilt",
@@ -215,27 +219,20 @@ def main():
     run_id, run_dir = resolve_run(args.run_id, args.run_dir)
     manifest_provenance = {"status": "legacy_unverified"}
     if args.manifest is not None:
-        manifest = load_dataset_manifest(args.manifest)
         expected = {
             "test_tokens": Path(args.test_npz),
             "test_packing_metadata": args.packing_metadata,
         }
         if args.cds_metadata is not None:
             expected["source_metadata"] = args.cds_metadata
-        for artifact_name, selected in expected.items():
-            declared = manifest_artifact_path(
-                manifest, args.manifest.resolve(), artifact_name
-            ).resolve()
-            if selected.resolve() != declared:
-                raise ValueError(
-                    f"{artifact_name} {selected.resolve()} does not match manifest {declared}"
-                )
-        manifest_provenance = {
-            "path": str(args.manifest.resolve()),
-            "dataset_id": manifest["dataset"]["id"],
-            "scientific_valid": manifest["dataset"]["scientific_valid"],
-            "schema": manifest["schema"],
-        }
+        _, manifest_provenance = bind_dataset_manifest(
+            args.manifest, expected_artifacts=expected, require_scientific=False
+        )
+    _, checkpoint_cfg, _ = load_codon_checkpoint(run_dir, ckpt_name=args.ckpt)
+    checkpoint_dataset = bind_checkpoint_dataset(
+        checkpoint_cfg,
+        manifest_provenance if args.manifest is not None else None,
+    )
     tokens = load_token_list(run_dir)
     pretrained, spec = load_model(run_dir, ckpt_name=args.ckpt)
     random_model = build_model(spec).eval()
@@ -254,6 +251,7 @@ def main():
     report = {
         "schema_version": 1, "run_id": run_id, "seed": args.seed,
         "dataset_manifest": manifest_provenance,
+        "checkpoint_dataset": checkpoint_dataset,
         "group_by": args.group_by, "n_splits": args.n_splits,
         "dataset": {"path": str(test_path.resolve()), "sha256": _sha256(test_path)},
         "checkpoint": {"path": str(checkpoint_path.resolve()), "sha256": _sha256(checkpoint_path)},

--- a/scripts/evaluate_test.py
+++ b/scripts/evaluate_test.py
@@ -21,6 +21,13 @@ from torch.utils.data import DataLoader
 
 from src.codonlm.checkpoints import build_codon_model_from_cfg, load_codon_checkpoint
 from src.codonlm.data_loading import PackedDataset, dynamic_lm_collate_fn
+from src.codonlm.evaluation_provenance import (
+    artifact_provenance,
+    bind_checkpoint_dataset,
+    bind_dataset_manifest,
+    bind_derived_dataset,
+)
+from src.codonlm.dataset_manifest import manifest_artifact_path
 from scripts._shared import resolve_run
 from src.codonlm.metrics_io import write_merge_metrics
 
@@ -67,7 +74,7 @@ def _find_test_npz(
 @torch.no_grad()
 def evaluate(
     model: torch.nn.Module, device: torch.device, loader: DataLoader
-) -> tuple[float, float]:
+) -> tuple[float, float, int]:
     total_loss = 0.0
     total_tokens = 0
     for xb, yb in loader:
@@ -82,7 +89,7 @@ def evaluate(
         total_tokens += max(1, valid)
     mean_nll = total_loss / max(1, total_tokens)
     ppl = float(math.exp(min(20.0, mean_nll)))
-    return mean_nll, ppl
+    return mean_nll, ppl, total_tokens
 
 
 def main() -> None:
@@ -92,6 +99,17 @@ def main() -> None:
     ap.add_argument(
         "--data_dir", help="override test NPZ directory (contains test_bs*.npz)"
     )
+    ap.add_argument("--test_npz", type=Path, help="explicit test or control dataset")
+    ap.add_argument(
+        "--manifest",
+        type=Path,
+        help="Frozen dataset manifest; required for corrected checkpoints.",
+    )
+    ap.add_argument(
+        "--derived_provenance",
+        type=Path,
+        help="Provenance sidecar when --test_npz is derived from the frozen test set.",
+    )
     ap.add_argument("--batch_size", type=int, default=None, help="evaluation batch size")
     args = ap.parse_args()
 
@@ -99,13 +117,35 @@ def main() -> None:
     run_id, run_dir = resolve_run(args.run_id, args.run_dir)
     repo_root = Path(__file__).resolve().parents[1]
 
-    state_dict, cfg, _ = load_codon_checkpoint(run_dir)
+    state_dict, cfg, checkpoint_path = load_codon_checkpoint(run_dir)
     model = build_codon_model_from_cfg(cfg)
     model.load_state_dict(state_dict, strict=False)
     model.to(dev()).eval()
 
     data_dir_opt = Path(args.data_dir) if args.data_dir else None
-    test_npz = _find_test_npz(run_id, cfg, repo_root, data_dir_opt)
+    test_npz = args.test_npz or _find_test_npz(run_id, cfg, repo_root, data_dir_opt)
+    test_npz = test_npz.expanduser().resolve()
+    manifest_provenance = None
+    derived_provenance = None
+    if args.manifest is not None:
+        if args.derived_provenance is None:
+            _, manifest_provenance = bind_dataset_manifest(
+                args.manifest, expected_artifacts={"test_tokens": test_npz}
+            )
+        else:
+            manifest, manifest_provenance = bind_dataset_manifest(args.manifest)
+            source_test = manifest_artifact_path(
+                manifest, args.manifest.expanduser().resolve(), "test_tokens"
+            )
+            derived_provenance = bind_derived_dataset(
+                test_npz,
+                args.derived_provenance,
+                manifest_provenance=manifest_provenance,
+                source_artifact_path=source_test,
+            )
+    elif args.derived_provenance is not None:
+        raise ValueError("--derived_provenance requires --manifest")
+    checkpoint_dataset = bind_checkpoint_dataset(cfg, manifest_provenance)
     ds = PackedDataset(test_npz)
 
     collate_fn = dynamic_lm_collate_fn if getattr(ds, "is_dynamic", False) else None
@@ -114,18 +154,25 @@ def main() -> None:
     if batch_size is None:
         batch_size = int(cfg.get("eval_batch_size", 16 if dev().type == "mps" else 64))
     loader = DataLoader(ds, batch_size=batch_size, collate_fn=collate_fn)
-    nll, ppl = evaluate(model, dev(), loader)
+    nll, ppl, evaluated_tokens = evaluate(model, dev(), loader)
     print(f"[test] loss={nll:.4f} ppl={ppl:.2f}")
 
     metrics_path = run_dir / "scores" / "metrics.json"
-    if not metrics_path.parent.exists():
-        metrics_path = repo_root / "outputs/scores" / run_id / "metrics.json"
 
     write_merge_metrics(
         metrics_path,
         {
             "test_loss": float(nll),
             "test_ppl": float(ppl),
+            "test_evaluated_tokens": int(evaluated_tokens),
+            "test_evaluation_provenance": {
+                "schema_version": 1,
+                "dataset_manifest": manifest_provenance or {"status": "legacy_unverified"},
+                "checkpoint_dataset": checkpoint_dataset,
+                "checkpoint": artifact_provenance(checkpoint_path),
+                "test_tokens": artifact_provenance(test_npz),
+                "derived_dataset": derived_provenance,
+            },
             "timestamp": datetime.now(timezone.utc).isoformat(),
         },
     )

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -29,6 +29,10 @@ import torch
 
 from . import query_model as Q
 from src.codonlm.checkpoints import load_codon_checkpoint
+from src.codonlm.evaluation_provenance import (
+    bind_checkpoint_dataset,
+    bind_dataset_manifest,
+)
 from src.codonlm.training.vocabulary import load_itos
 
 
@@ -151,6 +155,11 @@ def main() -> None:
     ap.add_argument("--csv")
     ap.add_argument("--seq_col", default="seq")
     ap.add_argument("--mode", choices=["dna_cds", "codon_tokens"], default="dna_cds")
+    ap.add_argument(
+        "--manifest",
+        type=Path,
+        help="Frozen pretraining manifest; required for corrected checkpoints.",
+    )
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
 
@@ -163,6 +172,10 @@ def main() -> None:
     itos = load_itos(itos_path)
     stoi = {token: index for index, token in enumerate(itos)}
     state_dict, cfg, checkpoint_path = load_codon_checkpoint(rd)
+    manifest_provenance = None
+    if args.manifest is not None:
+        _, manifest_provenance = bind_dataset_manifest(args.manifest)
+    checkpoint_dataset = bind_checkpoint_dataset(cfg, manifest_provenance)
     _validate_vocabulary(itos, state_dict, cfg, itos_path)
     model = Q.build_model_from_state(
         state_dict, cfg, setup_shape_runtime=False
@@ -235,6 +248,8 @@ def main() -> None:
         "validation_status": "causal_verified",
         "created_at": datetime.now(timezone.utc).isoformat(),
         "checkpoint": {"path": str(checkpoint_path.resolve()), "sha256": _sha256(checkpoint_path)},
+        "dataset_manifest": manifest_provenance or {"status": "legacy_unverified"},
+        "checkpoint_dataset": checkpoint_dataset,
         "vocabulary": {"path": str(itos_path.resolve()), "size": len(itos), "sha256": _sha256(itos_path)},
         "inputs": [{"path": str(path.resolve()), "sha256": _sha256(path)} for path in input_paths],
         "mask_mode": (

--- a/scripts/generate_synonymous_controls.py
+++ b/scripts/generate_synonymous_controls.py
@@ -1,185 +1,241 @@
 #!/usr/bin/env python3
-"""
-scripts/generate_synonymous_controls.py — Synonymous & Shuffling Control Suite Generator
-
-This script generates control variants of a test dataset to scientifically validate
-whether Genomics-LM encodes biological properties beyond basic composition and protein templates.
-
-It outputs:
-  1. Synonymous Mutated Control (preserves amino acid sequence, randomizes codon selection).
-  2. Codon Shuffled Control (shuffles codon order within each gene, preserving composition).
-  3. Protein Shuffled Control (shuffles amino acids, maintaining codon usage).
-
-Usage:
-  python -m scripts.generate_synonymous_controls --test_npz data/processed/global/my_run/test_bs256.npz
-"""
+"""Generate manifest-bound synonymous and sequence-shuffling controls."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import random
 from pathlib import Path
+from typing import Callable
+
 import numpy as np
 
-# Standard Genetic Code
+from src.codonlm.dataset_manifest import manifest_artifact_path
+from src.codonlm.evaluation_provenance import artifact_provenance, bind_dataset_manifest
+from src.codonlm.training.vocabulary import load_itos
+
+
 AA_TO_CODONS = {
-    'A': ['GCT', 'GCC', 'GCA', 'GCG'],
-    'R': ['CGT', 'CGC', 'CGA', 'CGG', 'AGA', 'AGG'],
-    'N': ['AAT', 'AAC'],
-    'D': ['GAT', 'GAC'],
-    'C': ['TGT', 'TGC'],
-    'Q': ['CAA', 'CAG'],
-    'E': ['GAA', 'GAG'],
-    'G': ['GGT', 'GGC', 'GGA', 'GGG'],
-    'H': ['CAT', 'CAC'],
-    'I': ['ATT', 'ATC', 'ATA'],
-    'L': ['TTA', 'TTG', 'CTT', 'CTC', 'CTA', 'CTG'],
-    'K': ['AAA', 'AAG'],
-    'M': ['ATG'],
-    'F': ['TTT', 'TTC'],
-    'P': ['CCT', 'CCC', 'CCA', 'CCG'],
-    'S': ['TCT', 'TCC', 'TCA', 'TCG', 'AGT', 'AGC'],
-    'T': ['ACT', 'ACC', 'ACA', 'ACG'],
-    'W': ['TGG'],
-    'Y': ['TAT', 'TAC'],
-    'V': ['GTT', 'GTC', 'GTA', 'GTG'],
-    '*': ['TAA', 'TAG', 'TGA']  # Stop codons
+    "A": ["GCT", "GCC", "GCA", "GCG"],
+    "R": ["CGT", "CGC", "CGA", "CGG", "AGA", "AGG"],
+    "N": ["AAT", "AAC"], "D": ["GAT", "GAC"], "C": ["TGT", "TGC"],
+    "Q": ["CAA", "CAG"], "E": ["GAA", "GAG"],
+    "G": ["GGT", "GGC", "GGA", "GGG"], "H": ["CAT", "CAC"],
+    "I": ["ATT", "ATC", "ATA"],
+    "L": ["TTA", "TTG", "CTT", "CTC", "CTA", "CTG"],
+    "K": ["AAA", "AAG"], "M": ["ATG"], "F": ["TTT", "TTC"],
+    "P": ["CCT", "CCC", "CCA", "CCG"],
+    "S": ["TCT", "TCC", "TCA", "TCG", "AGT", "AGC"],
+    "T": ["ACT", "ACC", "ACA", "ACG"], "W": ["TGG"],
+    "Y": ["TAT", "TAC"], "V": ["GTT", "GTC", "GTA", "GTG"],
+    "*": ["TAA", "TAG", "TGA"],
+}
+CODON_TO_AA = {
+    codon: amino_acid
+    for amino_acid, codons in AA_TO_CODONS.items()
+    for codon in codons
 }
 
-CODON_TO_AA = {codon: aa for aa, codons in AA_TO_CODONS.items() for codon in codons}
 
-# Vocabulary mapping (must match codon_tokenize.py)
-CODONS = [a + b + c for a in "ACGT" for b in "ACGT" for c in "ACGT"]
-SPECIALS = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>"]
-VOCAB = SPECIALS + CODONS
-stoi = {tok: i for i, tok in enumerate(VOCAB)}
-itos = {i: tok for i, tok in enumerate(VOCAB)}
+def _codon_spans(sequence: np.ndarray, itos: list[str]):
+    start = None
+    for index, value in enumerate(sequence):
+        token_id = int(value)
+        is_codon = 0 <= token_id < len(itos) and itos[token_id] in CODON_TO_AA
+        if is_codon and start is None:
+            start = index
+        elif not is_codon and start is not None:
+            yield start, index
+            start = None
+    if start is not None:
+        yield start, len(sequence)
 
-def synonymous_mutate_sequence(seq: np.ndarray, rng: random.Random) -> np.ndarray:
-    out = np.copy(seq)
-    for i in range(len(seq)):
-        val = int(seq[i])
-        # Preserve specials (PAD=0, BOS=1, EOS=2, SEP=3)
-        if val < 4:
+
+def synonymous_mutate_sequence(
+    sequence: np.ndarray, rng: random.Random, itos: list[str], stoi: dict[str, int]
+) -> np.ndarray:
+    output = np.copy(sequence)
+    for start, end in _codon_spans(sequence, itos):
+        for index in range(start, end):
+            amino_acid = CODON_TO_AA[itos[int(sequence[index])]]
+            output[index] = stoi[rng.choice(AA_TO_CODONS[amino_acid])]
+    return output
+
+
+def codon_shuffle_sequence(
+    sequence: np.ndarray, rng: random.Random, itos: list[str], _stoi: dict[str, int]
+) -> np.ndarray:
+    output = np.copy(sequence)
+    for start, end in _codon_spans(sequence, itos):
+        values = list(sequence[start:end])
+        rng.shuffle(values)
+        output[start:end] = values
+    return output
+
+
+def protein_shuffle_sequence(
+    sequence: np.ndarray, rng: random.Random, itos: list[str], stoi: dict[str, int]
+) -> np.ndarray:
+    output = np.copy(sequence)
+    for start, end in _codon_spans(sequence, itos):
+        amino_acids = [CODON_TO_AA[itos[int(value)]] for value in sequence[start:end]]
+        rng.shuffle(amino_acids)
+        output[start:end] = [
+            stoi[rng.choice(AA_TO_CODONS[amino_acid])]
+            for amino_acid in amino_acids
+        ]
+    return output
+
+
+def _transform_dataset(
+    X: np.ndarray,
+    Y: np.ndarray | None,
+    lengths: np.ndarray | None,
+    transform: Callable,
+    *,
+    rng: random.Random,
+    itos: list[str],
+    stoi: dict[str, int],
+) -> tuple[np.ndarray, np.ndarray | None]:
+    if lengths is not None:
+        output = np.copy(X)
+        offset = 0
+        for raw_length in lengths:
+            length = int(raw_length)
+            output[offset : offset + length] = transform(
+                X[offset : offset + length], rng, itos, stoi
+            )
+            offset += length
+        if offset != len(X):
+            raise ValueError("dynamic lengths do not cover the flat token array")
+        return output, None
+
+    if Y is None or X.ndim != 2 or Y.shape != X.shape:
+        raise ValueError("fixed controls require equally shaped two-dimensional X and Y")
+    output_x = np.zeros_like(X)
+    output_y = np.zeros_like(Y)
+    for row in range(len(X)):
+        transition_count = int(np.count_nonzero(Y[row]))
+        if transition_count == 0:
             continue
-        codon_str = itos[val]
-        aa = CODON_TO_AA.get(codon_str)
-        if aa is None:
-            continue
-        synonyms = AA_TO_CODONS[aa]
-        chosen_codon = rng.choice(synonyms)
-        out[i] = stoi[chosen_codon]
-    return out
+        if transition_count > 1 and not np.array_equal(
+            X[row, 1:transition_count], Y[row, : transition_count - 1]
+        ):
+            raise ValueError("source dataset violates the next-token X/Y shift invariant")
+        if np.any(X[row, transition_count:]) or np.any(Y[row, transition_count:]):
+            raise ValueError("source dataset contains non-PAD tokens after padding begins")
+        stream = np.concatenate(
+            (X[row, :transition_count], Y[row, transition_count - 1 : transition_count])
+        )
+        transformed = transform(stream, rng, itos, stoi)
+        output_x[row, :transition_count] = transformed[:-1]
+        output_y[row, :transition_count] = transformed[1:]
+    return output_x, output_y
 
-def codon_shuffle_sequence(seq: np.ndarray, rng: random.Random) -> np.ndarray:
-    out = np.copy(seq)
-    # Find positions of sense codons (ids >= 4)
-    codon_indices = [i for i, val in enumerate(seq) if val >= 4]
-    if not codon_indices:
-        return out
-    
-    # Extract, shuffle, and re-insert
-    codon_vals = [seq[i] for i in codon_indices]
-    rng.shuffle(codon_vals)
-    for idx, i in enumerate(codon_indices):
-        out[i] = codon_vals[idx]
-    return out
 
-def protein_shuffle_sequence(seq: np.ndarray, rng: random.Random) -> np.ndarray:
-    out = np.copy(seq)
-    # Find indices of sense codons (ids >= 4)
-    codon_indices = [i for i, val in enumerate(seq) if val >= 4]
-    if not codon_indices:
-        return out
-        
-    # Translate to amino acids
-    aas = []
-    for i in codon_indices:
-        codon_str = itos[int(seq[i])]
-        aas.append(CODON_TO_AA.get(codon_str, 'M'))  # Default to Methionine if not found
-        
-    # Shuffle amino acids
-    rng.shuffle(aas)
-    
-    # Re-encode back to codon ids (randomly choosing synonymous codons for each shuffled amino acid)
-    for idx, i in enumerate(codon_indices):
-        aa = aas[idx]
-        syns = AA_TO_CODONS[aa]
-        chosen = rng.choice(syns)
-        out[i] = stoi[chosen]
-    return out
+def _write_control(
+    path: Path,
+    X: np.ndarray,
+    Y: np.ndarray | None,
+    lengths: np.ndarray | None,
+    *,
+    kind: str,
+    seed: int,
+    manifest_provenance: dict | None,
+    source_provenance: dict,
+    vocabulary_provenance: dict,
+) -> None:
+    if lengths is None:
+        np.savez_compressed(path, X=X, Y=Y)
+    else:
+        np.savez_compressed(path, X=X, lengths=lengths)
+    provenance = {
+        "schema_version": 1,
+        "status": "derived_control_verified" if manifest_provenance else "legacy_unverified",
+        "control": kind,
+        "seed": seed,
+        "dataset_id": manifest_provenance.get("dataset_id") if manifest_provenance else None,
+        "dataset_manifest": manifest_provenance,
+        "vocabulary": vocabulary_provenance,
+        "source_test": source_provenance,
+        "output": artifact_provenance(path),
+    }
+    sidecar = path.with_suffix(path.suffix + ".provenance.json")
+    sidecar.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n")
+    print(f"[controls] saved {path} and {sidecar}")
+
 
 def main() -> None:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--test_npz", required=True, help="Path to test NPZ dataset")
-    ap.add_argument("--seed", type=int, default=1337)
-    args = ap.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test_npz", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--vocabulary", type=Path, help="Required for legacy data without a manifest.")
+    parser.add_argument("--out_dir", type=Path)
+    parser.add_argument("--seed", type=int, default=1337)
+    args = parser.parse_args()
 
-    test_path = Path(args.test_npz)
-    if not test_path.exists():
-        raise FileNotFoundError(f"Test NPZ not found: {test_path}")
+    test_path = args.test_npz.expanduser().resolve()
+    if not test_path.is_file():
+        raise FileNotFoundError(f"test dataset not found: {test_path}")
 
-    print(f"[controls] Loading test dataset from {test_path}...")
-    with np.load(test_path) as data:
-        X = data["X"]
-        Y = data.get("Y", None)
-        lengths = data.get("lengths", None)
+    manifest_provenance = None
+    if args.manifest:
+        manifest, manifest_provenance = bind_dataset_manifest(
+            args.manifest,
+            expected_artifacts={"test_tokens": test_path},
+            require_scientific=False,
+        )
+        vocabulary_path = manifest_artifact_path(
+            manifest, args.manifest.expanduser().resolve(), "vocabulary"
+        )
+    elif args.vocabulary:
+        vocabulary_path = args.vocabulary.expanduser().resolve()
+    else:
+        raise ValueError("provide --manifest or --vocabulary; vocabulary IDs are not inferred")
 
-    rng = random.Random(args.seed)
+    itos = load_itos(vocabulary_path)
+    stoi = {token: index for index, token in enumerate(itos)}
+    missing_codons = sorted(set(CODON_TO_AA) - set(stoi))
+    if missing_codons:
+        raise ValueError(f"vocabulary lacks standard codons: {missing_codons}")
 
-    # 1. Synonymous Recoding
-    print("[controls] Generating Synonymous Recoding control...")
-    X_syn = np.copy(X)
-    for i in range(len(X)):
-        X_syn[i] = synonymous_mutate_sequence(X[i], rng)
-    
-    Y_syn = None
-    if Y is not None:
-        Y_syn = np.copy(Y)
-        for i in range(len(Y)):
-            Y_syn[i] = synonymous_mutate_sequence(Y[i], rng)
+    with np.load(test_path, allow_pickle=False) as data:
+        X = np.asarray(data["X"])
+        Y = np.asarray(data["Y"]) if "Y" in data else None
+        lengths = np.asarray(data["lengths"]) if "lengths" in data else None
 
-    # 2. Codon Shuffling
-    print("[controls] Generating Codon Shuffling control...")
-    X_shuf = np.copy(X)
-    for i in range(len(X)):
-        X_shuf[i] = codon_shuffle_sequence(X[i], rng)
-        
-    Y_shuf = None
-    if Y is not None:
-        Y_shuf = np.copy(Y)
-        for i in range(len(Y)):
-            Y_shuf[i] = codon_shuffle_sequence(Y[i], rng)
+    controls = (
+        ("synonymous", synonymous_mutate_sequence, 0),
+        ("codon_shuffle", codon_shuffle_sequence, 1),
+        ("protein_shuffle", protein_shuffle_sequence, 2),
+    )
+    out_dir = (args.out_dir or test_path.parent).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    block_label = X.shape[1] if X.ndim > 1 else int(lengths.max(initial=0))
+    for kind, transform, seed_offset in controls:
+        control_x, control_y = _transform_dataset(
+            X,
+            Y,
+            lengths,
+            transform,
+            rng=random.Random(args.seed + seed_offset),
+            itos=itos,
+            stoi=stoi,
+        )
+        output = out_dir / f"test_control_{kind}_bs{block_label}.npz"
+        _write_control(
+            output,
+            control_x,
+            control_y,
+            lengths,
+            kind=kind,
+            seed=args.seed + seed_offset,
+            manifest_provenance=manifest_provenance,
+            source_provenance=artifact_provenance(test_path),
+            vocabulary_provenance=artifact_provenance(vocabulary_path),
+        )
 
-    # 3. Protein Shuffling
-    print("[controls] Generating Protein Shuffling control...")
-    X_prot = np.copy(X)
-    for i in range(len(X)):
-        X_prot[i] = protein_shuffle_sequence(X[i], rng)
-        
-    Y_prot = None
-    if Y is not None:
-        Y_prot = np.copy(Y)
-        for i in range(len(Y)):
-            Y_prot[i] = protein_shuffle_sequence(Y[i], rng)
-
-    # Save outputs
-    out_dir = test_path.parent
-    
-    npz_syn_path = out_dir / f"test_control_synonymous_bs{X.shape[1] if X.ndim > 1 else 256}.npz"
-    npz_shuf_path = out_dir / f"test_control_codon_shuffle_bs{X.shape[1] if X.ndim > 1 else 256}.npz"
-    npz_prot_path = out_dir / f"test_control_protein_shuffle_bs{X.shape[1] if X.ndim > 1 else 256}.npz"
-
-    def save_npz(path, x_arr, y_arr):
-        if lengths is not None:
-            np.savez_compressed(path, X=x_arr, lengths=lengths)
-        else:
-            np.savez_compressed(path, X=x_arr, Y=y_arr)
-        print(f"[controls] Saved control dataset to {path}")
-
-    save_npz(npz_syn_path, X_syn, Y_syn)
-    save_npz(npz_shuf_path, X_shuf, Y_shuf)
-    save_npz(npz_prot_path, X_prot, Y_prot)
 
 if __name__ == "__main__":
     main()

--- a/scripts/train_classifier.py
+++ b/scripts/train_classifier.py
@@ -60,6 +60,7 @@ from src.classifiers.probes import (
 from src.classifiers.linear_probe import fit_linear_svm, fit_logreg
 from src.classifiers.mlp_head import fit_mlp
 from src.classifiers.kmer_baselines import fit_kmer_logreg, fit_kmer_svm, fit_kmer_xgb
+from src.codonlm.evaluation_provenance import artifact_provenance, bind_embedding_pair
 
 
 def _read_labels_csv(path: Path) -> Dict[str, int]:
@@ -111,8 +112,26 @@ def main() -> None:
     out_dir = ensure_dir(cfg.get("out_dir", "outputs/reports/exp"))
     str(cfg.get("protocol", "std")).upper()
     clf_kind = str(cfg.get("classifier", {}).get("kind", "probe_logreg"))
+    provenance = {
+        "schema_version": 1,
+        "config": artifact_provenance(args.config),
+        "classifier_kind": clf_kind,
+        "task": cfg.get("task"),
+        "protocol": cfg.get("protocol", "std"),
+    }
 
     if clf_kind.startswith("probe") or clf_kind == "mlp":
+        require_verified = bool(cfg.get("require_verified_embeddings", False))
+        provenance["embedding_inputs"] = bind_embedding_pair(
+            cfg["data"]["train_embeddings"],
+            cfg["data"]["test_embeddings"],
+            require_verified=require_verified,
+        )
+        provenance["require_verified_embeddings"] = require_verified
+        provenance["labels"] = {
+            split: artifact_provenance(cfg["data"][f"{split}_labels"])
+            for split in ("train", "test")
+        }
         train_X, train_y = _align_embeddings(
             Path(cfg["data"]["train_embeddings"]), Path(cfg["data"]["train_labels"])
         )
@@ -159,6 +178,11 @@ def main() -> None:
                 y_pred = torch.argmax(logits, dim=1).cpu().numpy()
                 y_proba = torch.softmax(logits, dim=1).cpu().numpy()
         metrics = compute_metrics(test_y, y_pred, y_proba, bootstrap=True)
+        metrics["evaluation_provenance"] = {
+            "status": "verified" if require_verified else "legacy_unverified",
+            "path": str((out_dir / "provenance.json").resolve()),
+        }
+        save_json(out_dir / "provenance.json", provenance)
         save_json(out_dir / "metrics.json", metrics)
         plot_confusion(test_y, y_pred, out_dir / "confusion.png")
         if y_proba is not None:
@@ -173,6 +197,11 @@ def main() -> None:
         print(f"[train-clf] {clf_kind} → {out_dir}; metrics={json.dumps(metrics)}")
 
     else:
+        provenance["sequence_inputs"] = {
+            f"{split}_{kind}": artifact_provenance(cfg["data"][f"{split}_{kind}"])
+            for split in ("train", "test")
+            for kind in ("seqs", "labels")
+        }
         # k-mer baselines expect sequences
         _, train_seqs = _read_seqs_csv(Path(cfg["data"]["train_seqs"]))
         _, test_seqs = _read_seqs_csv(Path(cfg["data"]["test_seqs"]))
@@ -219,6 +248,11 @@ def main() -> None:
             except Exception:
                 y_proba = None
         metrics = compute_metrics(y_test_i, y_pred, y_proba, bootstrap=True)
+        metrics["evaluation_provenance"] = {
+            "status": "input_artifacts_recorded",
+            "path": str((out_dir / "provenance.json").resolve()),
+        }
+        save_json(out_dir / "provenance.json", provenance)
         save_json(out_dir / "metrics.json", metrics)
         plot_confusion(y_test_i, y_pred, out_dir / "confusion.png")
         if y_proba is not None:

--- a/src/codonlm/evaluation_provenance.py
+++ b/src/codonlm/evaluation_provenance.py
@@ -1,0 +1,243 @@
+"""Fail-closed dataset and checkpoint provenance for corrected evaluations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping
+
+from .dataset_manifest import file_sha256, load_dataset_manifest, manifest_artifact_path
+
+
+class EvaluationProvenanceError(ValueError):
+    """Raised when evaluation inputs cannot be bound to one frozen dataset."""
+
+
+def artifact_provenance(path: str | Path) -> dict:
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.is_file():
+        raise EvaluationProvenanceError(f"evaluation artifact not found: {resolved}")
+    return {
+        "path": str(resolved),
+        "bytes": resolved.stat().st_size,
+        "sha256": file_sha256(resolved),
+    }
+
+
+def bind_dataset_manifest(
+    manifest_path: str | Path,
+    *,
+    expected_artifacts: Mapping[str, str | Path] | None = None,
+    require_scientific: bool = True,
+) -> tuple[dict, dict]:
+    resolved = Path(manifest_path).expanduser().resolve()
+    manifest = load_dataset_manifest(resolved)
+    if require_scientific and not manifest["dataset"].get("scientific_valid"):
+        raise EvaluationProvenanceError(
+            f"dataset manifest is not marked scientific_valid: {resolved}"
+        )
+
+    bound_artifacts = {}
+    for name, selected_path in (expected_artifacts or {}).items():
+        selected = Path(selected_path).expanduser().resolve()
+        declared = manifest_artifact_path(manifest, resolved, name).resolve()
+        if selected != declared:
+            raise EvaluationProvenanceError(
+                f"{name} input {selected} does not match manifest artifact {declared}"
+            )
+        bound_artifacts[name] = artifact_provenance(declared)
+
+    vocabulary_path = manifest_artifact_path(manifest, resolved, "vocabulary").resolve()
+
+    provenance = {
+        "status": "frozen_manifest_verified",
+        **artifact_provenance(resolved),
+        "dataset_id": manifest["dataset"]["id"],
+        "scientific_valid": bool(manifest["dataset"]["scientific_valid"]),
+        "schema": manifest["schema"],
+        "vocabulary": artifact_provenance(vocabulary_path),
+        "bound_artifacts": bound_artifacts,
+    }
+    return manifest, provenance
+
+
+def bind_checkpoint_dataset(
+    checkpoint_cfg: Mapping,
+    manifest_provenance: Mapping | None,
+) -> dict:
+    checkpoint_manifest = checkpoint_cfg.get("dataset_manifest")
+    checkpoint_dataset_id = (
+        checkpoint_manifest.get("dataset_id")
+        if isinstance(checkpoint_manifest, Mapping)
+        else None
+    )
+    if checkpoint_dataset_id is None:
+        return {
+            "status": "legacy_checkpoint_unverified",
+            "dataset_id": None,
+        }
+    if manifest_provenance is None:
+        raise EvaluationProvenanceError(
+            "corrected checkpoint requires an explicit frozen dataset manifest"
+        )
+    selected_dataset_id = manifest_provenance.get("dataset_id")
+    if checkpoint_dataset_id != selected_dataset_id:
+        raise EvaluationProvenanceError(
+            "checkpoint dataset identity mismatch: "
+            f"checkpoint={checkpoint_dataset_id!r}, manifest={selected_dataset_id!r}"
+        )
+    checkpoint_vocabulary = checkpoint_cfg.get("vocabulary")
+    checkpoint_vocabulary_sha = (
+        checkpoint_vocabulary.get("sha256")
+        if isinstance(checkpoint_vocabulary, Mapping)
+        else None
+    )
+    manifest_vocabulary_sha = (
+        manifest_provenance.get("vocabulary", {}).get("sha256")
+    )
+    if (
+        checkpoint_vocabulary_sha is not None
+        and checkpoint_vocabulary_sha != manifest_vocabulary_sha
+    ):
+        raise EvaluationProvenanceError(
+            "checkpoint vocabulary mismatch: "
+            f"checkpoint={checkpoint_vocabulary_sha!r}, manifest={manifest_vocabulary_sha!r}"
+        )
+    return {
+        "status": "checkpoint_manifest_verified",
+        "dataset_id": checkpoint_dataset_id,
+        "vocabulary_sha256": checkpoint_vocabulary_sha,
+    }
+
+
+def bind_derived_dataset(
+    artifact_path: str | Path,
+    provenance_path: str | Path,
+    *,
+    manifest_provenance: Mapping,
+    source_artifact_path: str | Path,
+) -> dict:
+    """Verify a derived evaluator input against its frozen source artifact."""
+    resolved_provenance = Path(provenance_path).expanduser().resolve()
+    try:
+        provenance = json.loads(resolved_provenance.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EvaluationProvenanceError(
+            f"cannot read derived dataset provenance {resolved_provenance}: {exc}"
+        ) from exc
+
+    if provenance.get("status") != "derived_control_verified":
+        raise EvaluationProvenanceError(
+            f"unsupported derived dataset provenance status: {provenance.get('status')!r}"
+        )
+    if provenance.get("dataset_id") != manifest_provenance.get("dataset_id"):
+        raise EvaluationProvenanceError("derived dataset manifest identity mismatch")
+
+    expected_vocabulary = manifest_provenance.get("vocabulary", {}).get("sha256")
+    if provenance.get("vocabulary", {}).get("sha256") != expected_vocabulary:
+        raise EvaluationProvenanceError("derived dataset vocabulary mismatch")
+
+    comparisons = (
+        ("derived output", artifact_provenance(artifact_path), provenance.get("output")),
+        (
+            "derived source",
+            artifact_provenance(source_artifact_path),
+            provenance.get("source_test"),
+        ),
+    )
+    for label, current, declared in comparisons:
+        if not isinstance(declared, Mapping):
+            raise EvaluationProvenanceError(f"{label} provenance is missing")
+        if any(current.get(key) != declared.get(key) for key in ("path", "bytes", "sha256")):
+            raise EvaluationProvenanceError(f"{label} provenance mismatch")
+
+    return {
+        "status": "derived_dataset_verified",
+        "provenance": artifact_provenance(resolved_provenance),
+        "derivation": provenance,
+    }
+
+
+def bind_embedding_artifact(path: str | Path, *, require_verified: bool) -> dict:
+    embedding = Path(path).expanduser().resolve()
+    metadata_path = embedding.with_suffix(embedding.suffix + ".metadata.json")
+    if not metadata_path.is_file():
+        if require_verified:
+            raise EvaluationProvenanceError(
+                f"verified embedding metadata sidecar not found: {metadata_path}"
+            )
+        return {
+            "status": "legacy_embedding_unverified",
+            "embedding": artifact_provenance(embedding),
+        }
+    try:
+        metadata = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EvaluationProvenanceError(
+            f"cannot read embedding metadata {metadata_path}: {exc}"
+        ) from exc
+    if require_verified:
+        if metadata.get("validation_status") != "causal_verified":
+            raise EvaluationProvenanceError(
+                f"embedding is not causally verified: {embedding}"
+            )
+        if metadata.get("dataset_manifest", {}).get("status") != "frozen_manifest_verified":
+            raise EvaluationProvenanceError(
+                f"embedding lacks frozen dataset provenance: {embedding}"
+            )
+        if metadata.get("checkpoint_dataset", {}).get("status") != "checkpoint_manifest_verified":
+            raise EvaluationProvenanceError(
+                f"embedding checkpoint is not bound to its dataset: {embedding}"
+            )
+    return {
+        "status": "verified_embedding" if require_verified else "metadata_present",
+        "embedding": artifact_provenance(embedding),
+        "metadata": artifact_provenance(metadata_path),
+        "extraction": metadata,
+    }
+
+
+def bind_embedding_pair(
+    train_path: str | Path,
+    test_path: str | Path,
+    *,
+    require_verified: bool,
+) -> dict:
+    train = bind_embedding_artifact(train_path, require_verified=require_verified)
+    test = bind_embedding_artifact(test_path, require_verified=require_verified)
+    if require_verified:
+        train_extraction = train["extraction"]
+        test_extraction = test["extraction"]
+        comparisons = {
+            "dataset_id": (
+                train_extraction["dataset_manifest"].get("dataset_id"),
+                test_extraction["dataset_manifest"].get("dataset_id"),
+            ),
+            "checkpoint_sha256": (
+                train_extraction["checkpoint"].get("sha256"),
+                test_extraction["checkpoint"].get("sha256"),
+            ),
+            "vocabulary_sha256": (
+                train_extraction["vocabulary"].get("sha256"),
+                test_extraction["vocabulary"].get("sha256"),
+            ),
+        }
+        mismatches = {
+            name: values for name, values in comparisons.items() if values[0] != values[1]
+        }
+        if mismatches:
+            raise EvaluationProvenanceError(
+                f"train/test embedding provenance mismatch: {mismatches}"
+            )
+    return {"train": train, "test": test}
+
+
+__all__ = [
+    "EvaluationProvenanceError",
+    "artifact_provenance",
+    "bind_embedding_artifact",
+    "bind_embedding_pair",
+    "bind_checkpoint_dataset",
+    "bind_derived_dataset",
+    "bind_dataset_manifest",
+]

--- a/tests/test_evaluation_provenance.py
+++ b/tests/test_evaluation_provenance.py
@@ -1,0 +1,331 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import yaml
+
+from scripts.training_preflight import _write_fixture
+from scripts.audit_generated_sequences import _read_manifest_training
+from src.codonlm.dataset_manifest import artifact_entry, finalize_manifest
+from src.codonlm.evaluation_provenance import (
+    EvaluationProvenanceError,
+    artifact_provenance,
+    bind_checkpoint_dataset,
+    bind_dataset_manifest,
+)
+from src.codonlm.model_tiny_gpt import TinyGPT
+
+
+def _corrected_run(tmp_path: Path):
+    manifest_path, manifest = _write_fixture(tmp_path / "freeze")
+    run_dir = tmp_path / "run"
+    (run_dir / "checkpoints").mkdir(parents=True)
+    vocabulary_path = manifest_path.parent / "itos.txt"
+    (run_dir / "itos.txt").write_bytes(vocabulary_path.read_bytes())
+    cfg = {
+        "vocab_size": 8,
+        "block_size": 8,
+        "n_layer": 1,
+        "n_head": 1,
+        "n_embd": 16,
+        "dropout": 0.0,
+        "use_sdpa": True,
+        "test_npz": [str(manifest_path.parent / "test.npz")],
+        "dataset_manifest": {
+            "dataset_id": manifest["dataset"]["id"],
+            "path": str(manifest_path),
+        },
+        "vocabulary": {"sha256": manifest["vocabulary"]["sha256"]},
+    }
+    model = TinyGPT(
+        vocab_size=8,
+        block_size=8,
+        n_layer=1,
+        n_head=1,
+        n_embd=16,
+        dropout=0.0,
+        use_sdpa=True,
+    )
+    torch.save(
+        {"model": model.state_dict(), "cfg": cfg},
+        run_dir / "checkpoints" / "best.pt",
+    )
+    return manifest_path, manifest, run_dir
+
+
+def test_manifest_binding_verifies_declared_artifacts(tmp_path):
+    manifest_path, manifest = _write_fixture(tmp_path)
+    _, provenance = bind_dataset_manifest(
+        manifest_path,
+        expected_artifacts={
+            "train_tokens": manifest_path.parent / "train.npz",
+            "test_tokens": manifest_path.parent / "test.npz",
+        },
+    )
+
+    assert provenance["status"] == "frozen_manifest_verified"
+    assert provenance["dataset_id"] == manifest["dataset"]["id"]
+    assert set(provenance["bound_artifacts"]) == {"train_tokens", "test_tokens"}
+
+    wrong = tmp_path / "wrong.npz"
+    wrong.touch()
+    with pytest.raises(EvaluationProvenanceError, match="does not match"):
+        bind_dataset_manifest(
+            manifest_path, expected_artifacts={"test_tokens": wrong}
+        )
+
+
+def test_corrected_checkpoint_requires_matching_manifest_and_vocabulary(tmp_path):
+    manifest_path, manifest = _write_fixture(tmp_path)
+    _, provenance = bind_dataset_manifest(manifest_path)
+    cfg = {
+        "dataset_manifest": {"dataset_id": manifest["dataset"]["id"]},
+        "vocabulary": {"sha256": manifest["vocabulary"]["sha256"]},
+    }
+    assert bind_checkpoint_dataset(cfg, provenance)["status"] == "checkpoint_manifest_verified"
+
+    with pytest.raises(EvaluationProvenanceError, match="explicit frozen"):
+        bind_checkpoint_dataset(cfg, None)
+    with pytest.raises(EvaluationProvenanceError, match="identity mismatch"):
+        bind_checkpoint_dataset(
+            {"dataset_manifest": {"dataset_id": "different"}}, provenance
+        )
+    with pytest.raises(EvaluationProvenanceError, match="vocabulary mismatch"):
+        bind_checkpoint_dataset(
+            {**cfg, "vocabulary": {"sha256": "different"}}, provenance
+        )
+
+
+def test_corrected_test_evaluation_emits_frozen_provenance(tmp_path):
+    manifest_path, manifest, run_dir = _corrected_run(tmp_path)
+    command = [
+        "python",
+        "-m",
+        "scripts.evaluate_test",
+        "--run_dir",
+        str(run_dir),
+        "--manifest",
+        str(manifest_path),
+        "--batch_size",
+        "2",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FORCE_CPU": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads((run_dir / "scores" / "metrics.json").read_text())
+    provenance = report["test_evaluation_provenance"]
+    assert provenance["dataset_manifest"]["dataset_id"] == manifest["dataset"]["id"]
+    assert provenance["checkpoint_dataset"]["status"] == "checkpoint_manifest_verified"
+    assert report["test_evaluated_tokens"] > 0
+
+    without_manifest = subprocess.run(
+        command[:5] + command[7:],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FORCE_CPU": "1"},
+    )
+    assert without_manifest.returncode != 0
+    assert "explicit frozen dataset manifest" in without_manifest.stderr
+
+
+def test_corrected_test_evaluation_accepts_verified_derived_control(tmp_path):
+    manifest_path, manifest, run_dir = _corrected_run(tmp_path)
+    source = manifest_path.parent / "test.npz"
+    control = tmp_path / "control.npz"
+    control.write_bytes(source.read_bytes())
+    sidecar = control.with_suffix(".npz.provenance.json")
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "derived_control_verified",
+                "control": "fixture",
+                "seed": 1337,
+                "dataset_id": manifest["dataset"]["id"],
+                "vocabulary": artifact_provenance(manifest_path.parent / "itos.txt"),
+                "source_test": artifact_provenance(source),
+                "output": artifact_provenance(control),
+            }
+        )
+    )
+    command = [
+        "python",
+        "-m",
+        "scripts.evaluate_test",
+        "--run_dir",
+        str(run_dir),
+        "--test_npz",
+        str(control),
+        "--manifest",
+        str(manifest_path),
+        "--derived_provenance",
+        str(sidecar),
+        "--batch_size",
+        "2",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FORCE_CPU": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((run_dir / "scores" / "metrics.json").read_text())
+    assert (
+        report["test_evaluation_provenance"]["derived_dataset"]["status"]
+        == "derived_dataset_verified"
+    )
+
+    control.write_bytes(control.read_bytes() + b"tampered")
+    failed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FORCE_CPU": "1"},
+    )
+    assert failed.returncode != 0
+    assert "derived output provenance mismatch" in failed.stderr
+
+
+def test_corrected_embedding_extraction_records_dataset_identity(tmp_path):
+    manifest_path, manifest, run_dir = _corrected_run(tmp_path)
+    fasta = tmp_path / "input.fasta"
+    fasta.write_text(">gene-1\nAAACCC\n")
+    output = tmp_path / "embeddings.npz"
+    command = [
+        "python",
+        "-m",
+        "scripts.extract_embeddings",
+        "--run_dir",
+        str(run_dir),
+        "--fasta",
+        str(fasta),
+        "--manifest",
+        str(manifest_path),
+        "--out",
+        str(output),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    metadata = json.loads(output.with_suffix(".npz.metadata.json").read_text())
+    assert metadata["dataset_manifest"]["dataset_id"] == manifest["dataset"]["id"]
+    assert metadata["checkpoint_dataset"]["status"] == "checkpoint_manifest_verified"
+
+
+def _verified_embeddings(path: Path, ids: list[str], dataset_id: str):
+    values = np.array(
+        [[0.0, 0.1], [0.2, 0.0], [0.1, 0.2], [1.0, 0.9], [0.8, 1.0], [0.9, 0.8]],
+        dtype=np.float32,
+    )
+    np.savez(path, X=values, ids=np.asarray(ids, dtype=object))
+    metadata = {
+        "validation_status": "causal_verified",
+        "dataset_manifest": {
+            "status": "frozen_manifest_verified",
+            "dataset_id": dataset_id,
+        },
+        "checkpoint_dataset": {
+            "status": "checkpoint_manifest_verified",
+            "dataset_id": dataset_id,
+        },
+        "checkpoint": {"sha256": "checkpoint-sha"},
+        "vocabulary": {"sha256": "vocabulary-sha"},
+    }
+    path.with_suffix(".npz.metadata.json").write_text(json.dumps(metadata))
+
+
+def test_classifier_requires_matching_verified_embedding_provenance(tmp_path):
+    ids = [f"gene-{index}" for index in range(6)]
+    train_embeddings = tmp_path / "train.npz"
+    test_embeddings = tmp_path / "test.npz"
+    _verified_embeddings(train_embeddings, ids, "dataset-a")
+    _verified_embeddings(test_embeddings, ids, "dataset-a")
+    for split in ("train", "test"):
+        labels = tmp_path / f"{split}_labels.csv"
+        labels.write_text(
+            "id,label\n"
+            + "".join(f"{identifier},{0 if index < 3 else 1}\n" for index, identifier in enumerate(ids))
+        )
+    output = tmp_path / "report"
+    config = tmp_path / "probe.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "task": "fixture",
+                "protocol": "corrected",
+                "out_dir": str(output),
+                "require_verified_embeddings": True,
+                "data": {
+                    "train_embeddings": str(train_embeddings),
+                    "test_embeddings": str(test_embeddings),
+                    "train_labels": str(tmp_path / "train_labels.csv"),
+                    "test_labels": str(tmp_path / "test_labels.csv"),
+                },
+                "classifier": {"kind": "probe_logreg", "C": 1.0},
+            }
+        )
+    )
+
+    result = subprocess.run(
+        ["python", "-m", "scripts.train_classifier", "--config", str(config)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    metrics = json.loads((output / "metrics.json").read_text())
+    assert metrics["evaluation_provenance"]["status"] == "verified"
+    provenance = json.loads((output / "provenance.json").read_text())
+    assert provenance["embedding_inputs"]["train"]["status"] == "verified_embedding"
+
+    test_metadata = test_embeddings.with_suffix(".npz.metadata.json")
+    mismatched = json.loads(test_metadata.read_text())
+    mismatched["checkpoint"]["sha256"] = "different"
+    test_metadata.write_text(json.dumps(mismatched))
+    failed = subprocess.run(
+        ["python", "-m", "scripts.train_classifier", "--config", str(config)],
+        capture_output=True,
+        text=True,
+    )
+    assert failed.returncode != 0
+    assert "embedding provenance mismatch" in failed.stderr
+
+
+def test_generated_audit_derives_train_only_records_from_manifest(tmp_path):
+    manifest_path, manifest = _write_fixture(tmp_path)
+    metadata_path = manifest_path.parent / "cds_meta.tsv"
+    dna_path = manifest_path.parent / "cds_dna.txt"
+    splits = ["train"] * 5 + ["val"] * 2 + ["test"] * 2
+    metadata_path.write_text(
+        "line_idx\tsplit\tsource_id\n"
+        + "".join(
+            f"{index}\t{split}\trecord-{index}\n"
+            for index, split in enumerate(splits)
+        )
+    )
+    dna_path.write_text("".join("AAACCCGGG\n" for _ in splits))
+    manifest["artifacts"]["source_metadata"] = artifact_entry(
+        metadata_path, manifest_path.parent, "source_metadata"
+    )
+    manifest["artifacts"]["source_dna"] = artifact_entry(
+        dna_path, manifest_path.parent, "source_dna"
+    )
+    manifest = finalize_manifest(manifest)
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    records, provenance = _read_manifest_training(manifest_path)
+
+    assert [record["source_id"] for record in records] == [
+        f"record-{index}" for index in range(5)
+    ]
+    assert provenance["training_source"]["record_count"] == 5
+    assert provenance["training_source"]["selection"] == "source_metadata.split == train"

--- a/tests/test_global_split_and_baselines.py
+++ b/tests/test_global_split_and_baselines.py
@@ -549,6 +549,8 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
         "scripts.generate_synonymous_controls",
         "--test_npz",
         str(test_npz),
+        "--manifest",
+        str(output_dir / "manifest.json"),
     ]
     res_controls = subprocess.run(cmd_controls, capture_output=True, text=True)
     assert res_controls.returncode == 0, f"Controls generation failed: {res_controls.stderr}"
@@ -568,6 +570,18 @@ def test_global_split_and_baselines_end_to_end(tmp_path):
 
     with np.load(control_syn) as data:
         assert data["X"].shape == (expected_len, 128)
+        for control_x, control_y in zip(data["X"], data["Y"]):
+            transition_count = int(np.count_nonzero(control_y))
+            assert np.array_equal(
+                control_x[1:transition_count],
+                control_y[: transition_count - 1],
+            )
+
+    provenance = json.loads(
+        control_syn.with_suffix(".npz.provenance.json").read_text()
+    )
+    assert provenance["status"] == "derived_control_verified"
+    assert provenance["control"] == "synonymous"
         
     print("Synonymous controls test completed successfully.")
 


### PR DESCRIPTION
## Summary
- add fail-closed manifest, checkpoint, vocabulary, artifact, and embedding provenance checks across corrected evaluators
- bind generated-sequence audits to train-only frozen source records
- generate synonymous and shuffled controls without crossing CDS boundaries or breaking packed X/Y alignment, with verified derivation sidecars
- document corrected evaluation commands and mark the evaluator-fixture training gate complete

## Validation
- scoped Ruff checks passed
- full pytest suite: 281 passed, 1 skipped, 1 xpassed

Tracks #92; does not close the training/revalidation epic.