### PR TITLE
Formalize corrected pipeline freeze v1

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-In progress. The corrected datasets, evaluator contracts, and generation protocol
-separation are complete. The program remains blocked on the formal pipeline freeze,
-immutable training configs, and the MPS policy gate.
+In progress. The corrected pipeline freeze, evaluator contracts, and generation
+protocol separation are complete. The program remains blocked on immutable training
+configs and the MPS policy gate.
 
 ## Phase 0: Close Pre-Training Gates
 

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -1,9 +1,9 @@
 # Leakage-Controlled CodonLM Revalidation Plan
 
 ## Status
-In progress. Engineering gates, the local corrected dataset freeze, and evaluator
-contracts are complete; full retraining remains blocked on the formal pipeline
-freeze, runtime-policy selection, and immutable training configuration gate.
+In progress. Engineering gates, the corrected pipeline freeze, and evaluator
+contracts are complete; full retraining remains blocked on runtime-policy selection
+and the immutable training configuration gate.
 
 ## Phase 1: Governance and CI
 - [x] Relabel legacy results and unsupported claims (#87).
@@ -46,13 +46,13 @@ preflight completes without OOM, non-finite updates, provenance gaps, or leakage
   protein-cluster and nearest-neighbor reports under the grouped-holdout policy.
 - [x] Record manifest hashes, group/record/fragment/chunk/token counts, achieved
   split fractions, ambiguity statistics, and audit reports.
-- [ ] Tag the dataset schema and artifact generation as the pipeline freeze.
+- [x] Tag the dataset schema and artifact generation as the pipeline freeze.
 
-Local freeze `718417694607bed760fcb2335db1f65c96ef69cdae1612853e8778eef5ba8406`
+Portable freeze `1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249`
 contains genome dataset `da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9`
 and genus dataset `10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95`.
-The freeze is a local acceptance artifact until this pipeline PR merges and a
-clean-checkout reproduction confirms the same identities.
+The tracked `corrected-codonlm-v1` contract verifies the full local artifact tree
+and rejects source, manifest, protocol, seed, or identity drift.
 
 Exit gate: a clean checkout can reproduce byte-identical manifests and all blocking
 audits pass. Any later semantic change creates a new dataset version.

--- a/configs/corrected_codonlm_freeze_v1.json
+++ b/configs/corrected_codonlm_freeze_v1.json
@@ -1,0 +1,54 @@
+{
+  "dataset_freeze_id": "1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249",
+  "dataset_freeze_schema": {
+    "name": "codonlm_dataset_freeze",
+    "version": 2
+  },
+  "protocols": {
+    "genome": {
+      "achieved_record_fractions": {
+        "test": 0.07331613328209914,
+        "train": 0.8190152055772081,
+        "val": 0.10766866114069276
+      },
+      "dataset_id": "da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9",
+      "group_counts": {
+        "test": 2,
+        "train": 20,
+        "val": 2
+      },
+      "manifest_sha256": "519e5e7ef42f66d9fa33a3bdc95e2160c71c952ee9ea6b958def3f645733005d",
+      "record_counts": {
+        "test": 6678,
+        "train": 74600,
+        "val": 9807
+      }
+    },
+    "genus": {
+      "achieved_record_fractions": {
+        "test": 0.1937096438242033,
+        "train": 0.7432004297350333,
+        "val": 0.06308992644076344
+      },
+      "dataset_id": "10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95",
+      "group_counts": {
+        "test": 2,
+        "train": 19,
+        "val": 2
+      },
+      "manifest_sha256": "910b586824434f84cea2bad98a3c7ce9edad12223d2b7d0dbf5fbd1e06980439",
+      "record_counts": {
+        "test": 17670,
+        "train": 67794,
+        "val": 5755
+      }
+    }
+  },
+  "release": "corrected-codonlm-v1",
+  "schema": {
+    "name": "codonlm_pipeline_freeze_contract",
+    "version": 1
+  },
+  "source_config_sha256": "0c8fdb7f5866609a4161116dfa573bbd475b9923639ff0676b671e8ac54c45ac",
+  "split_seed": 1337
+}

--- a/docs/DATASET_MANIFEST.md
+++ b/docs/DATASET_MANIFEST.md
@@ -76,3 +76,31 @@ copies and report all protein-cluster crossings and nearest-neighbor identities.
 Protein homology is diagnostic here because homologous genes are expected across
 whole genomes and genera; strict blocking remains mandatory for explicitly
 homology-held-out evaluations.
+
+Freeze schema v2 computes its identity without storage paths, so relocating a
+byte-identical build does not change the aggregate freeze ID. To migrate or restore
+the index for already completed protocol artifacts without repeating the expensive
+alignment audits:
+
+```bash
+python -m scripts.freeze_corrected_datasets \
+  --config configs/corrected_codonlm_dataset_v1.yaml \
+  --freeze-id corrected-codonlm-v1 \
+  --seed 1337 \
+  --finalize-existing
+```
+
+The reviewed release contract is
+`configs/corrected_codonlm_freeze_v1.json`. Verify the complete local artifact tree,
+including every source, manifest, packed array, audit, vocabulary, and the approved
+dataset identities, before training:
+
+```bash
+python -m scripts.verify_dataset_freeze \
+  --freeze data/processed/corrected/corrected-codonlm-v1/freeze.json \
+  --expected configs/corrected_codonlm_freeze_v1.json
+```
+
+The first portable aggregate freeze ID is
+`1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249`.
+The underlying genome and genus dataset IDs are unchanged by the index migration.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -34,6 +34,15 @@ This document captures the end-to-end journey of Genomics-LM. It details how we 
   next-token alignment and CDS boundaries, and emit hash-bound derivation sidecars
   that corrected test evaluation verifies before scoring.
 
+## 2026-07-22: Corrected Pipeline Freeze v1
+
+* Migrated the aggregate dataset freeze to a location-independent v2 identity while
+  preserving the genome- and genus-held-out dataset identities.
+* Recorded the reviewed `corrected-codonlm-v1` source, seed, manifest, record/group
+  count, and dataset identity contract in version control.
+* Added fail-closed verification of the full local source and artifact tree against
+  that contract, plus a metadata-only finalization path for completed dataset builds.
+
 ---
 
 ## 1. Stage 1: Toy Scale (The Grammar School)

--- a/scripts/freeze_corrected_datasets.py
+++ b/scripts/freeze_corrected_datasets.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -19,7 +21,9 @@ from src.codonlm.dataset_manifest import file_sha256, load_dataset_manifest
 
 
 FREEZE_SCHEMA_NAME = "codonlm_dataset_freeze"
-FREEZE_SCHEMA_VERSION = 1
+FREEZE_SCHEMA_VERSION = 2
+CONTRACT_SCHEMA_NAME = "codonlm_pipeline_freeze_contract"
+CONTRACT_SCHEMA_VERSION = 1
 GROUP_PROTOCOLS = ("genome", "genus")
 
 
@@ -115,12 +119,14 @@ def build_freeze_index(
     manifests: dict[str, tuple[dict[str, Any], Path]],
 ) -> dict[str, Any]:
     validate_protocol_manifests(manifests)
+    manifest_paths = [path.resolve() for _, path in manifests.values()]
+    freeze_root = Path(os.path.commonpath([path.parent for path in manifest_paths]))
     protocols = {}
     for protocol in GROUP_PROTOCOLS:
         manifest, manifest_path = manifests[protocol]
         protocols[protocol] = {
             "dataset_id": manifest["dataset"]["id"],
-            "manifest_path": str(manifest_path.resolve()),
+            "manifest_path": os.path.relpath(manifest_path.resolve(), freeze_root),
             "manifest_sha256": file_sha256(manifest_path),
             "record_counts": manifest["split_policy"]["record_counts"],
             "group_counts": manifest["split_policy"]["group_counts"],
@@ -131,15 +137,100 @@ def build_freeze_index(
     payload = {
         "schema": {"name": FREEZE_SCHEMA_NAME, "version": FREEZE_SCHEMA_VERSION},
         "config": {
-            "path": str(config_path.resolve()),
+            "path": os.path.relpath(config_path.resolve(), freeze_root),
             "sha256": file_sha256(config_path),
         },
         "split_seed": int(seed),
         "protocols": protocols,
     }
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    payload["freeze_id"] = hashlib.sha256(encoded).hexdigest()
+    payload["freeze_id"] = freeze_identity(payload)
     return payload
+
+
+def freeze_identity(index: dict[str, Any]) -> str:
+    """Return a location-independent identity for a genome/genus freeze pair."""
+    payload = copy.deepcopy(index)
+    payload.pop("freeze_id", None)
+    payload.get("config", {}).pop("path", None)
+    for protocol in payload.get("protocols", {}).values():
+        protocol.pop("manifest_path", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def freeze_contract(index: dict[str, Any], *, release: str) -> dict[str, Any]:
+    """Extract the portable, reviewable approval contract from a freeze index."""
+    return {
+        "schema": {
+            "name": CONTRACT_SCHEMA_NAME,
+            "version": CONTRACT_SCHEMA_VERSION,
+        },
+        "release": release,
+        "dataset_freeze_schema": index["schema"],
+        "dataset_freeze_id": index["freeze_id"],
+        "source_config_sha256": index["config"]["sha256"],
+        "split_seed": int(index["split_seed"]),
+        "protocols": {
+            protocol: {
+                key: index["protocols"][protocol][key]
+                for key in (
+                    "dataset_id",
+                    "manifest_sha256",
+                    "record_counts",
+                    "group_counts",
+                    "achieved_record_fractions",
+                )
+            }
+            for protocol in GROUP_PROTOCOLS
+        },
+    }
+
+
+def validate_freeze_contract(index: dict[str, Any], contract: dict[str, Any]) -> None:
+    schema = contract.get("schema", {})
+    if schema != {"name": CONTRACT_SCHEMA_NAME, "version": CONTRACT_SCHEMA_VERSION}:
+        raise ValueError(f"unsupported pipeline freeze contract schema: {schema!r}")
+    expected = freeze_contract(index, release=str(contract.get("release", "")))
+    if contract != expected:
+        raise ValueError("pipeline freeze contract does not match the dataset freeze")
+
+
+def load_and_validate_freeze(path: Path) -> dict[str, Any]:
+    """Validate a freeze index and every bound manifest/artifact."""
+    resolved = path.expanduser().resolve()
+    index = json.loads(resolved.read_text())
+    expected_schema = {"name": FREEZE_SCHEMA_NAME, "version": FREEZE_SCHEMA_VERSION}
+    if index.get("schema") != expected_schema:
+        raise ValueError(
+            f"unsupported dataset freeze schema: {index.get('schema')!r}; "
+            f"expected {expected_schema!r}"
+        )
+    if index.get("freeze_id") != freeze_identity(index):
+        raise ValueError("dataset freeze identity mismatch")
+
+    config_path = (resolved.parent / index["config"]["path"]).resolve()
+    if file_sha256(config_path) != index["config"]["sha256"]:
+        raise ValueError("dataset freeze source config hash mismatch")
+
+    manifests = {}
+    for protocol in GROUP_PROTOCOLS:
+        declared = index["protocols"][protocol]
+        manifest_path = (resolved.parent / declared["manifest_path"]).resolve()
+        if file_sha256(manifest_path) != declared["manifest_sha256"]:
+            raise ValueError(f"{protocol} manifest hash mismatch")
+        manifest = load_dataset_manifest(manifest_path)
+        if manifest["dataset"]["id"] != declared["dataset_id"]:
+            raise ValueError(f"{protocol} dataset identity mismatch")
+        for key in (
+            "record_counts",
+            "group_counts",
+            "achieved_record_fractions",
+        ):
+            if manifest["split_policy"][key] != declared[key]:
+                raise ValueError(f"{protocol} {key} mismatch")
+        manifests[protocol] = (manifest, manifest_path)
+    validate_protocol_manifests(manifests)
+    return index
 
 
 def _run_builder(
@@ -203,6 +294,11 @@ def main() -> None:
         action="store_true",
         help="Verify the pinned inventory without building derived datasets.",
     )
+    parser.add_argument(
+        "--finalize-existing",
+        action="store_true",
+        help="Rebuild only freeze.json from already completed protocol manifests.",
+    )
     args = parser.parse_args()
 
     config_path = Path(args.config)
@@ -210,33 +306,41 @@ def main() -> None:
     print(f"[freeze] Verified {len(cfg['datasets'])} pinned source files.")
     if args.verify_sources_only:
         return
-    if shutil.which(args.mmseqs_executable) is None:
-        raise SystemExit(
-            f"[error] MMseqs2 executable not found: {args.mmseqs_executable}; "
-            "the scientific freeze cannot skip the homology gate"
-        )
-    if shutil.which(args.nucleotide_executable) is None:
-        raise SystemExit(
-            f"[error] nucleotide aligner not found: {args.nucleotide_executable}; "
-            "the scientific freeze cannot skip nucleotide nearest-neighbor mapping"
-        )
-
     output_root = Path(args.output_root)
     run_root = Path(args.run_root)
-    manifest_paths = {
-        protocol: _run_builder(
-            config_path=config_path,
-            freeze_id=args.freeze_id,
-            protocol=protocol,
-            seed=args.seed,
-            output_root=output_root,
-            run_root=run_root,
-            mmseqs_executable=args.mmseqs_executable,
-            nucleotide_executable=args.nucleotide_executable,
-            audit_threads=args.audit_threads,
-        )
-        for protocol in GROUP_PROTOCOLS
-    }
+    if args.finalize_existing:
+        manifest_paths = {
+            protocol: output_root / args.freeze_id / protocol / "manifest.json"
+            for protocol in GROUP_PROTOCOLS
+        }
+        missing = [str(path) for path in manifest_paths.values() if not path.is_file()]
+        if missing:
+            raise ValueError(f"cannot finalize missing protocol manifests: {missing}")
+    else:
+        if shutil.which(args.mmseqs_executable) is None:
+            raise SystemExit(
+                f"[error] MMseqs2 executable not found: {args.mmseqs_executable}; "
+                "the scientific freeze cannot skip the homology gate"
+            )
+        if shutil.which(args.nucleotide_executable) is None:
+            raise SystemExit(
+                f"[error] nucleotide aligner not found: {args.nucleotide_executable}; "
+                "the scientific freeze cannot skip nucleotide nearest-neighbor mapping"
+            )
+        manifest_paths = {
+            protocol: _run_builder(
+                config_path=config_path,
+                freeze_id=args.freeze_id,
+                protocol=protocol,
+                seed=args.seed,
+                output_root=output_root,
+                run_root=run_root,
+                mmseqs_executable=args.mmseqs_executable,
+                nucleotide_executable=args.nucleotide_executable,
+                audit_threads=args.audit_threads,
+            )
+            for protocol in GROUP_PROTOCOLS
+        }
     manifests = {
         protocol: (load_dataset_manifest(path), path)
         for protocol, path in manifest_paths.items()

--- a/scripts/verify_dataset_freeze.py
+++ b/scripts/verify_dataset_freeze.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Verify a completed corrected dataset against its tracked release contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from scripts.freeze_corrected_datasets import (
+    load_and_validate_freeze,
+    validate_freeze_contract,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--freeze", type=Path, required=True)
+    parser.add_argument("--expected", type=Path, required=True)
+    args = parser.parse_args()
+
+    index = load_and_validate_freeze(args.freeze)
+    contract = json.loads(args.expected.read_text())
+    validate_freeze_contract(index, contract)
+    print(
+        f"[freeze] verified release={contract['release']} "
+        f"freeze_id={index['freeze_id']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dataset_freeze.py
+++ b/tests/test_dataset_freeze.py
@@ -9,7 +9,10 @@ import yaml
 
 from scripts.freeze_corrected_datasets import (
     build_freeze_index,
+    freeze_contract,
+    freeze_identity,
     load_and_validate_source_config,
+    validate_freeze_contract,
     validate_protocol_manifests,
 )
 
@@ -104,6 +107,32 @@ def test_freeze_index_binds_both_scientific_protocols(tmp_path):
     assert index["split_seed"] == 1337
     assert set(index["protocols"]) == {"genome", "genus"}
     assert index["protocols"]["genome"]["dataset_id"] == "genome-id"
+    assert index["schema"]["version"] == 2
+    assert index["freeze_id"] == freeze_identity(index)
+    assert not Path(index["config"]["path"]).is_absolute()
+    assert not Path(index["protocols"]["genome"]["manifest_path"]).is_absolute()
+
+    contract = freeze_contract(index, release="corrected-codonlm-v1")
+    validate_freeze_contract(index, contract)
+    contract["protocols"]["genome"]["dataset_id"] = "drifted"
+    with pytest.raises(ValueError, match="does not match"):
+        validate_freeze_contract(index, contract)
+
+    relocated = tmp_path / "relocated"
+    relocated.mkdir()
+    relocated_config = relocated / "sources.yaml"
+    relocated_config.write_bytes(config_path.read_bytes())
+    relocated_manifests = {}
+    for protocol in ("genome", "genus"):
+        path = relocated / f"{protocol}-manifest.json"
+        path.write_text(json.dumps(_protocol_manifest(protocol), sort_keys=True))
+        relocated_manifests[protocol] = (_protocol_manifest(protocol), path)
+    relocated_index = build_freeze_index(
+        config_path=relocated_config,
+        seed=1337,
+        manifests=relocated_manifests,
+    )
+    assert relocated_index["freeze_id"] == index["freeze_id"]
 
 
 def test_freeze_rejects_cross_protocol_source_drift(tmp_path):


### PR DESCRIPTION
## Summary
- migrate the aggregate dataset freeze to a location-independent schema v2 identity
- add a tracked corrected-codonlm-v1 approval contract for the existing genome/genus artifacts
- add fail-closed full-tree verification and metadata-only finalization for completed builds
- update the training tracks and dataset documentation with the approved portable freeze identity

The underlying genome and genus dataset identities are unchanged. Only the aggregate freeze identity changes because absolute storage paths are excluded from schema v2.

## Validation
- real 24-source local artifact tree verified against the tracked contract
- focused freeze, manifest, and evaluator tests: 18 passed
- full pytest suite: 281 passed, 1 skipped, 1 xpassed
- scoped Ruff checks passed

Tracks #92; does not close the training/revalidation epic.