### PR TITLE
Select corrected MPS runtime policy

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -3,8 +3,8 @@
 ## Status
 
 In progress. The corrected pipeline freeze, evaluator contracts, and generation
-protocol separation are complete. The program remains blocked on immutable training
-configs and the MPS policy gate.
+protocol separation are complete. The conservative corrected-data MPS policy is
+selected. The program remains blocked on immutable primary training configs.
 
 ## Phase 0: Close Pre-Training Gates
 
@@ -21,9 +21,12 @@ configs and the MPS policy gate.
 - [x] Resolve generation protocol issue #85 before generation comparisons.
 - [x] Implement and merge batch-aware memmap conversion with fixed/dynamic parity
   tests (#90).
-- [ ] Measure the merged #90 path on MPS and record useful-token throughput and
+- [x] Measure the merged #90 path on MPS and record useful-token throughput and
   memory evidence as part of the runtime policy gate.
-- [ ] Select the MPS runtime policy through an equal-token quality gate.
+- [x] Select the MPS runtime policy through the predeclared runtime/quality gate.
+  The compute candidates failed the 1.5x runtime entry threshold, so no candidate
+  entered equal-token quality validation and the reference compute policy was
+  retained with batch-aware mmap.
 - [ ] Add immutable corrected primary configs and config-contract tests.
 
 Exit gate: the frozen artifacts reproduce, all leakage gates pass, evaluator fixtures

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -2,8 +2,8 @@
 
 ## Status
 In progress. Engineering gates, the corrected pipeline freeze, and evaluator
-contracts are complete; full retraining remains blocked on runtime-policy selection
-and the immutable training configuration gate.
+contracts are complete; full retraining remains blocked on the immutable training
+configuration gate.
 
 ## Phase 1: Governance and CI
 - [x] Relabel legacy results and unsupported claims (#87).
@@ -70,9 +70,8 @@ Exit gate: all evaluators consume explicit frozen artifacts, reject incompatible
 inputs, preserve grouping, and emit machine-readable provenance.
 
 ## Phase 6: Train Corrected Models
-- [ ] Select the MPS runtime policy through the equal-token quality gate in the
-  optimized training validation track; record the selected policy without changing
-  architecture or objectives.
+- [x] Select the MPS runtime policy through the optimized training validation gate;
+  record the fail-closed reference policy without changing architecture or objectives.
 - [ ] Train genome-held-out models from random initialization at seeds `1337` and
   `2027` with matched non-PAD token exposure.
 - [ ] Run a separately labeled genus-held-out training protocol.
@@ -97,5 +96,5 @@ passing manifests, no invalid updates, and complete checkpoint/resume provenance
 ## Deferred Follow-Ups
 - [x] Separate raw, CDS-constrained, and guided generation protocols (#85).
 - [x] Implement batch-aware memmap conversion with fixed/dynamic parity tests (#90).
-- [ ] Record whether the merged batch-aware path improves useful-token throughput on
+- [x] Record whether the merged batch-aware path improves useful-token throughput on
   MPS without a memory regression before freezing the runtime policy.

--- a/conductor/tracks/optimized_training_validation_20260717/plan.md
+++ b/conductor/tracks/optimized_training_validation_20260717/plan.md
@@ -1,7 +1,20 @@
 # Optimized Training Quality Validation & Context Ablation Plan
 
 ## Status
-Planned.
+Corrected-data runtime decision complete. The original legacy Stage 2.6 paired
+fine-tuning experiment was not promoted into the corrected program.
+
+## Corrected-Data Disposition
+
+The frozen genome-held-out dataset was benchmarked on the target M2/8 GB host after
+the batch-aware mmap merge. Mmap was throughput-neutral and reduced dataset-loading
+RSS by 99.79%, so it was promoted. Checkpointing off at batch 4 reached only 1.31x
+the mmap reference and increased driver memory by about 47%; batch 8 was slower.
+Neither compute candidate met the predeclared 1.5x runtime entry gate, so spending
+training tokens on their quality phase could not promote them. The corrected program
+therefore retains batch 4, accumulation 32, activation checkpointing, AMP, MHA, and
+the separator mask, with batch-aware mmap enabled. Evidence is recorded in
+`docs/CORRECTED_MPS_RUNTIME_GATE.md`.
 
 ## Purpose
 Turn the July 2026 MPS throughput benchmark into a production training policy without

--- a/configs/corrected_mps_runtime_base.yaml
+++ b/configs/corrected_mps_runtime_base.yaml
@@ -1,0 +1,43 @@
+# Throughput/quality-gate base for the frozen genome-held-out corrected dataset.
+# This is not a full-training authorization or a scientific result config.
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.1
+label_smoothing: 0.05
+use_sdpa: true
+sep_mask_enabled: true
+transfer_from: null
+
+batch_size: 4
+grad_accum_steps: 32
+epochs: 1
+lr: 0.0003
+min_lr: 0.00003
+weight_decay: 0.05
+warmup_steps: 100
+optimizer: adamw
+scheduler: cosine
+early_stop_patience: 2
+
+seed: 1337
+dataloader_seed: 1337
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+
+out_dir: runs/corrected_mps_runtime_base/checkpoints
+scores_dir: runs/corrected_mps_runtime_base/scores

--- a/configs/corrected_mps_runtime_matrix.yaml
+++ b/configs/corrected_mps_runtime_matrix.yaml
@@ -1,0 +1,28 @@
+base_config: configs/corrected_mps_runtime_base.yaml
+warmup_steps: 20
+measure_steps: 100
+variants:
+  - name: reference_preloaded_b4_checkpoint
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: true
+      use_mmap: false
+  - name: reference_mmap_b4_checkpoint
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: true
+      use_mmap: true
+  - name: mmap_b4_no_checkpoint
+    overrides:
+      batch_size: 4
+      grad_accum_steps: 32
+      use_checkpoint: false
+      use_mmap: true
+  - name: mmap_b8_no_checkpoint
+    overrides:
+      batch_size: 8
+      grad_accum_steps: 16
+      use_checkpoint: false
+      use_mmap: true

--- a/docs/CORRECTED_MPS_RUNTIME_GATE.md
+++ b/docs/CORRECTED_MPS_RUNTIME_GATE.md
@@ -1,0 +1,48 @@
+# Corrected MPS Runtime Gate
+
+## Decision
+
+The corrected primary training policy retains batch 4, gradient accumulation 32,
+activation checkpointing, FP16 MPS autocast, standard multi-head SDPA, and the
+explicit separator mask. It adopts the merged batch-aware NPY mmap loader.
+
+No optimized compute candidate entered the equal-token quality phase. The
+predeclared runtime gate required at least a 1.5x speedup before quality promotion:
+checkpointing off at batch 4 reached only 1.31x and increased MPS driver memory by
+about 47%; batch 8 was slower than the reference and approached the unified-memory
+pressure regime. Retaining the reference is the fail-closed outcome, not evidence
+that checkpointing improves model quality.
+
+## Target And Protocol
+
+- Hardware: Apple M2 with 8 GB unified memory.
+- Software: macOS 26.5.1, PyTorch 2.12.0, MPS backend.
+- Dataset: frozen corrected genome holdout
+  `da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9`.
+- Model: random-initialized basic 10-layer, 8-head, width-384 CodonLM.
+- Objective: next-token prediction only.
+- Exposure: 20 warmup and 100 measured microbatches, seed 1337.
+- Every variant used effective sequence batch 128.
+
+```bash
+caffeinate -i python -m scripts.benchmark_training_speed \
+  --matrix configs/corrected_mps_runtime_matrix.yaml \
+  --out runs/corrected_mps_runtime_gate
+```
+
+## Results
+
+| Variant | Useful tok/s | Dataset RSS delta | Peak MPS driver | Estimated epoch |
+| --- | ---: | ---: | ---: | ---: |
+| Preloaded, b4, checkpoint | 2,892 | 508.6 MB | 2.45 GB | 142.1 min |
+| Mmap, b4, checkpoint | 2,900 | 1.1 MB | 2.45 GB | 141.7 min |
+| Mmap, b4, no checkpoint | 3,807 | 0.6 MB | 3.59 GB | 107.9 min |
+| Mmap, b8, no checkpoint | 1,105 | 0.8 MB | 4.71 GB | 375.9 min |
+
+Batch-aware mmap was throughput-neutral (`1.003x`) and reduced dataset-loading RSS
+by `99.79%`. This is the only promoted change. The raw machine-readable evidence is
+stored in `docs/benchmarks/corrected_mps_runtime_gate.json`.
+
+The epoch estimate is a throughput projection, not a completed training epoch. Full
+quality measurement begins with the bounded corrected-data pilot after immutable
+primary configs pass their contract tests.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -43,6 +43,16 @@ This document captures the end-to-end journey of Genomics-LM. It details how we 
 * Added fail-closed verification of the full local source and artifact tree against
   that contract, plus a metadata-only finalization path for completed dataset builds.
 
+## 2026-07-22: Corrected MPS Runtime Policy
+
+* Benchmarked preloaded and batch-aware mmap loading plus checkpoint/batch variants
+  on the frozen corrected genome dataset using the 10L8H width-384 primary family.
+* Batch-aware mmap preserved useful-token throughput while reducing dataset-loading
+  RSS from about 509 MB to 1 MB.
+* Checkpointing off at batch 4 improved throughput by only 1.31x and increased MPS
+  driver memory by about 47%; batch 8 slowed sharply. Both failed the predeclared
+  1.5x runtime entry gate, so the reference compute policy was retained with mmap.
+
 ---
 
 ## 1. Stage 1: Toy Scale (The Grammar School)

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -207,6 +207,12 @@ python -m scripts.benchmark_training_speed \
 For a materially different dataset or model, copy the Stage 2.6 matrix manifest,
 point `base_config` at the new training YAML, and adjust its named overrides.
 
+The frozen corrected genome dataset was measured separately using
+`configs/corrected_mps_runtime_matrix.yaml`. The accepted policy and raw evidence are
+documented in `docs/CORRECTED_MPS_RUNTIME_GATE.md`: batch-aware mmap is enabled, but
+batch 4, accumulation 32, and activation checkpointing are retained because the
+compute candidates did not meet the predeclared runtime promotion threshold.
+
 When resuming mid-epoch, do not force a new sweep unless needed. If `--force`
 selects a different `batch_size` or `grad_accum_steps` than the checkpoint used,
 the trainer restores model/optimizer state but ignores the old mid-epoch skip

--- a/docs/benchmarks/corrected_mps_runtime_gate.json
+++ b/docs/benchmarks/corrected_mps_runtime_gate.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-07-22",
+  "environment": {
+    "device": "Apple M2",
+    "memory_bytes": 8589934592,
+    "macos": "26.5.1 (25F80)",
+    "pytorch": "2.12.0",
+    "backend": "mps"
+  },
+  "provenance": {
+    "git_base_sha": "1899cbeafed4fc69464fb41c551b04cf4dec30e4",
+    "dataset_freeze_id": "1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249",
+    "genome_dataset_id": "da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9",
+    "base_config_sha256": "431c1d7aeff1fc3dac7ceb97a387aec9d44bf36602ec04d51f26b9f7d299c782",
+    "matrix_config_sha256": "3092bd24a496fd4b7646c65d14baa749381d0969bea79d08594475c1a60510d5"
+  },
+  "protocol": {
+    "warmup_microbatches": 20,
+    "measured_microbatches": 100,
+    "seed": 1337,
+    "effective_sequence_batch": 128,
+    "command": "caffeinate -i python -m scripts.benchmark_training_speed --matrix configs/corrected_mps_runtime_matrix.yaml --out runs/corrected_mps_runtime_gate"
+  },
+  "results": [
+    {
+      "name": "reference_preloaded_b4_checkpoint",
+      "batch_size": 4,
+      "grad_accum_steps": 32,
+      "use_checkpoint": true,
+      "use_mmap": false,
+      "non_pad_tokens_per_sec": 2891.8848963944088,
+      "padding_fraction": 0.24721679687499998,
+      "dataset_rss_delta_bytes": 508624896,
+      "process_peak_rss_bytes": 718536704,
+      "mps_peak_allocated_bytes": 1158596096,
+      "mps_peak_driver_bytes": 2450194432,
+      "estimated_epoch_seconds": 8527.401066600652
+    },
+    {
+      "name": "reference_mmap_b4_checkpoint",
+      "batch_size": 4,
+      "grad_accum_steps": 32,
+      "use_checkpoint": true,
+      "use_mmap": true,
+      "non_pad_tokens_per_sec": 2899.941277953018,
+      "padding_fraction": 0.24721679687499998,
+      "dataset_rss_delta_bytes": 1064960,
+      "process_peak_rss_bytes": 512704512,
+      "mps_peak_allocated_bytes": 1158596096,
+      "mps_peak_driver_bytes": 2450194432,
+      "estimated_epoch_seconds": 8503.710932866525
+    },
+    {
+      "name": "mmap_b4_no_checkpoint",
+      "batch_size": 4,
+      "grad_accum_steps": 32,
+      "use_checkpoint": false,
+      "use_mmap": true,
+      "non_pad_tokens_per_sec": 3807.4311184158473,
+      "padding_fraction": 0.24721679687499998,
+      "dataset_rss_delta_bytes": 557056,
+      "process_peak_rss_bytes": 435666944,
+      "mps_peak_allocated_bytes": 405809152,
+      "mps_peak_driver_bytes": 3591061504,
+      "estimated_epoch_seconds": 6476.876818788087
+    },
+    {
+      "name": "mmap_b8_no_checkpoint",
+      "batch_size": 8,
+      "grad_accum_steps": 16,
+      "use_checkpoint": false,
+      "use_mmap": true,
+      "non_pad_tokens_per_sec": 1104.8280140517288,
+      "padding_fraction": 0.23943603515625,
+      "dataset_rss_delta_bytes": 819200,
+      "process_peak_rss_bytes": 457621504,
+      "mps_peak_allocated_bytes": 425416704,
+      "mps_peak_driver_bytes": 4713021440,
+      "estimated_epoch_seconds": 22551.15757893287
+    }
+  ],
+  "acceptance": {
+    "minimum_candidate_speedup": 1.5,
+    "mmap_throughput_ratio_vs_preloaded": 1.0027858583059976,
+    "mmap_dataset_rss_reduction_fraction": 0.9979061976549414,
+    "b4_no_checkpoint_speedup_vs_mmap_reference": 1.3129338677862468,
+    "b4_no_checkpoint_driver_memory_ratio": 1.4656230775403214,
+    "b8_no_checkpoint_speedup_vs_mmap_reference": 0.38098289177482725,
+    "quality_gate_status": "not_entered_candidate_failed_runtime_gate"
+  },
+  "selected_policy": {
+    "batch_size": 4,
+    "grad_accum_steps": 32,
+    "use_checkpoint": true,
+    "use_mmap": true,
+    "amp": true,
+    "n_kv_head": null,
+    "use_sdpa": true,
+    "sep_mask_enabled": true,
+    "bucket_batching": false,
+    "decision": "reference_runtime_retained_with_batch_aware_mmap"
+  }
+}

--- a/scripts/benchmark_training_speed.py
+++ b/scripts/benchmark_training_speed.py
@@ -115,6 +115,10 @@ def write_results(path: str | Path, results: list[dict[str, Any]]) -> None:
         "wall_sec_per_optimizer_step",
         "peak_allocated_bytes",
         "peak_driver_bytes",
+        "process_rss_start_bytes",
+        "process_rss_after_dataset_bytes",
+        "dataset_rss_delta_bytes",
+        "process_peak_rss_bytes",
         "error",
     ]
     with (out_dir / "results.csv").open("w", newline="") as handle:

--- a/scripts/optimize_train_batching.py
+++ b/scripts/optimize_train_batching.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import json
 import os
+import resource
 import subprocess
 import sys
 import tempfile
@@ -38,6 +39,11 @@ OOM_PATTERNS = (
     "allocation",
     "failed to allocate",
 )
+
+
+def _process_max_rss_bytes() -> int:
+    raw = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return raw if sys.platform == "darwin" else raw * 1024
 
 
 def load_yaml(path: str | Path) -> dict[str, Any]:
@@ -227,7 +233,12 @@ def run_candidate_benchmark(
     train_paths = _path_list(cfg.get("train_npz", cfg.get("train_paths")))
     if not train_paths:
         raise ValueError("Config must define train_npz or train_paths")
-    train_ds, val_ds = build_codon_lm_datasets(train_paths, train_paths, use_mmap=bool(cfg.get("use_mmap", False)))
+    val_paths = _path_list(cfg.get("val_npz", cfg.get("val_paths"))) or train_paths
+    rss_start_bytes = _process_max_rss_bytes()
+    train_ds, val_ds = build_codon_lm_datasets(
+        train_paths, val_paths, use_mmap=bool(cfg.get("use_mmap", False))
+    )
+    rss_after_dataset_bytes = _process_max_rss_bytes()
     loader, _, _, _ = build_codon_lm_dataloaders(train_ds, val_ds, cfg)
     loader_iter = iter(loader)
 
@@ -342,6 +353,7 @@ def run_candidate_benchmark(
     tokens_per_sec = total_tokens / measured
     non_pad_tokens_per_sec = non_pad_tokens / measured
     train_len = len(train_ds)
+    process_peak_rss_bytes = _process_max_rss_bytes()
     return {
         "status": "ok",
         "device": str(device),
@@ -361,6 +373,10 @@ def run_candidate_benchmark(
         "wall_sec_per_optimizer_step": measured / max(optimizer_steps, 1),
         "peak_allocated_bytes": int(measured_stats["peak_allocated_bytes"]),
         "peak_driver_bytes": int(measured_stats["peak_driver_bytes"]),
+        "process_rss_start_bytes": rss_start_bytes,
+        "process_rss_after_dataset_bytes": rss_after_dataset_bytes,
+        "dataset_rss_delta_bytes": max(0, rss_after_dataset_bytes - rss_start_bytes),
+        "process_peak_rss_bytes": process_peak_rss_bytes,
         "amp_requested": bool(cfg.get("amp", True)),
         "amp_active": amp and mps_autocast_ok,
         "avg_step_ms": (sum(times) / max(len(times), 1)) * 1000.0,

--- a/tests/test_batch_optimizer.py
+++ b/tests/test_batch_optimizer.py
@@ -169,6 +169,8 @@ def test_candidate_benchmark_counts_non_pad_tokens_and_partial_step(tmp_path):
 
     assert result["status"] == "ok"
     assert result["optimizer_steps"] == 2
+    assert result["process_peak_rss_bytes"] >= result["process_rss_start_bytes"]
+    assert result["dataset_rss_delta_bytes"] >= 0
     assert result["processed_tokens"] == 30
     assert result["non_pad_tokens"] == 24
     assert result["padding_fraction"] == pytest.approx(0.2)

--- a/tests/test_corrected_mps_runtime_policy.py
+++ b/tests/test_corrected_mps_runtime_policy.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_runtime_matrix_preserves_model_objective_and_effective_batch():
+    base = yaml.safe_load((ROOT / "configs/corrected_mps_runtime_base.yaml").read_text())
+    matrix = yaml.safe_load(
+        (ROOT / "configs/corrected_mps_runtime_matrix.yaml").read_text()
+    )
+
+    assert base["dataset_manifest"].endswith(
+        "corrected-codonlm-v1/genome/manifest.json"
+    )
+    assert (base["n_layer"], base["n_head"], base["n_embd"]) == (10, 8, 384)
+    assert base["transfer_from"] is None
+    assert base["device"] == "mps"
+
+    permitted = {"batch_size", "grad_accum_steps", "use_checkpoint", "use_mmap"}
+    for variant in matrix["variants"]:
+        overrides = variant["overrides"]
+        assert set(overrides) <= permitted
+        assert overrides["batch_size"] * overrides["grad_accum_steps"] == 128
+
+
+def test_recorded_runtime_policy_applies_predeclared_gate():
+    evidence = json.loads(
+        (ROOT / "docs/benchmarks/corrected_mps_runtime_gate.json").read_text()
+    )
+    acceptance = evidence["acceptance"]
+    policy = evidence["selected_policy"]
+
+    assert acceptance["mmap_throughput_ratio_vs_preloaded"] >= 0.95
+    assert acceptance["mmap_dataset_rss_reduction_fraction"] >= 0.95
+    assert acceptance["b4_no_checkpoint_speedup_vs_mmap_reference"] < acceptance[
+        "minimum_candidate_speedup"
+    ]
+    assert acceptance["b8_no_checkpoint_speedup_vs_mmap_reference"] < 1.0
+    assert acceptance["quality_gate_status"].startswith("not_entered")
+    assert policy == {
+        "batch_size": 4,
+        "grad_accum_steps": 32,
+        "use_checkpoint": True,
+        "use_mmap": True,
+        "amp": True,
+        "n_kv_head": None,
+        "use_sdpa": True,
+        "sep_mask_enabled": True,
+        "bucket_batching": False,
+        "decision": "reference_runtime_retained_with_batch_aware_mmap",
+    }
+
+
+def test_recorded_ratios_match_raw_results():
+    evidence = json.loads(
+        (ROOT / "docs/benchmarks/corrected_mps_runtime_gate.json").read_text()
+    )
+    results = {row["name"]: row for row in evidence["results"]}
+    reference = results["reference_mmap_b4_checkpoint"]
+    preloaded = results["reference_preloaded_b4_checkpoint"]
+    no_checkpoint = results["mmap_b4_no_checkpoint"]
+
+    assert evidence["acceptance"]["mmap_throughput_ratio_vs_preloaded"] == pytest.approx(
+        reference["non_pad_tokens_per_sec"] / preloaded["non_pad_tokens_per_sec"]
+    )
+    assert evidence["acceptance"][
+        "b4_no_checkpoint_speedup_vs_mmap_reference"
+    ] == pytest.approx(
+        no_checkpoint["non_pad_tokens_per_sec"]
+        / reference["non_pad_tokens_per_sec"]
+    )


### PR DESCRIPTION
## Summary
- benchmark the merged batch-aware mmap loader and checkpoint/batch variants on the frozen corrected genome dataset using Apple M2 MPS
- add process RSS evidence to the isolated benchmark harness and load the real validation split instead of a second training copy
- promote batch-aware mmap while retaining the fail-closed batch 4, accumulation 32, activation-checkpointed compute policy
- record machine-readable evidence, a human-readable decision report, config contracts, and track status

Checkpointing off at batch 4 reached 1.31x, below the predeclared 1.5x runtime entry gate, and raised driver memory about 47%. Batch 8 was slower and reached about 4.7 GB driver memory. Neither candidate could enter the equal-token quality phase, so the reference compute policy remains selected.

## Validation
- full corrected MPS matrix completed outside the sandbox on Apple M2/8 GB
- focused runtime/mmap tests: 21 passed
- full pytest suite: 284 passed, 1 skipped, 1 xpassed
- scoped Ruff checks passed

Tracks #92; does not close the training/revalidation epic.