### PR TITLE
Expand corrected training and critic phases

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -2,123 +2,175 @@
 
 ## Status
 
-In progress. The corrected pipeline freeze, evaluator contracts, and generation
-protocol separation are complete. The conservative corrected-data MPS policy is
-selected. The program remains blocked on immutable primary training configs.
+In progress. Dataset, evaluator, generation-protocol, and MPS runtime gates are
+complete. Immutable primary configs are the final prerequisite before the bounded
+pilot. Internal CodonLM extensions and the external ProteinCritic are gated later and
+cannot be silently enabled in the primary run.
 
-## Phase 0: Close Pre-Training Gates
+## Phase 0: Freeze Primary Contracts
 
-- [x] Pin the intended 24-source GBFF inventory by explicit assembly ID, byte size,
-  and SHA-256 digest.
-- [x] Add a fail-closed command that builds genome/genus protocols, validates their
-  shared source/vocabulary/packing contract, and emits a content-addressed freeze
-  index.
-- [x] Complete the local Phase 4 build of immutable
-  genome-held-out and genus-held-out datasets.
-- [x] Record source, split, fragment, chunk, packed-array, vocabulary, and audit
-  hashes plus count summaries.
-- [x] Complete frozen-manifest evaluator fixtures and provenance validation.
-- [x] Resolve generation protocol issue #85 before generation comparisons.
-- [x] Implement and merge batch-aware memmap conversion with fixed/dynamic parity
-  tests (#90).
-- [x] Measure the merged #90 path on MPS and record useful-token throughput and
-  memory evidence as part of the runtime policy gate.
-- [x] Select the MPS runtime policy through the predeclared runtime/quality gate.
-  The compute candidates failed the 1.5x runtime entry threshold, so no candidate
-  entered equal-token quality validation and the reference compute policy was
-  retained with batch-aware mmap.
-- [ ] Add immutable corrected primary configs and config-contract tests.
+- [x] Freeze the 24-source genome/genus datasets, vocabulary, packing, leakage
+  reports, evaluator contracts, and generation protocols.
+- [x] Select the corrected MPS policy: batch 4, accumulation 32, checkpointing, AMP,
+  MHA/SDPA, separator mask, and batch-aware mmap.
+- [ ] Add immutable genome-seed-1337, genome-seed-2027, and genus primary configs.
+- [ ] Pin the training-token budget, optimizer/scheduler, validation/checkpoint
+  cadence, output naming, and pilot limits.
+- [ ] Add config-contract tests requiring random initialization and rejecting shape,
+  offset, termination, replay, critic/energy, RoPE, SwiGLU, GQA, or other undeclared
+  primary objectives and architectures.
 
-Exit gate: the frozen artifacts reproduce, all leakage gates pass, evaluator fixtures
-pass, MPS preflight passes, and no unresolved semantic choice can change the training
-stream.
+Exit gate: no unresolved choice can alter the primary training stream, objective,
+architecture, exposure, or provenance.
 
-## Phase 1: Train the Primary Basic Model
+## Phase 1: Run the Bounded Primary Pilot
 
-- [ ] Run a bounded end-to-end pilot from random initialization on the frozen
-  genome-held-out dataset; verify loss scale, token counters, validation, checkpoint,
-  resume, memory, and wall-time estimates.
+- [ ] Train from random initialization on a bounded portion of the frozen
+  genome-held-out stream using the exact primary model and runtime policy.
+- [ ] Verify initial loss scale, finite gradients, committed non-PAD tokens,
+  optimizer/scheduler counters, validation, and wall-time estimates.
+- [ ] Verify `last`/`best` checkpoint creation and exact resume without replaying or
+  omitting committed updates.
+- [ ] Record peak host/MPS memory, throughput, non-finite groups, termination reason,
+  and resolved provenance.
+- [ ] Approve the immutable configs for full training or revise them through a new
+  versioned config contract and repeat the pilot.
+
+Exit gate: pilot and resume complete on MPS without OOM, non-finite update,
+counter/provenance mismatch, or an unexplained loss anomaly.
+
+## Phase 2: Train the Primary Basic Model
+
 - [ ] Train the genome-held-out primary model at seed `1337`.
 - [ ] Train the identical genome-held-out primary model at seed `2027`.
-- [ ] Train the separately labeled genus-held-out primary model from random
+- [ ] Train the separately labelled genus-held-out primary model from random
   initialization.
-- [ ] Verify matched non-PAD exposure and config identity across comparable runs.
+- [ ] Verify matched architecture, objective, non-PAD exposure, and config identity
+  across comparable runs.
 - [ ] Archive complete run manifests, checkpoints, logs, and failure telemetry.
 
-Exit gate: all declared primary runs complete without leakage, OOM, non-finite update,
-counter mismatch, or provenance failure.
+Exit gate: all primary runs finish without leakage, OOM, invalid update, counter
+mismatch, or provenance failure.
 
-## Phase 2: Evaluate and Decide on the Primary Model
+## Phase 3: Evaluate and Decide on the Primary Model
 
-- [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test tokens.
-- [ ] Report per-seed and aggregate loss, perplexity, bits/codon, and improvement over
-  the best simple baseline.
+- [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test
+  tokens; report loss, perplexity, bits/codon, and improvement over the best baseline.
 - [ ] Extract causal embeddings with dataset/checkpoint/vocabulary/code provenance.
 - [ ] Run EC, essentiality, AMR, and DNA-shape evaluations with controlled splits and
   shared controls.
-- [ ] Run generated-sequence memorization, nucleotide-neighbor, and protein-neighbor
-  audits using the separated generation protocols.
-- [ ] Publish the corrected primary report with confidence intervals and limitations.
-- [ ] Record a go/no-go decision for extension training.
+- [ ] Run raw and syntax-constrained generation with memorization and nucleotide/
+  protein nearest-neighbor audits; do not use critic scores for promotion yet.
+- [ ] Publish per-seed and aggregate primary results with confidence intervals and
+  limitations, then record a go/no-go decision for extensions.
 
-Exit gate: the primary model outperforms the best simple intrinsic baseline and the
-report satisfies the corrected promotion criteria. Otherwise pause and audit.
+Exit gate: the basic model outperforms the best simple intrinsic baseline and the
+corrected report passes its promotion criteria. Otherwise pause and audit.
 
-## Phase 3: Multi-Offset `n+x` Ablation
+## Phase 4: Revalidate the External ProteinCritic
 
-- [ ] Predeclare offsets, weights, initialization policy, token budget, metrics, and
-  acceptance thresholds.
-- [ ] Train matched multi-offset runs without changing the primary architecture or
-  data split.
-- [ ] Report next-token and per-offset losses separately.
-- [ ] Rerun intrinsic, long-range, downstream, termination, and memory evaluations.
-- [ ] Promote or reject the extension using the specification gates.
+- [ ] Select and freeze one critic architecture rather than mixing historical
+  average-pooled, structural-transfer, and bidirectional variants.
+- [ ] Freeze protein sources, label definitions, task vocabularies, preprocessing,
+  and train/validation/test artifacts with exact provenance.
+- [ ] Split translated proteins by sequence-homology clusters and report label/class
+  balance, missing classes, cluster thresholds, and cross-split nearest neighbors.
+- [ ] Retrain Pfam-family, EC-function, stability, and declared structural/protein-
+  type heads under the corrected split; do not initialize from a holdout-exposed
+  critic unless the transfer protocol proves compatibility and isolation.
+- [ ] Calibrate every probability-producing head and report class-aware metrics,
+  confidence intervals, reliability, and generated-protein OOD behavior.
+- [ ] Version the passing critic checkpoint and bind it to its dataset, labels,
+  architecture, and calibration artifacts.
 
-Exit gate: any accepted long-range gain is replicated and does not materially degrade
-next-token loss, termination, stability, or runtime reliability.
+Exit gate: the corrected critic is suitable for its declared ranking or calibrated-
+probability use. Until then, legacy critic outputs are exploratory only and cannot
+support promotion, stability, family, function, or guidance claims.
 
-## Phase 4: Termination and Replay Ablation
+## Phase 5: Multi-Offset `n+x` Ablation
 
-- [ ] Predeclare termination buckets, replay construction, decoding conditions, and
-  matched prompt/sample seeds.
-- [ ] Train the termination-head condition without replay.
-- [ ] Train the generated-prefix replay condition if the head-only result is
-  insufficient.
-- [ ] Compare natural, syntax-constrained, replay-trained, and decoder-biased behavior
-  without conflating them.
+- [ ] Predeclare offsets (including whether `n+2` is used), weights, projection-head
+  initialization, backbone-freeze/joint-training policy, token budget, and metrics.
+- [ ] State separately whether offset logits are auxiliary training signals or are
+  consumed by a merged-prior decoder at inference.
+- [ ] Train matched multi-offset runs from the corrected primary checkpoint without
+  changing data splits or the main next-token head.
+- [ ] Report main next-token loss and every offset loss separately; rerun long-range,
+  downstream, termination, runtime, and memory evaluations.
+- [ ] Promote or reject the extension using replicated predeclared gates.
+
+Exit gate: a replicated long-range/downstream gain does not materially degrade
+next-token quality, termination, memory, or runtime reliability.
+
+## Phase 6: Termination and Replay Ablation
+
+- [ ] Predeclare distance buckets, replay construction, matched prompts/seeds,
+  decoding conditions, token budget, and acceptance thresholds.
+- [ ] Train the termination-head condition without replay from the corrected primary
+  checkpoint.
+- [ ] Add generated-prefix replay only if the head-only condition is insufficient.
+- [ ] Compare natural, syntax-constrained, replay-trained, and decoder-biased
+  behavior without conflating training and inference interventions.
 - [ ] Report length distributions, natural-stop, early-stop, and hard-cap rates plus
-  primary loss and sequence-quality controls.
-- [ ] Promote or reject the termination extension.
+  primary loss, sequence controls, runtime, and memorization.
 
-Exit gate: natural completion improves without forced-stop dependence, short-sequence
-collapse, or material primary-quality regression.
+Exit gate: natural completion improves without forced-stop dependence,
+short-sequence collapse, or material primary-quality regression.
 
-## Phase 5: Biophysical Shape-Guidance Ablation
+## Phase 7: Biophysical Shape-Guidance Ablation
 
-- [ ] Freeze and document the shape-encoder artifact, targets, training sources, and
-  relationship to all heldout groups.
-- [ ] Train the frozen-encoder condition from the corrected primary checkpoint.
-- [ ] Train the jointly unfrozen condition with recorded discriminative learning
-  rates and matched token exposure.
+- [ ] Freeze the shape-encoder artifact, targets, training sources, and relationship
+  to every CodonLM and ProteinCritic heldout group.
+- [ ] Train the corrected primary plus a frozen shape encoder.
+- [ ] Train the corrected primary plus a jointly unfrozen encoder using recorded
+  discriminative learning rates and matched token exposure.
 - [ ] Run grouped DNA-shape evaluation with one-hot, random-model, 5-mer, and 7-mer
   controls on shared folds.
 - [ ] Rerun synonymous and de novo generation with matched seeds, confidence
-  intervals, absolute effects, and memorization audits.
+  intervals, absolute effects, and memorization audits. Use corrected critic scores
+  only if Phase 4 passed.
 - [ ] Promote or reject shape guidance independently of termination and multi-offset
   objectives.
 
 Exit gate: replicated shape-guided improvement survives sequence controls and does
-not depend on leakage, unmatched decoding, or proxy-only interpretation.
+not depend on leakage, unmatched decoding, an invalid critic, or proxy-only claims.
 
-## Phase 6: Combined Candidate and Final Report
+## Phase 8: Combined Candidate and Generation Interventions
 
-- [ ] Combine only independently promoted extensions and predeclare the rationale.
-- [ ] Train a matched combined candidate; do not replace independent ablations.
-- [ ] Rerun the complete intrinsic, downstream, generation, memorization, runtime, and
-  provenance suite.
-- [ ] Publish a versioned comparison covering the basic model and every extension.
+- [ ] Combine only independently promoted internal extensions and predeclare their
+  initialization, objectives, weights, and rationale.
+- [ ] Train a matched combined candidate; retain every independent ablation.
+- [ ] Evaluate raw, syntax-constrained, decoder-biased, ReD, corrected-critic-guided,
+  and any EBM-guided generation as distinct protocols with matched seeds and budgets.
+- [ ] Treat ProteinCritic, EBM, ReD, and decoder constraints as external inference
+  interventions unless a separately declared training objective explicitly uses one.
+- [ ] Rerun intrinsic, downstream, generation, memorization, runtime, and provenance
+  suites for the combined candidate.
+
+Exit gate: each combined gain remains attributable, and no external intervention is
+misreported as an intrinsic property of the generator.
+
+## Phase 9: Publish the Corrected Program
+
+- [ ] Publish a versioned comparison of the primary, each internal extension, the
+  corrected ProteinCritic, the combined candidate, and external interventions.
+- [ ] Report exact commands, hashes, seeds, token exposure, confidence intervals,
+  absolute effects, failed gates, and limitations.
 - [ ] Update repository headline tables while preserving a separate legacy section.
-- [ ] Close or create follow-up issues based on failed gates and remaining limitations.
+- [ ] Record final promotion/rejection decisions and create follow-up issues for
+  unresolved failures.
 
-Exit gate: the selected model is supported by corrected replicated evidence, and each
-claimed gain can be attributed to a tested extension.
+Exit gate: corrected evidence supports every selected component, and each claimed
+gain is traceable to a controlled experiment.
+
+## Global Rules
+
+- No legacy checkpoint initializes corrected primary training.
+- Implemented code is not enabled unless its phase and immutable config declare it.
+- No existing legacy checkpoint is treated as an all-extension model: the replay
+  lineage has offset plus termination/replay components, while the shape-guided
+  lineage has shape plus termination but no offset heads.
+- ProteinCritic is external to CodonLM and does not block primary training, but its
+  corrected gate blocks critic-based evaluation, promotion, and guidance claims.
+- A failed primary or extension gate stops dependent work; later components cannot
+  conceal the failure.

--- a/conductor/tracks/corrected_model_training_20260721/spec.md
+++ b/conductor/tracks/corrected_model_training_20260721/spec.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Planned. Dataset freeze and evaluator validation are prerequisites; no full training
-run is authorized until their gates pass.
+In progress. Dataset, evaluator, generation-protocol, and MPS gates pass. Immutable
+primary configs and a bounded pilot remain prerequisites for full training.
 
 ## Objective
 
@@ -27,6 +27,9 @@ which models are trained, how they are compared, and when an extension is promot
    than merely forcing a decoder stop?
 5. Does DNA-shape conditioning add information beyond codon identity and local
    nucleotide-context controls?
+6. Can a homology-controlled, calibrated ProteinCritic provide valid external
+   family, function, stability, or structural ranking on heldout and generated
+   proteins?
 
 ## Prerequisite Gates
 
@@ -39,8 +42,10 @@ Full training is blocked until all of the following are true:
   homology reports complete under the declared grouped-holdout policy.
 - Every final evaluator consumes explicit frozen artifacts and emits provenance.
 - CPU integration and MPS train/save/resume preflights pass.
-- The MPS runtime policy is selected by an equal-token quality comparison without
-  changing model architecture or objectives.
+- The fail-closed corrected MPS runtime policy is selected without changing model
+  architecture or objectives.
+- Immutable primary configs exclude every optional internal head and external
+  guidance objective, and a bounded MPS pilot passes.
 
 ## Stage 1: Primary Basic CodonLM
 
@@ -56,8 +61,7 @@ next-codon prediction.
   shorter context.
 - Dropout 0.1, including attention-probability dropout during training.
 - Vocabulary resolved exclusively from the frozen tokenizer artifact.
-- Standard multi-head or grouped-query attention selected only through the MPS
-  runtime/quality gate.
+- Standard multi-head attention under the selected MPS runtime policy.
 
 ### Excluded from the primary model
 
@@ -94,7 +98,19 @@ Failure to outperform the best simple intrinsic baseline pauses extension traini
 and triggers a data, objective, optimization, and evaluation audit. Extensions must
 not be used to conceal a failed primary model.
 
-## Stage 3: Multi-Offset Long-Range Extension
+## Stage 3: Corrected External ProteinCritic
+
+ProteinCritic is a separate bidirectional protein-sequence classifier, not a CodonLM
+head. Its family, function, stability, and structural outputs may be used only after
+its protein sources, labels, homology-clustered splits, architecture, checkpoint, and
+calibration artifacts are frozen and validated.
+
+Retrain one selected critic architecture under this protocol. Report class balance,
+cluster leakage, per-head discrimination, calibration, confidence intervals, and
+out-of-distribution behavior on generated proteins. Legacy critic checkpoints remain
+exploratory and cannot decide corrected CodonLM promotion.
+
+## Stage 4: Multi-Offset Long-Range Extension
 
 Multi-offset heads predict future tokens such as `n+4`, `n+8`, `n+16`, and `n+32`
 from the causal hidden state. They are auxiliary training signals intended to retain
@@ -109,9 +125,13 @@ Promotion requires:
 - Primary next-token validation loss no more than 2% worse than the matched control.
 - No termination, stability, memory, or non-finite-update regression.
 - Improvement with confidence intervals in at least one predeclared long-range or
-  downstream metric.
+downstream metric.
 
-## Stage 4: Termination and Length Extension
+The protocol must state whether `n+2` is included and whether offset distributions
+are auxiliary losses only or are consumed by an inference-time merged-prior decoder.
+These heads do not automatically change ordinary next-token sampling.
+
+## Stage 5: Termination and Length Extension
 
 The termination head predicts distance-to-stop categories. Generated-prefix replay
 may expose it to off-distribution states encountered during autoregressive decoding.
@@ -129,7 +149,7 @@ Promotion requires improved natural terminal-stop and hard-cap rates without sho
 peptide collapse, material perplexity regression, or degradation in sequence-quality
 controls.
 
-## Stage 5: Biophysical Shape-Guided Extension
+## Stage 6: Biophysical Shape-Guided Extension
 
 The biophysical extension conditions causal token representations on a nucleotide
 shape encoder. It tests whether explicit local physical descriptors add information
@@ -151,6 +171,22 @@ corrected held-out claims.
 Promotion requires paired confidence intervals and improvement over one-hot codon,
 random-model, 5-mer, and 7-mer controls under gene/genome-grouped folds. Parameter
 movement alone is not evidence of useful co-adaptation.
+
+## Stage 7: Combined Model and External Generation
+
+Only independently promoted internal extensions may be combined. Raw sampling,
+syntax constraints, decoder bias, ReD, ProteinCritic guidance, and EBM guidance are
+separate inference protocols with matched prompts, seeds, and budgets. External
+guidance is not an intrinsic generator improvement and cannot be reported as one.
+
+## Legacy Capability Inventory
+
+- The historical separate-heads replay lineage contains multi-offset heads,
+  termination prediction, and replay training, but no biophysical shape encoder.
+- The historical shape-guided lineage contains shape conditioning and termination
+  prediction, but no multi-offset heads.
+- No historical checkpoint is an approved all-extension model, and none may
+  initialize the corrected primary result.
 
 ## Artifact Contract
 

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -69,9 +69,11 @@ audits pass. Any later semantic change creates a new dataset version.
 Exit gate: all evaluators consume explicit frozen artifacts, reject incompatible
 inputs, preserve grouping, and emit machine-readable provenance.
 
-## Phase 6: Train Corrected Models
+## Phase 6: Freeze Configs, Pilot, and Train the Primary Models
 - [x] Select the MPS runtime policy through the optimized training validation gate;
   record the fail-closed reference policy without changing architecture or objectives.
+- [ ] Freeze immutable basic-model configs and pass a bounded MPS train/checkpoint/
+  resume pilot before authorizing full training.
 - [ ] Train genome-held-out models from random initialization at seeds `1337` and
   `2027` with matched non-PAD token exposure.
 - [ ] Run a separately labeled genus-held-out training protocol.
@@ -81,13 +83,49 @@ inputs, preserve grouping, and emit machine-readable provenance.
 Exit gate: two genome-held-out seeds and the declared genus-held-out run finish with
 passing manifests, no invalid updates, and complete checkpoint/resume provenance.
 
-## Phase 7: Evaluate and Publish
+## Phase 7: Evaluate and Promote the Primary Model
 - [ ] Produce the uniform/unigram/bigram/trigram/CodonLM intrinsic table with loss,
   perplexity, bits/codon, token count, and improvement over the best simple baseline.
 - [ ] Extract corrected causal embeddings and rerun EC, essentiality, AMR, and
   DNA-shape evaluations under their controlled splits and shared controls.
-- [ ] Run nucleotide/protein nearest-neighbor and training-match coverage audits for
-  generated sequences before reporting memorization or novelty.
+- [ ] Run raw/constrained generation plus nucleotide/protein nearest-neighbor and
+  training-match coverage audits before reporting memorization or novelty.
+- [ ] Record a primary go/no-go decision before training optional extensions.
+
+Exit gate: the primary model beats the best simple intrinsic baseline and all
+reported downstream evidence uses corrected checkpoints and controlled splits.
+
+## Phase 8: Revalidate ProteinCritic
+- [ ] Freeze protein sources, task labels/vocabularies, preprocessing, and
+  homology-clustered train/validation/test artifacts.
+- [ ] Retrain one selected bidirectional attention-pooled critic architecture for
+  the declared family, function, stability, and structural tasks.
+- [ ] Report leakage, class balance, discrimination, calibration, confidence
+  intervals, and generated-protein OOD behavior for every head.
+- [ ] Version and provenance-bind any critic allowed to support corrected evaluation
+  or generation guidance.
+
+Exit gate: legacy critic outputs remain exploratory until the corrected critic passes;
+critic failure does not invalidate primary intrinsic results but blocks critic-based
+claims and interventions.
+
+## Phase 9: Run Internal Extension Ablations
+- [ ] Test multi-offset `n+x` heads with declared offsets, weights, backbone policy,
+  and auxiliary-versus-decoder usage.
+- [ ] Test termination prediction before adding generated-prefix replay or decoder
+  bias.
+- [ ] Test frozen and jointly trained biophysical shape encoders against sequence
+  controls.
+- [ ] Promote each extension independently before training a combined candidate.
+
+Exit gate: every accepted extension has replicated attributable gains without a
+material primary-quality, memory, runtime, termination, or leakage regression.
+
+## Phase 10: Evaluate Interventions and Publish
+- [ ] Keep raw, constrained, decoder-biased, ReD, critic-guided, and EBM-guided
+  generation as separate matched protocols.
+- [ ] Combine only independently promoted internal extensions and rerun the complete
+  intrinsic, downstream, generation, memorization, runtime, and provenance suite.
 - [ ] Publish a versioned report with exact commands, hashes, per-seed and aggregate
   results, confidence intervals, limitations, and failed gates.
 - [ ] Update README and benchmark documents from the versioned report while retaining

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -84,6 +84,22 @@ packing policy creates a new dataset version and invalidates dependent training 
 - Use the MPS runtime configuration only after its equal-token quality gate passes.
 - Preserve configs, manifests, logs, checkpoints, consumed-token counters, wall time,
   and peak-memory metrics for every run.
+- Train the primary next-token-only model before any optional CodonLM head is
+  enabled; a bounded pilot must pass before the full primary runs.
+- Treat multi-offset, termination/replay, and biophysical conditioning as separate
+  internal ablations before combining any of them.
+
+## ProteinCritic Revalidation Protocol
+
+ProteinCritic is external to CodonLM and does not block primary intrinsic training or
+evaluation. It does block any corrected claim based on critic family, function,
+stability, structure, ranking, filtering, or guidance.
+
+Before such use, freeze protein sources and labels, split translated proteins by
+sequence-homology clusters, retrain one selected critic architecture, calibrate each
+declared head, measure generated-protein out-of-distribution behavior, and bind the
+checkpoint to its dataset and evaluation artifacts. Legacy critic results remain
+exploratory.
 
 ## Corrected Evaluation Protocol
 1. Compare uniform, unigram, bigram, trigram, and CodonLM loss, perplexity, and
@@ -95,6 +111,9 @@ packing policy creates a new dataset version and invalidates dependent training 
    class-aware confidence intervals.
 5. Audit generated sequences against training nucleotide and protein records before
    making novelty or memorization claims.
+6. Report raw, syntax-constrained, decoder-biased, ReD, critic-guided, and EBM-guided
+   generation as distinct protocols; do not attribute an external intervention to
+   the underlying generator.
 
 ## Promotion Criteria
 Corrected results may replace legacy headlines only when:
@@ -114,9 +133,14 @@ Those results do not satisfy this track's scientific promotion criteria. Context
 ablation intended for corrected claims must use the frozen corrected datasets and
 the evaluation protocol defined here.
 
+The [corrected model training track](../corrected_model_training_20260721/) owns the
+ordered primary, critic, extension, combined-candidate, and publication gates.
+
 ## Non-Goals
 - Retrofitting corrected claims onto legacy checkpoints or embeddings.
 - Changing model size or adding objectives during the controlled revalidation.
+- Treating legacy ProteinCritic outputs as corrected evidence or automatically
+  bundling every implemented extension into one model.
 - Treating smoke runs, validation subsets, or CPU execution as final MPS evidence.
 - Requiring generation-protocol or memmap optimizations (#85 and #90) before the
   first corrected intrinsic and probe report.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -53,6 +53,17 @@ This document captures the end-to-end journey of Genomics-LM. It details how we 
   driver memory by about 47%; batch 8 slowed sharply. Both failed the predeclared
   1.5x runtime entry gate, so the reference compute policy was retained with mmap.
 
+## 2026-07-23: Corrected Training Phase Expansion
+
+* Separated immutable configuration, bounded pilot, primary training, and primary
+  evaluation into explicit gates before optional objectives are enabled.
+* Added a corrected ProteinCritic revalidation phase with protein-homology splits,
+  calibration, provenance, and generated-protein OOD evaluation requirements.
+* Ordered multi-offset, termination/replay, and biophysical guidance as independent
+  ablations, followed by a combined candidate only for promoted components.
+* Classified critic, EBM, ReD, decoder bias, and syntax constraints as external
+  generation interventions rather than intrinsic generator features.
+
 ---
 
 ## 1. Stage 1: Toy Scale (The Grammar School)


### PR DESCRIPTION
## Summary
- split immutable config, bounded pilot, primary training, and primary evaluation into explicit gates
- add corrected ProteinCritic retraining with homology-clustered splits, calibration, provenance, and generated-protein OOD evaluation
- define multi-offset, termination/replay, and biophysical guidance as independent internal ablations
- separate raw/constrained, ReD, critic, EBM, and decoder-bias inference interventions from intrinsic generator changes
- document that no legacy checkpoint contains or validates every extension

This is a governance-only change. It does not enable heads, change objectives, or start training.

## Validation
- `git diff --check`
- `pytest -q` (284 passed, 1 skipped, 1 xpassed)

Tracks #92; does not close the training/revalidation epic.