### PR TITLE
Freeze corrected primary training contracts

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -2,10 +2,10 @@
 
 ## Status
 
-In progress. Dataset, evaluator, generation-protocol, and MPS runtime gates are
-complete. Immutable primary configs are the final prerequisite before the bounded
-pilot. Internal CodonLM extensions and the external ProteinCritic are gated later and
-cannot be silently enabled in the primary run.
+In progress. Dataset, evaluator, generation-protocol, MPS runtime, and immutable
+primary-config gates are complete. The bounded MPS pilot is the final prerequisite
+before full primary training. Internal CodonLM extensions and the external
+ProteinCritic are gated later and cannot be silently enabled in the primary run.
 
 ## Phase 0: Freeze Primary Contracts
 
@@ -13,10 +13,10 @@ cannot be silently enabled in the primary run.
   reports, evaluator contracts, and generation protocols.
 - [x] Select the corrected MPS policy: batch 4, accumulation 32, checkpointing, AMP,
   MHA/SDPA, separator mask, and batch-aware mmap.
-- [ ] Add immutable genome-seed-1337, genome-seed-2027, and genus primary configs.
-- [ ] Pin the training-token budget, optimizer/scheduler, validation/checkpoint
+- [x] Add immutable genome-seed-1337, genome-seed-2027, and genus primary configs.
+- [x] Pin the training-token budget, optimizer/scheduler, validation/checkpoint
   cadence, output naming, and pilot limits.
-- [ ] Add config-contract tests requiring random initialization and rejecting shape,
+- [x] Add config-contract tests requiring random initialization and rejecting shape,
   offset, termination, replay, critic/energy, RoPE, SwiGLU, GQA, or other undeclared
   primary objectives and architectures.
 

--- a/conductor/tracks/corrected_model_training_20260721/spec.md
+++ b/conductor/tracks/corrected_model_training_20260721/spec.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-In progress. Dataset, evaluator, generation-protocol, and MPS gates pass. Immutable
-primary configs and a bounded pilot remain prerequisites for full training.
+In progress. Dataset, evaluator, generation-protocol, MPS, and immutable primary-
+config gates pass. A bounded MPS pilot remains the prerequisite for full training.
 
 ## Objective
 

--- a/configs/corrected_primary_genome_seed1337_v1.yaml
+++ b/configs/corrected_primary_genome_seed1337_v1.yaml
@@ -1,0 +1,71 @@
+primary_training_contract:
+  schema: codonlm_primary_training_config
+  version: 1
+  release: corrected-codonlm-v1
+  role: primary
+  protocol: genome
+  dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
+  dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
+
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+run_id: corrected-codonlm-v1-genome-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 10
+max_time_minutes: null
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.1
+label_smoothing: 0.05
+tie_embeddings: true
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+multi_offset_loss_enabled: false
+multi_offset_targets: []
+termination_loss_enabled: false
+replay_loss_enabled: false
+freeze_backbone: false
+eos_loss_weight: 1.0
+transfer_from: null
+
+batch_size: 4
+grad_accum_steps: 32
+lr: 0.0003
+lr_embedding: 0.0003
+min_lr: 0.00003
+weight_decay: 0.05
+warmup_steps: 100
+optimizer: adamw
+scheduler: cosine
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores

--- a/configs/corrected_primary_genome_seed2027_v1.yaml
+++ b/configs/corrected_primary_genome_seed2027_v1.yaml
@@ -1,0 +1,71 @@
+primary_training_contract:
+  schema: codonlm_primary_training_config
+  version: 1
+  release: corrected-codonlm-v1
+  role: primary
+  protocol: genome
+  dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
+  dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
+
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+run_id: corrected-codonlm-v1-genome-seed2027
+seed: 2027
+dataloader_seed: 2027
+epochs: 10
+max_time_minutes: null
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.1
+label_smoothing: 0.05
+tie_embeddings: true
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+multi_offset_loss_enabled: false
+multi_offset_targets: []
+termination_loss_enabled: false
+replay_loss_enabled: false
+freeze_backbone: false
+eos_loss_weight: 1.0
+transfer_from: null
+
+batch_size: 4
+grad_accum_steps: 32
+lr: 0.0003
+lr_embedding: 0.0003
+min_lr: 0.00003
+weight_decay: 0.05
+warmup_steps: 100
+optimizer: adamw
+scheduler: cosine
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores

--- a/configs/corrected_primary_genus_seed1337_v1.yaml
+++ b/configs/corrected_primary_genus_seed1337_v1.yaml
@@ -1,0 +1,71 @@
+primary_training_contract:
+  schema: codonlm_primary_training_config
+  version: 1
+  release: corrected-codonlm-v1
+  role: primary
+  protocol: genus
+  dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
+  dataset_id: 10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95
+
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genus/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genus/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genus/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genus/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genus/test_bs512.npz
+
+run_id: corrected-codonlm-v1-genus-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 10
+max_time_minutes: null
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.1
+label_smoothing: 0.05
+tie_embeddings: true
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+multi_offset_loss_enabled: false
+multi_offset_targets: []
+termination_loss_enabled: false
+replay_loss_enabled: false
+freeze_backbone: false
+eos_loss_weight: 1.0
+transfer_from: null
+
+batch_size: 4
+grad_accum_steps: 32
+lr: 0.0003
+lr_embedding: 0.0003
+min_lr: 0.00003
+weight_decay: 0.05
+warmup_steps: 100
+optimizer: adamw
+scheduler: cosine
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores

--- a/configs/corrected_primary_pilot_genome_seed1337_v1.yaml
+++ b/configs/corrected_primary_pilot_genome_seed1337_v1.yaml
@@ -1,0 +1,71 @@
+primary_training_contract:
+  schema: codonlm_primary_training_config
+  version: 1
+  release: corrected-codonlm-v1
+  role: pilot
+  protocol: genome
+  dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
+  dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
+
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+run_id: corrected-codonlm-v1-pilot-genome-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 1
+max_time_minutes: 30
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.1
+label_smoothing: 0.05
+tie_embeddings: true
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+multi_offset_loss_enabled: false
+multi_offset_targets: []
+termination_loss_enabled: false
+replay_loss_enabled: false
+freeze_backbone: false
+eos_loss_weight: 1.0
+transfer_from: null
+
+batch_size: 4
+grad_accum_steps: 32
+lr: 0.0003
+lr_embedding: 0.0003
+min_lr: 0.00003
+weight_decay: 0.05
+warmup_steps: 100
+optimizer: adamw
+scheduler: cosine
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores

--- a/docs/CORRECTED_PRIMARY_TRAINING_CONFIGS.md
+++ b/docs/CORRECTED_PRIMARY_TRAINING_CONFIGS.md
@@ -1,0 +1,74 @@
+# Corrected Primary Training Configs
+
+The corrected primary CodonLM is frozen in four versioned configs:
+
+| Config | Purpose | Limit |
+| --- | --- | --- |
+| `corrected_primary_pilot_genome_seed1337_v1.yaml` | MPS pilot and resume gate | one epoch, 30 minutes per invocation |
+| `corrected_primary_genome_seed1337_v1.yaml` | primary genome replicate 1 | 10 complete epochs |
+| `corrected_primary_genome_seed2027_v1.yaml` | primary genome replicate 2 | 10 complete epochs |
+| `corrected_primary_genus_seed1337_v1.yaml` | separate harder genus holdout | 10 complete epochs |
+
+The two genome replicates differ only in random seed and run identity. They consume
+the same frozen training transitions for 10 full epochs, with early stopping disabled,
+so their committed non-PAD exposure is directly comparable. The genus run uses a
+different grouped split and is reported separately rather than pooled with those
+replicates.
+
+All four configs define the basic 10-layer, 8-head, width-384 causal model. They
+explicitly disable checkpoint transfer, GQA, RoPE, SwiGLU, shape guidance,
+multi-offset heads, termination/replay objectives, and backbone freezing. The MPS
+runtime is batch 4, accumulation 32, AMP, activation checkpointing, SDPA with the
+separator mask, batch-aware NPY mmap, and no DataLoader workers.
+
+## Contract Validation
+
+Validate a config without loading the large local dataset:
+
+```bash
+python -m scripts.validate_primary_training_config \
+  configs/corrected_primary_pilot_genome_seed1337_v1.yaml
+```
+
+Marked configs are also validated automatically before the trainer loads data or
+constructs the model. Unknown keys and changes to data identity, architecture,
+objective, optimizer, scheduler, runtime, exposure, or output identity are fatal.
+CLI data, transfer-checkpoint, and run-ID overrides are rejected. An OOM saves
+`last.pt` but never rewrites an immutable config; changing batch policy requires a
+new reviewed contract version.
+
+## Pilot
+
+Start the bounded pilot on Apple Silicon:
+
+```bash
+caffeinate -i python -m src.codonlm.train_codon_lm \
+  --config configs/corrected_primary_pilot_genome_seed1337_v1.yaml
+```
+
+The 30-minute limit is per process invocation. It intentionally exercises a
+mid-epoch checkpoint. Resume from the committed accumulation-group boundary:
+
+```bash
+caffeinate -i python -m src.codonlm.train_codon_lm \
+  --config configs/corrected_primary_pilot_genome_seed1337_v1.yaml \
+  --resume runs/corrected-codonlm-v1-pilot-genome-seed1337/checkpoints/last.pt
+```
+
+Repeat the resume command until the one-epoch pilot completes validation and writes
+`best.pt`. Approve the full configs only after checking finite loss, zero aborted
+groups, optimizer/scheduler advancement, committed-token continuity, peak memory,
+throughput, dataset/vocabulary provenance, and the observed epoch wall time.
+
+## Full Runs
+
+After pilot approval, run each primary config without overrides:
+
+```bash
+caffeinate -i python -m src.codonlm.train_codon_lm \
+  --config configs/corrected_primary_genome_seed1337_v1.yaml
+```
+
+Use the same `--resume runs/<run-id>/checkpoints/last.pt` pattern after an interrupted
+full run. Each epoch performs full validation and writes `last.pt`; an improved epoch
+also writes `best.pt`. A periodic `last.pt` is written approximately every 30 minutes.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -738,6 +738,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     collate function, so `uint8` NPY sidecars are converted to `torch.long` once per
     batch instead of materializing a separate `int64` NumPy copy per sample. Direct
     `dataset[i]` behavior remains unchanged for compatibility.
+*   **Immutable Corrected Primary Training Contracts (2026-07-23):** Added a bounded
+    genome pilot, two exposure-matched genome replicates, and one separately reported
+    genus-holdout config for the 10L/8H/d384 next-token-only model. A fail-closed
+    startup validator binds every config to the corrected dataset freeze and rejects
+    data, seed, architecture, objective, optimizer, scheduler, runtime, or output
+    drift, including legacy transfer and undeclared extension keys. Full runs use 10
+    complete epochs with early stopping disabled; the pilot uses resumable 30-minute
+    invocations until its first full validation. Immutable configs are never rewritten
+    by the OOM safeguard.
 
 ---
 *End of Log*

--- a/scripts/validate_primary_training_config.py
+++ b/scripts/validate_primary_training_config.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Validate an immutable corrected primary-training YAML contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from src.codonlm.training.primary_contract import (
+    load_and_validate_primary_training_config,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", type=Path)
+    args = parser.parse_args()
+    result = load_and_validate_primary_training_config(args.config)
+    print(json.dumps({"status": "passed", **result}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -147,6 +147,29 @@ def dev(force_gpu: bool = False, requested: str = "auto"):
 
 
 def run_training(cfg: dict, args) -> None:
+    primary_contract = cfg.get("primary_training_contract")
+    if primary_contract is not None:
+        from src.codonlm.training.primary_contract import (
+            validate_primary_training_config,
+        )
+
+        contract_result = validate_primary_training_config(cfg)
+        requested_run_id = _normalize_run_id(args.run_id)
+        if requested_run_id and requested_run_id != contract_result["run_id"]:
+            raise ValueError(
+                "--run_id cannot override an immutable primary training config"
+            )
+        for name in ("train_npz", "val_npz", "test_npz", "transfer_from"):
+            if getattr(args, name, None) is not None:
+                raise ValueError(
+                    f"--{name} cannot override an immutable primary training config"
+                )
+        print(
+            "[contract] corrected primary config verified "
+            f"role={contract_result['role']} protocol={contract_result['protocol']} "
+            f"seed={contract_result['seed']}"
+        )
+
     resume_path = args.resume or cfg.pop("resume", None)
     if resume_path is not None:
         resume_path = str(resume_path)
@@ -1213,7 +1236,9 @@ def run_training(cfg: dict, args) -> None:
 
             if improved:
                 save_checkpoint_atomic(ckpt_payload, ckpt_dir / "best.pt")
-            elif no_improve >= int(cfg.get("early_stop_patience", 5)):
+            elif int(cfg.get("early_stop_patience", 5)) > 0 and no_improve >= int(
+                cfg.get("early_stop_patience", 5)
+            ):
                 print("[early-stopping] no improvement; stopping.")
                 break
     except NonfiniteGroupLimitError as exc:
@@ -1273,7 +1298,10 @@ def run_training(cfg: dict, args) -> None:
             print("\n" + "="*80)
             print("[OOM SAFEGUARD] Out-Of-Memory error detected during training loop execution!")
             print(f"Error detail: {exc}")
-            print("Attempting to save last.pt checkpoint and downscale batch size in the config...")
+            if primary_contract is None:
+                print("Attempting to save last.pt checkpoint and downscale batch size in the config...")
+            else:
+                print("Attempting to save last.pt without modifying the immutable config...")
             print("="*80 + "\n")
             
             try:
@@ -1284,7 +1312,7 @@ def run_training(cfg: dict, args) -> None:
             except Exception as save_exc:
                 print(f"[OOM SAFEGUARD] Failed to save checkpoint: {save_exc}")
                 
-            if hasattr(args, "config") and args.config:
+            if primary_contract is None and hasattr(args, "config") and args.config:
                 try:
                     import yaml
                     config_path = Path(args.config)
@@ -1305,6 +1333,11 @@ def run_training(cfg: dict, args) -> None:
                         print(f"[OOM SAFEGUARD] Config file {args.config} batch_size downscaled: {old_bs} -> {new_bs} (grad_accum_steps doubled: {old_gas} -> {new_gas})")
                 except Exception as yml_exc:
                     print(f"[OOM SAFEGUARD] Failed to update config: {yml_exc}")
+            elif primary_contract is not None:
+                print(
+                    "[OOM SAFEGUARD] Immutable primary config was not modified; "
+                    "a new versioned runtime contract is required to change batch size."
+                )
             raise exc
         else:
             print(f"[error] training failed: {exc}", file=sys.stderr)

--- a/src/codonlm/training/primary_contract.py
+++ b/src/codonlm/training/primary_contract.py
@@ -1,0 +1,193 @@
+"""Fail-closed contract for corrected primary CodonLM training configs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+
+SCHEMA_NAME = "codonlm_primary_training_config"
+SCHEMA_VERSION = 1
+RELEASE = "corrected-codonlm-v1"
+DATASET_FREEZE_ID = "1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249"
+
+DATASETS = {
+    "genome": {
+        "dataset_id": "da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9",
+        "root": "data/processed/corrected/corrected-codonlm-v1/genome",
+    },
+    "genus": {
+        "dataset_id": "10f41e818182704bbe4f95fbd81eb8696047762a32f84d167a4101675945ab95",
+        "root": "data/processed/corrected/corrected-codonlm-v1/genus",
+    },
+}
+
+COMMON_VALUES: dict[str, Any] = {
+    "block_size": 512,
+    "vocab_size": 68,
+    "n_layer": 10,
+    "n_head": 8,
+    "n_embd": 384,
+    "dropout": 0.1,
+    "label_smoothing": 0.05,
+    "tie_embeddings": True,
+    "use_sdpa": True,
+    "sep_mask_enabled": True,
+    "n_kv_head": None,
+    "use_rope": False,
+    "use_swiglu": False,
+    "use_shape_guidance": False,
+    "unfreeze_encoder": False,
+    "multi_offset_loss_enabled": False,
+    "multi_offset_targets": [],
+    "termination_loss_enabled": False,
+    "replay_loss_enabled": False,
+    "freeze_backbone": False,
+    "eos_loss_weight": 1.0,
+    "transfer_from": None,
+    "batch_size": 4,
+    "grad_accum_steps": 32,
+    "lr": 0.0003,
+    "lr_embedding": 0.0003,
+    "min_lr": 0.00003,
+    "weight_decay": 0.05,
+    "warmup_steps": 100,
+    "optimizer": "adamw",
+    "scheduler": "cosine",
+    "early_stop_patience": 0,
+    "max_nonfinite_accumulation_groups": 0,
+    "checkpoint_every_steps": 0,
+    "checkpoint_every_minutes": 30,
+    "save_epochs": False,
+    "device": "mps",
+    "force_gpu": True,
+    "amp": True,
+    "use_checkpoint": True,
+    "use_mmap": True,
+    "bucket_batching": False,
+    "num_workers": 0,
+    "pin_memory": False,
+    "compile": False,
+    "out_dir": "outputs/checkpoints",
+    "scores_dir": "outputs/scores",
+}
+
+ALLOWED_KEYS = frozenset(
+    {
+        "primary_training_contract",
+        "dataset_manifest",
+        "itos_path",
+        "train_npz",
+        "val_npz",
+        "test_npz",
+        "run_id",
+        "seed",
+        "dataloader_seed",
+        "epochs",
+        "max_time_minutes",
+        *COMMON_VALUES,
+    }
+)
+
+
+def _require_equal(cfg: Mapping[str, Any], key: str, expected: Any) -> None:
+    if key not in cfg:
+        raise ValueError(f"primary config is missing required key {key!r}")
+    if cfg[key] != expected:
+        raise ValueError(
+            f"primary config key {key!r} must be {expected!r}, got {cfg[key]!r}"
+        )
+
+
+def validate_primary_training_config(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a corrected primary or pilot config without requiring local data."""
+    contract = cfg.get("primary_training_contract")
+    if not isinstance(contract, Mapping):
+        raise ValueError("missing primary_training_contract mapping")
+    expected_header = {
+        "schema": SCHEMA_NAME,
+        "version": SCHEMA_VERSION,
+        "release": RELEASE,
+        "dataset_freeze_id": DATASET_FREEZE_ID,
+    }
+    for key, expected in expected_header.items():
+        if contract.get(key) != expected:
+            raise ValueError(
+                f"primary_training_contract.{key} must be {expected!r}, "
+                f"got {contract.get(key)!r}"
+            )
+
+    role = contract.get("role")
+    protocol = contract.get("protocol")
+    if role not in {"pilot", "primary"}:
+        raise ValueError("primary_training_contract.role must be 'pilot' or 'primary'")
+    if protocol not in DATASETS:
+        raise ValueError("primary_training_contract.protocol must be 'genome' or 'genus'")
+    if role == "pilot" and protocol != "genome":
+        raise ValueError("the corrected primary pilot must use the genome protocol")
+
+    dataset = DATASETS[str(protocol)]
+    if contract.get("dataset_id") != dataset["dataset_id"]:
+        raise ValueError("primary training dataset_id does not match the frozen protocol")
+
+    unknown = sorted(set(cfg) - ALLOWED_KEYS)
+    if unknown:
+        raise ValueError(f"undeclared primary config keys are not allowed: {unknown}")
+    for key, expected in COMMON_VALUES.items():
+        _require_equal(cfg, key, expected)
+
+    root = dataset["root"]
+    paths = {
+        "dataset_manifest": f"{root}/manifest.json",
+        "itos_path": f"{root}/itos.txt",
+        "train_npz": f"{root}/train_bs512.npz",
+        "val_npz": f"{root}/val_bs512.npz",
+        "test_npz": f"{root}/test_bs512.npz",
+    }
+    for key, expected in paths.items():
+        _require_equal(cfg, key, expected)
+
+    seed = int(cfg.get("seed", -1))
+    allowed_seeds = {1337} if protocol == "genus" or role == "pilot" else {1337, 2027}
+    if seed not in allowed_seeds:
+        raise ValueError(f"unsupported {role} seed {seed} for {protocol} protocol")
+    _require_equal(cfg, "dataloader_seed", seed)
+
+    if role == "pilot":
+        _require_equal(cfg, "epochs", 1)
+        _require_equal(cfg, "max_time_minutes", 30)
+        expected_run_id = "corrected-codonlm-v1-pilot-genome-seed1337"
+    else:
+        _require_equal(cfg, "epochs", 10)
+        _require_equal(cfg, "max_time_minutes", None)
+        expected_run_id = f"corrected-codonlm-v1-{protocol}-seed{seed}"
+    _require_equal(cfg, "run_id", expected_run_id)
+    return {
+        "role": role,
+        "protocol": protocol,
+        "seed": seed,
+        "run_id": expected_run_id,
+        "dataset_id": dataset["dataset_id"],
+        "dataset_freeze_id": DATASET_FREEZE_ID,
+    }
+
+
+def load_and_validate_primary_training_config(path: str | Path) -> dict[str, Any]:
+    config_path = Path(path)
+    cfg = yaml.safe_load(config_path.read_text()) or {}
+    if not isinstance(cfg, dict):
+        raise ValueError(f"training config must contain a YAML mapping: {config_path}")
+    return validate_primary_training_config(cfg)
+
+
+__all__ = [
+    "DATASET_FREEZE_ID",
+    "DATASETS",
+    "RELEASE",
+    "SCHEMA_NAME",
+    "SCHEMA_VERSION",
+    "load_and_validate_primary_training_config",
+    "validate_primary_training_config",
+]

--- a/tests/test_primary_training_contract.py
+++ b/tests/test_primary_training_contract.py
@@ -1,0 +1,73 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.codonlm.training.primary_contract import (
+    load_and_validate_primary_training_config,
+    validate_primary_training_config,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGS = (
+    "corrected_primary_pilot_genome_seed1337_v1.yaml",
+    "corrected_primary_genome_seed1337_v1.yaml",
+    "corrected_primary_genome_seed2027_v1.yaml",
+    "corrected_primary_genus_seed1337_v1.yaml",
+)
+
+
+@pytest.mark.parametrize("name", CONFIGS)
+def test_tracked_primary_configs_pass_contract(name):
+    result = load_and_validate_primary_training_config(ROOT / "configs" / name)
+    assert result["run_id"].startswith("corrected-codonlm-v1-")
+
+
+def _genome_config():
+    path = ROOT / "configs" / "corrected_primary_genome_seed1337_v1.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("transfer_from", "legacy.pt"),
+        ("n_kv_head", 4),
+        ("use_rope", True),
+        ("use_swiglu", True),
+        ("use_shape_guidance", True),
+        ("multi_offset_loss_enabled", True),
+        ("termination_loss_enabled", True),
+        ("replay_loss_enabled", True),
+        ("early_stop_patience", 2),
+        ("epochs", 9),
+    ),
+)
+def test_contract_rejects_primary_drift(key, value):
+    cfg = deepcopy(_genome_config())
+    cfg[key] = value
+    with pytest.raises(ValueError, match=key):
+        validate_primary_training_config(cfg)
+
+
+def test_contract_rejects_undeclared_objective_or_architecture_key():
+    cfg = deepcopy(_genome_config())
+    cfg["protein_critic_loss_enabled"] = True
+    with pytest.raises(ValueError, match="undeclared primary config keys"):
+        validate_primary_training_config(cfg)
+
+
+def test_genome_replicates_differ_only_in_seed_identity():
+    first = yaml.safe_load(
+        (ROOT / "configs" / "corrected_primary_genome_seed1337_v1.yaml").read_text()
+    )
+    second = yaml.safe_load(
+        (ROOT / "configs" / "corrected_primary_genome_seed2027_v1.yaml").read_text()
+    )
+    for cfg in (first, second):
+        cfg.pop("seed")
+        cfg.pop("dataloader_seed")
+        cfg.pop("run_id")
+    assert first == second


### PR DESCRIPTION
## Summary
- add immutable configs for the bounded MPS pilot, two genome-held-out seeds, and the separate genus-held-out run
- enforce the corrected dataset, basic 10L/8H/d384 architecture, next-token-only objective, optimizer, runtime, exposure, and output contracts at trainer startup
- reject extension/config/CLI drift and prevent OOM recovery from rewriting immutable configs
- document pilot/resume/full-run commands and complete Phase 0 of the corrected training track

## Training policy
- full primary runs use 10 complete epochs with early stopping disabled
- genome seeds 1337 and 2027 are mechanically identical except for seed and run identity
- genus holdout remains a separately reported protocol
- pilot runs in resumable 30-minute segments until epoch 1 validation completes

## Verification
- `pytest -q` (300 passed, 1 skipped, 1 xpassed)
- `ruff check src/codonlm/training/primary_contract.py src/codonlm/training/loop.py scripts/validate_primary_training_config.py tests/test_primary_training_contract.py`
- all four tracked configs pass `python -m scripts.validate_primary_training_config <config>`

Tracks #92
