### PR TITLE
Correct pilot schedule and resume metrics

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -25,6 +25,11 @@ architecture, exposure, or provenance.
 
 ## Phase 1: Run the Bounded Primary Pilot
 
+The first lifecycle run completed on 2026-07-23 with exact resume counters, zero
+invalid groups, stable MPS memory, and validation loss `4.031`, but exposed a
+compressed one-epoch cosine horizon and segment-only training-loss reporting. Those
+results are diagnostic only; repeat Phase 1 under config-contract schema v2.
+
 - [ ] Train from random initialization on a bounded portion of the frozen
   genome-held-out stream using the exact primary model and runtime policy.
 - [ ] Verify initial loss scale, finite gradients, committed non-PAD tokens,

--- a/configs/corrected_primary_genome_seed1337_v2.yaml
+++ b/configs/corrected_primary_genome_seed1337_v2.yaml
@@ -1,6 +1,6 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 1
+  version: 2
   release: corrected-codonlm-v1
   role: primary
   protocol: genome
@@ -13,9 +13,9 @@ train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
 val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
 test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
 
-run_id: corrected-codonlm-v1-genome-seed2027
-seed: 2027
-dataloader_seed: 2027
+run_id: corrected-codonlm-v1-genome-seed1337
+seed: 1337
+dataloader_seed: 1337
 epochs: 10
 max_time_minutes: null
 
@@ -51,6 +51,7 @@ weight_decay: 0.05
 warmup_steps: 100
 optimizer: adamw
 scheduler: cosine
+scheduler_total_steps: 5000
 early_stop_patience: 0
 max_nonfinite_accumulation_groups: 0
 checkpoint_every_steps: 0

--- a/configs/corrected_primary_genome_seed2027_v2.yaml
+++ b/configs/corrected_primary_genome_seed2027_v2.yaml
@@ -1,8 +1,8 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 1
+  version: 2
   release: corrected-codonlm-v1
-  role: pilot
+  role: primary
   protocol: genome
   dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
   dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
@@ -13,11 +13,11 @@ train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
 val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
 test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
 
-run_id: corrected-codonlm-v1-pilot-genome-seed1337
-seed: 1337
-dataloader_seed: 1337
-epochs: 1
-max_time_minutes: 30
+run_id: corrected-codonlm-v1-genome-seed2027
+seed: 2027
+dataloader_seed: 2027
+epochs: 10
+max_time_minutes: null
 
 block_size: 512
 vocab_size: 68
@@ -51,6 +51,7 @@ weight_decay: 0.05
 warmup_steps: 100
 optimizer: adamw
 scheduler: cosine
+scheduler_total_steps: 5000
 early_stop_patience: 0
 max_nonfinite_accumulation_groups: 0
 checkpoint_every_steps: 0

--- a/configs/corrected_primary_genus_seed1337_v2.yaml
+++ b/configs/corrected_primary_genus_seed1337_v2.yaml
@@ -1,6 +1,6 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 1
+  version: 2
   release: corrected-codonlm-v1
   role: primary
   protocol: genus
@@ -51,6 +51,7 @@ weight_decay: 0.05
 warmup_steps: 100
 optimizer: adamw
 scheduler: cosine
+scheduler_total_steps: 5000
 early_stop_patience: 0
 max_nonfinite_accumulation_groups: 0
 checkpoint_every_steps: 0

--- a/configs/corrected_primary_pilot_genome_seed1337_v2.yaml
+++ b/configs/corrected_primary_pilot_genome_seed1337_v2.yaml
@@ -1,8 +1,8 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 1
+  version: 2
   release: corrected-codonlm-v1
-  role: primary
+  role: pilot
   protocol: genome
   dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
   dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
@@ -13,11 +13,11 @@ train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
 val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
 test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
 
-run_id: corrected-codonlm-v1-genome-seed1337
+run_id: corrected-codonlm-v1-pilot-genome-seed1337
 seed: 1337
 dataloader_seed: 1337
-epochs: 10
-max_time_minutes: null
+epochs: 1
+max_time_minutes: 30
 
 block_size: 512
 vocab_size: 68
@@ -51,6 +51,7 @@ weight_decay: 0.05
 warmup_steps: 100
 optimizer: adamw
 scheduler: cosine
+scheduler_total_steps: 5000
 early_stop_patience: 0
 max_nonfinite_accumulation_groups: 0
 checkpoint_every_steps: 0

--- a/docs/CORRECTED_PRIMARY_TRAINING_CONFIGS.md
+++ b/docs/CORRECTED_PRIMARY_TRAINING_CONFIGS.md
@@ -4,10 +4,10 @@ The corrected primary CodonLM is frozen in four versioned configs:
 
 | Config | Purpose | Limit |
 | --- | --- | --- |
-| `corrected_primary_pilot_genome_seed1337_v1.yaml` | MPS pilot and resume gate | one epoch, 30 minutes per invocation |
-| `corrected_primary_genome_seed1337_v1.yaml` | primary genome replicate 1 | 10 complete epochs |
-| `corrected_primary_genome_seed2027_v1.yaml` | primary genome replicate 2 | 10 complete epochs |
-| `corrected_primary_genus_seed1337_v1.yaml` | separate harder genus holdout | 10 complete epochs |
+| `corrected_primary_pilot_genome_seed1337_v2.yaml` | MPS pilot and resume gate | one epoch, 30 minutes per invocation |
+| `corrected_primary_genome_seed1337_v2.yaml` | primary genome replicate 1 | 10 complete epochs |
+| `corrected_primary_genome_seed2027_v2.yaml` | primary genome replicate 2 | 10 complete epochs |
+| `corrected_primary_genus_seed1337_v2.yaml` | separate harder genus holdout | 10 complete epochs |
 
 The two genome replicates differ only in random seed and run identity. They consume
 the same frozen training transitions for 10 full epochs, with early stopping disabled,
@@ -27,7 +27,7 @@ Validate a config without loading the large local dataset:
 
 ```bash
 python -m scripts.validate_primary_training_config \
-  configs/corrected_primary_pilot_genome_seed1337_v1.yaml
+  configs/corrected_primary_pilot_genome_seed1337_v2.yaml
 ```
 
 Marked configs are also validated automatically before the trainer loads data or
@@ -43,15 +43,17 @@ Start the bounded pilot on Apple Silicon:
 
 ```bash
 caffeinate -i python -m src.codonlm.train_codon_lm \
-  --config configs/corrected_primary_pilot_genome_seed1337_v1.yaml
+  --config configs/corrected_primary_pilot_genome_seed1337_v2.yaml
 ```
 
-The 30-minute limit is per process invocation. It intentionally exercises a
+The 30-minute limit is per process invocation. The pilot retains the full primary
+5,000-step cosine horizon; its one-epoch bound does not compress the learning-rate
+schedule. It intentionally exercises a
 mid-epoch checkpoint. Resume from the committed accumulation-group boundary:
 
 ```bash
 caffeinate -i python -m src.codonlm.train_codon_lm \
-  --config configs/corrected_primary_pilot_genome_seed1337_v1.yaml \
+  --config configs/corrected_primary_pilot_genome_seed1337_v2.yaml \
   --resume runs/corrected-codonlm-v1-pilot-genome-seed1337/checkpoints/last.pt
 ```
 
@@ -60,13 +62,17 @@ Repeat the resume command until the one-epoch pilot completes validation and wri
 groups, optimizer/scheduler advancement, committed-token continuity, peak memory,
 throughput, dataset/vocabulary provenance, and the observed epoch wall time.
 
+Training-loss sums, counts, and the first finite loss are checkpointed with each
+partial epoch, so the final epoch training loss covers all resumed segments rather
+than only the last process invocation.
+
 ## Full Runs
 
 After pilot approval, run each primary config without overrides:
 
 ```bash
 caffeinate -i python -m src.codonlm.train_codon_lm \
-  --config configs/corrected_primary_genome_seed1337_v1.yaml
+  --config configs/corrected_primary_genome_seed1337_v2.yaml
 ```
 
 Use the same `--resume runs/<run-id>/checkpoints/last.pt` pattern after an interrupted

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -747,6 +747,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     complete epochs with early stopping disabled; the pilot uses resumable 30-minute
     invocations until its first full validation. Immutable configs are never rewritten
     by the OOM safeguard.
+*   **Primary Pilot Diagnostic Run (2026-07-23):** Completed one frozen genome epoch
+    over seven resumable MPS invocations: 500 optimizer/scheduler steps, 25,238,438
+    committed non-PAD tokens, zero invalid accumulation groups, validation loss
+    4.031 (PPL 56.31), and stable 1.16 GB peak tensor / 2.45 GB peak driver MPS
+    allocation. The run correctly exposed two contract defects before full training:
+    its one-epoch cosine schedule was compressed to 500 rather than the primary 5,000
+    steps, and resumed epoch training loss covered only the final segment. Contract
+    schema v2 pins the shared 5,000-step horizon and checkpoints cumulative epoch
+    loss state; the diagnostic run does not authorize full training.
 
 ---
 *End of Log*

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -676,7 +676,10 @@ def run_training(cfg: dict, args) -> None:
     else:
         max_epochs = int(epochs_cfg)
     steps_per_epoch = math.ceil(len(train_loader) / max(1, gacc))
-    total_steps = max(1, steps_per_epoch * max_epochs)
+    computed_total_steps = max(1, steps_per_epoch * max_epochs)
+    total_steps = int(cfg.get("scheduler_total_steps", computed_total_steps))
+    if total_steps <= 0:
+        raise ValueError("scheduler_total_steps must be positive")
     use_cosine = scheduler_name == "cosine"
     if use_cosine:
         warmup_for_lambda = max(1, warmup_steps)
@@ -715,6 +718,12 @@ def run_training(cfg: dict, args) -> None:
     current_epoch_idx = 0
     current_microbatch_idx = 0
     current_resume_microbatch_idx = 0
+    epoch_train_metrics = {
+        "total_loss_sum": 0.0,
+        "next_loss_sum": 0.0,
+        "microbatches": 0,
+        "initial_loss": None,
+    }
 
     try:
         if transfer_path:
@@ -810,6 +819,10 @@ def run_training(cfg: dict, args) -> None:
             accumulation_health.load_state_dict(
                 ckpt_resume.get("accumulation_health")
             )
+            saved_epoch_metrics = ckpt_resume.get("epoch_train_metrics") or {}
+            for key in epoch_train_metrics:
+                if key in saved_epoch_metrics:
+                    epoch_train_metrics[key] = saved_epoch_metrics[key]
             checkpoint_batch_size = ckpt_resume.get("batch_size")
             checkpoint_grad_accum = ckpt_resume.get("grad_accum_steps")
             if checkpoint_batch_size is not None and int(checkpoint_batch_size) != int(cfg["batch_size"]):
@@ -877,6 +890,7 @@ def run_training(cfg: dict, args) -> None:
                 "train_batches": int(len(train_loader)),
                 "accumulation_health": accumulation_health.state_dict(),
                 "max_nonfinite_accumulation_groups": max_nonfinite_groups,
+                "epoch_train_metrics": dict(epoch_train_metrics),
             }
             if use_shape_guidance and encoder is not None:
                 payload["encoder"] = encoder.state_dict()
@@ -894,7 +908,13 @@ def run_training(cfg: dict, args) -> None:
             nonlocal consumed_train_tokens, pending_train_tokens
             mps_autocast_ok = True
             model.train(split=="train")
-            total, next_total, term_total, replay_total, n = 0.0, 0.0, 0.0, 0.0, 0
+            if split == "train":
+                total = float(epoch_train_metrics["total_loss_sum"])
+                next_total = float(epoch_train_metrics["next_loss_sum"])
+                n = int(epoch_train_metrics["microbatches"])
+            else:
+                total, next_total, n = 0.0, 0.0, 0
+            term_total, replay_total = 0.0, 0.0
             term_count = 0
             replay_count = 0
             offset_totals = {offset: 0.0 for offset in multi_offset_weights}
@@ -1050,16 +1070,29 @@ def run_training(cfg: dict, args) -> None:
                                 f"{max_nonfinite_groups}: {accumulation_health.aborted_groups}"
                             )
                     continue
+                optimizer_stepped = False
                 if split=="train":
                     loss.backward()
                     pending_train_tokens += int(yb.ne(PAD_ID).sum().item())
                     accumulation_health.record_finite_microbatch()
                     if accumulation_health.active_microbatches == gacc:
                         step_optimizer(accumulation_health.active_microbatches)
-                        if split == "train" and periodic_ckpt.should_save(step):
-                            save_last_checkpoint(epoch_idx, reason="periodic")
+                        optimizer_stepped = True
+                periodic_save_due = (
+                    optimizer_stepped and periodic_ckpt.should_save(step)
+                )
                 total += loss.item()
                 next_total += float(next_loss.detach().item())
+                if split == "train":
+                    if epoch_train_metrics["initial_loss"] is None:
+                        epoch_train_metrics["initial_loss"] = float(loss.detach().item())
+                        print(
+                            "[train] initial_loss="
+                            f"{epoch_train_metrics['initial_loss']:.6f}"
+                        )
+                    epoch_train_metrics["total_loss_sum"] = total
+                    epoch_train_metrics["next_loss_sum"] = next_total
+                    epoch_train_metrics["microbatches"] = n + 1
                 if term_loss is not None:
                     term_total += float(term_loss.detach().item())
                     term_count += 1
@@ -1070,6 +1103,8 @@ def run_training(cfg: dict, args) -> None:
                     offset_totals[offset] += float(offset_loss.detach().item())
                     offset_counts[offset] += 1
                 n += 1
+                if periodic_save_due:
+                    save_last_checkpoint(epoch_idx, reason="periodic")
                 sample_runtime_memory()
                 wall_timer.check()
             
@@ -1131,6 +1166,13 @@ def run_training(cfg: dict, args) -> None:
             epoch_idx = epoch + 1
             skip_for_epoch = resume_microbatch_idx if epoch == start_epoch else 0
             resume_microbatch_idx = 0
+            if skip_for_epoch == 0:
+                epoch_train_metrics.update(
+                    total_loss_sum=0.0,
+                    next_loss_sum=0.0,
+                    microbatches=0,
+                    initial_loss=None,
+                )
             train_loss, train_next_loss, train_term_loss, train_replay_term_loss, train_skips, train_offsets, train_health = one_pass(
                 "train",
                 train_loader,

--- a/src/codonlm/training/primary_contract.py
+++ b/src/codonlm/training/primary_contract.py
@@ -9,7 +9,7 @@ import yaml
 
 
 SCHEMA_NAME = "codonlm_primary_training_config"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 RELEASE = "corrected-codonlm-v1"
 DATASET_FREEZE_ID = "1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249"
 
@@ -56,6 +56,7 @@ COMMON_VALUES: dict[str, Any] = {
     "warmup_steps": 100,
     "optimizer": "adamw",
     "scheduler": "cosine",
+    "scheduler_total_steps": 5000,
     "early_stop_patience": 0,
     "max_nonfinite_accumulation_groups": 0,
     "checkpoint_every_steps": 0,

--- a/tests/test_primary_training_contract.py
+++ b/tests/test_primary_training_contract.py
@@ -12,10 +12,10 @@ from src.codonlm.training.primary_contract import (
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIGS = (
-    "corrected_primary_pilot_genome_seed1337_v1.yaml",
-    "corrected_primary_genome_seed1337_v1.yaml",
-    "corrected_primary_genome_seed2027_v1.yaml",
-    "corrected_primary_genus_seed1337_v1.yaml",
+    "corrected_primary_pilot_genome_seed1337_v2.yaml",
+    "corrected_primary_genome_seed1337_v2.yaml",
+    "corrected_primary_genome_seed2027_v2.yaml",
+    "corrected_primary_genus_seed1337_v2.yaml",
 )
 
 
@@ -26,7 +26,7 @@ def test_tracked_primary_configs_pass_contract(name):
 
 
 def _genome_config():
-    path = ROOT / "configs" / "corrected_primary_genome_seed1337_v1.yaml"
+    path = ROOT / "configs" / "corrected_primary_genome_seed1337_v2.yaml"
     return yaml.safe_load(path.read_text())
 
 
@@ -42,6 +42,7 @@ def _genome_config():
         ("termination_loss_enabled", True),
         ("replay_loss_enabled", True),
         ("early_stop_patience", 2),
+        ("scheduler_total_steps", 500),
         ("epochs", 9),
     ),
 )
@@ -61,10 +62,10 @@ def test_contract_rejects_undeclared_objective_or_architecture_key():
 
 def test_genome_replicates_differ_only_in_seed_identity():
     first = yaml.safe_load(
-        (ROOT / "configs" / "corrected_primary_genome_seed1337_v1.yaml").read_text()
+        (ROOT / "configs" / "corrected_primary_genome_seed1337_v2.yaml").read_text()
     )
     second = yaml.safe_load(
-        (ROOT / "configs" / "corrected_primary_genome_seed2027_v1.yaml").read_text()
+        (ROOT / "configs" / "corrected_primary_genome_seed2027_v2.yaml").read_text()
     )
     for cfg in (first, second):
         cfg.pop("seed")


### PR DESCRIPTION
## Summary
- pin a shared 5,000-step cosine horizon for the bounded pilot and full primary runs
- persist cumulative epoch training-loss state and initial loss across mid-epoch resumes
- save periodic checkpoints only after the committed optimizer group and its metrics agree
- version the corrected primary configs as schema v2 and document the diagnostic pilot

## Pilot evidence
- completed one frozen genome epoch across seven resumable MPS invocations
- 500 optimizer/scheduler steps and 25,238,438 committed non-PAD tokens
- zero non-finite or aborted accumulation groups
- stable MPS peaks: 1.16 GB allocated, 2.45 GB driver
- validation loss 4.031 (PPL 56.31)

The run validated lifecycle and runtime behavior, but it is diagnostic only because schema v1 compressed the cosine schedule to 500 steps and reported only the final segment's training loss. Full training remains blocked until the schema-v2 pilot is repeated.

## Verification
- `pytest -q` (301 passed, 1 skipped, 1 xpassed)
- focused contract/preflight tests pass after config rename
- Ruff and all four schema-v2 config validations pass

Tracks #92
