### PR TITLE
Align resumed metrics with optimizer commits

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -28,7 +28,10 @@ architecture, exposure, or provenance.
 The first lifecycle run completed on 2026-07-23 with exact resume counters, zero
 invalid groups, stable MPS memory, and validation loss `4.031`, but exposed a
 compressed one-epoch cosine horizon and segment-only training-loss reporting. Those
-results are diagnostic only; repeat Phase 1 under config-contract schema v2.
+results are diagnostic only. A schema-v2 segment then verified the 5,000-step
+scheduler but found that pending, uncommitted microbatch losses entered checkpoint
+metrics. Repeat Phase 1 under schema v3, which commits token and loss accounting at
+the same accumulation-group boundary.
 
 - [ ] Train from random initialization on a bounded portion of the frozen
   genome-held-out stream using the exact primary model and runtime policy.

--- a/configs/corrected_primary_genome_seed1337_v3.yaml
+++ b/configs/corrected_primary_genome_seed1337_v3.yaml
@@ -1,6 +1,6 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 2
+  version: 3
   release: corrected-codonlm-v1
   role: primary
   protocol: genome

--- a/configs/corrected_primary_genome_seed2027_v3.yaml
+++ b/configs/corrected_primary_genome_seed2027_v3.yaml
@@ -1,8 +1,8 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 2
+  version: 3
   release: corrected-codonlm-v1
-  role: pilot
+  role: primary
   protocol: genome
   dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
   dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
@@ -13,11 +13,11 @@ train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
 val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
 test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
 
-run_id: corrected-codonlm-v1-pilot-genome-seed1337
-seed: 1337
-dataloader_seed: 1337
-epochs: 1
-max_time_minutes: 30
+run_id: corrected-codonlm-v1-genome-seed2027
+seed: 2027
+dataloader_seed: 2027
+epochs: 10
+max_time_minutes: null
 
 block_size: 512
 vocab_size: 68

--- a/configs/corrected_primary_genus_seed1337_v3.yaml
+++ b/configs/corrected_primary_genus_seed1337_v3.yaml
@@ -1,6 +1,6 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 2
+  version: 3
   release: corrected-codonlm-v1
   role: primary
   protocol: genus

--- a/configs/corrected_primary_pilot_genome_seed1337_v3.yaml
+++ b/configs/corrected_primary_pilot_genome_seed1337_v3.yaml
@@ -1,8 +1,8 @@
 primary_training_contract:
   schema: codonlm_primary_training_config
-  version: 2
+  version: 3
   release: corrected-codonlm-v1
-  role: primary
+  role: pilot
   protocol: genome
   dataset_freeze_id: 1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249
   dataset_id: da3dfce28b7a46b8640d75c7cb417c867137a99e004ea359d85784ff0c269db9
@@ -13,11 +13,11 @@ train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
 val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
 test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
 
-run_id: corrected-codonlm-v1-genome-seed2027
-seed: 2027
-dataloader_seed: 2027
-epochs: 10
-max_time_minutes: null
+run_id: corrected-codonlm-v1-pilot-genome-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 1
+max_time_minutes: 30
 
 block_size: 512
 vocab_size: 68

--- a/docs/CORRECTED_PRIMARY_TRAINING_CONFIGS.md
+++ b/docs/CORRECTED_PRIMARY_TRAINING_CONFIGS.md
@@ -4,10 +4,10 @@ The corrected primary CodonLM is frozen in four versioned configs:
 
 | Config | Purpose | Limit |
 | --- | --- | --- |
-| `corrected_primary_pilot_genome_seed1337_v2.yaml` | MPS pilot and resume gate | one epoch, 30 minutes per invocation |
-| `corrected_primary_genome_seed1337_v2.yaml` | primary genome replicate 1 | 10 complete epochs |
-| `corrected_primary_genome_seed2027_v2.yaml` | primary genome replicate 2 | 10 complete epochs |
-| `corrected_primary_genus_seed1337_v2.yaml` | separate harder genus holdout | 10 complete epochs |
+| `corrected_primary_pilot_genome_seed1337_v3.yaml` | MPS pilot and resume gate | one epoch, 30 minutes per invocation |
+| `corrected_primary_genome_seed1337_v3.yaml` | primary genome replicate 1 | 10 complete epochs |
+| `corrected_primary_genome_seed2027_v3.yaml` | primary genome replicate 2 | 10 complete epochs |
+| `corrected_primary_genus_seed1337_v3.yaml` | separate harder genus holdout | 10 complete epochs |
 
 The two genome replicates differ only in random seed and run identity. They consume
 the same frozen training transitions for 10 full epochs, with early stopping disabled,
@@ -27,7 +27,7 @@ Validate a config without loading the large local dataset:
 
 ```bash
 python -m scripts.validate_primary_training_config \
-  configs/corrected_primary_pilot_genome_seed1337_v2.yaml
+  configs/corrected_primary_pilot_genome_seed1337_v3.yaml
 ```
 
 Marked configs are also validated automatically before the trainer loads data or
@@ -43,7 +43,7 @@ Start the bounded pilot on Apple Silicon:
 
 ```bash
 caffeinate -i python -m src.codonlm.train_codon_lm \
-  --config configs/corrected_primary_pilot_genome_seed1337_v2.yaml
+  --config configs/corrected_primary_pilot_genome_seed1337_v3.yaml
 ```
 
 The 30-minute limit is per process invocation. The pilot retains the full primary
@@ -53,7 +53,7 @@ mid-epoch checkpoint. Resume from the committed accumulation-group boundary:
 
 ```bash
 caffeinate -i python -m src.codonlm.train_codon_lm \
-  --config configs/corrected_primary_pilot_genome_seed1337_v2.yaml \
+  --config configs/corrected_primary_pilot_genome_seed1337_v3.yaml \
   --resume runs/corrected-codonlm-v1-pilot-genome-seed1337/checkpoints/last.pt
 ```
 
@@ -62,9 +62,9 @@ Repeat the resume command until the one-epoch pilot completes validation and wri
 groups, optimizer/scheduler advancement, committed-token continuity, peak memory,
 throughput, dataset/vocabulary provenance, and the observed epoch wall time.
 
-Training-loss sums, counts, and the first finite loss are checkpointed with each
-partial epoch, so the final epoch training loss covers all resumed segments rather
-than only the last process invocation.
+Only metrics belonging to optimizer-committed accumulation groups are checkpointed.
+Pending groups are replayed after resume without double-counting their loss. Thus the
+final epoch training loss covers every committed microbatch exactly once.
 
 ## Full Runs
 
@@ -72,7 +72,7 @@ After pilot approval, run each primary config without overrides:
 
 ```bash
 caffeinate -i python -m src.codonlm.train_codon_lm \
-  --config configs/corrected_primary_genome_seed1337_v2.yaml
+  --config configs/corrected_primary_genome_seed1337_v3.yaml
 ```
 
 Use the same `--resume runs/<run-id>/checkpoints/last.pt` pattern after an interrupted

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -755,7 +755,11 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     its one-epoch cosine schedule was compressed to 500 rather than the primary 5,000
     steps, and resumed epoch training loss covered only the final segment. Contract
     schema v2 pins the shared 5,000-step horizon and checkpoints cumulative epoch
-    loss state; the diagnostic run does not authorize full training.
+    loss state; the diagnostic run does not authorize full training. The first
+    schema-v2 segment verified the corrected scheduler (LR `2.99995e-4` at step 113)
+    but found 3,645 metric microbatches recorded at a 3,616-microbatch optimizer
+    boundary. Schema v3 keeps pending loss state outside checkpoints and commits token
+    and loss counters atomically; schema-v2 checkpoints must not be resumed.
 
 ---
 *End of Log*

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -724,6 +724,12 @@ def run_training(cfg: dict, args) -> None:
         "microbatches": 0,
         "initial_loss": None,
     }
+    pending_train_metrics = {
+        "total_loss_sum": 0.0,
+        "next_loss_sum": 0.0,
+        "microbatches": 0,
+        "initial_loss": None,
+    }
 
     try:
         if transfer_path:
@@ -1035,6 +1041,25 @@ def run_training(cfg: dict, args) -> None:
                     accumulation_health.complete_group()
                     consumed_train_tokens += pending_train_tokens
                     pending_train_tokens = 0
+                    epoch_train_metrics["total_loss_sum"] += pending_train_metrics[
+                        "total_loss_sum"
+                    ]
+                    epoch_train_metrics["next_loss_sum"] += pending_train_metrics[
+                        "next_loss_sum"
+                    ]
+                    epoch_train_metrics["microbatches"] += pending_train_metrics[
+                        "microbatches"
+                    ]
+                    if epoch_train_metrics["initial_loss"] is None:
+                        epoch_train_metrics["initial_loss"] = pending_train_metrics[
+                            "initial_loss"
+                        ]
+                    pending_train_metrics.update(
+                        total_loss_sum=0.0,
+                        next_loss_sum=0.0,
+                        microbatches=0,
+                        initial_loss=None,
+                    )
                     step += 1
                     current_resume_microbatch_idx = batch_idx + 1
                     if use_cosine:
@@ -1058,6 +1083,12 @@ def run_training(cfg: dict, args) -> None:
                     if split == "train":
                         discarded = accumulation_health.abort_group(optim)
                         pending_train_tokens = 0
+                        pending_train_metrics.update(
+                            total_loss_sum=0.0,
+                            next_loss_sum=0.0,
+                            microbatches=0,
+                            initial_loss=None,
+                        )
                         current_resume_microbatch_idx = batch_idx + 1
                         print(
                             "[train] aborted nonfinite accumulation group "
@@ -1072,6 +1103,17 @@ def run_training(cfg: dict, args) -> None:
                     continue
                 optimizer_stepped = False
                 if split=="train":
+                    loss_value = float(loss.detach().item())
+                    next_loss_value = float(next_loss.detach().item())
+                    if (
+                        epoch_train_metrics["initial_loss"] is None
+                        and pending_train_metrics["initial_loss"] is None
+                    ):
+                        pending_train_metrics["initial_loss"] = loss_value
+                        print(f"[train] initial_loss={loss_value:.6f}")
+                    pending_train_metrics["total_loss_sum"] += loss_value
+                    pending_train_metrics["next_loss_sum"] += next_loss_value
+                    pending_train_metrics["microbatches"] += 1
                     loss.backward()
                     pending_train_tokens += int(yb.ne(PAD_ID).sum().item())
                     accumulation_health.record_finite_microbatch()
@@ -1081,18 +1123,9 @@ def run_training(cfg: dict, args) -> None:
                 periodic_save_due = (
                     optimizer_stepped and periodic_ckpt.should_save(step)
                 )
-                total += loss.item()
-                next_total += float(next_loss.detach().item())
-                if split == "train":
-                    if epoch_train_metrics["initial_loss"] is None:
-                        epoch_train_metrics["initial_loss"] = float(loss.detach().item())
-                        print(
-                            "[train] initial_loss="
-                            f"{epoch_train_metrics['initial_loss']:.6f}"
-                        )
-                    epoch_train_metrics["total_loss_sum"] = total
-                    epoch_train_metrics["next_loss_sum"] = next_total
-                    epoch_train_metrics["microbatches"] = n + 1
+                if split != "train":
+                    total += loss.item()
+                    next_total += float(next_loss.detach().item())
                 if term_loss is not None:
                     term_total += float(term_loss.detach().item())
                     term_count += 1
@@ -1110,6 +1143,11 @@ def run_training(cfg: dict, args) -> None:
             
             if split == "train" and accumulation_health.active_microbatches:
                 step_optimizer(accumulation_health.active_microbatches)
+
+            if split == "train":
+                total = float(epoch_train_metrics["total_loss_sum"])
+                next_total = float(epoch_train_metrics["next_loss_sum"])
+                n = int(epoch_train_metrics["microbatches"])
 
             offset_avgs = {
                 offset: (offset_totals[offset] / max(offset_counts[offset], 1))
@@ -1168,6 +1206,12 @@ def run_training(cfg: dict, args) -> None:
             resume_microbatch_idx = 0
             if skip_for_epoch == 0:
                 epoch_train_metrics.update(
+                    total_loss_sum=0.0,
+                    next_loss_sum=0.0,
+                    microbatches=0,
+                    initial_loss=None,
+                )
+                pending_train_metrics.update(
                     total_loss_sum=0.0,
                     next_loss_sum=0.0,
                     microbatches=0,

--- a/src/codonlm/training/primary_contract.py
+++ b/src/codonlm/training/primary_contract.py
@@ -9,7 +9,7 @@ import yaml
 
 
 SCHEMA_NAME = "codonlm_primary_training_config"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 RELEASE = "corrected-codonlm-v1"
 DATASET_FREEZE_ID = "1582505ae40445422711fa15918ee9c229caf84b1b3feba1a71f078259892249"
 

--- a/tests/test_nonfinite_accumulation.py
+++ b/tests/test_nonfinite_accumulation.py
@@ -104,6 +104,7 @@ def test_nonfinite_abort_checkpoint_and_resume_preserve_step_counters(
     assert checkpoint["consumed_train_tokens"] == 0
     assert checkpoint["scheduler"]["last_epoch"] == 0
     assert checkpoint["epoch_microbatch_idx"] == 2
+    assert checkpoint["epoch_train_metrics"]["microbatches"] == 0
     assert checkpoint["accumulation_health"] == {
         "active_microbatches": 0,
         "nonfinite_microbatches": 1,
@@ -129,5 +130,6 @@ def test_nonfinite_abort_checkpoint_and_resume_preserve_step_counters(
     assert resumed["consumed_train_tokens"] == 12
     assert resumed["scheduler"]["last_epoch"] == 2
     assert resumed["epoch_microbatch_idx"] == 0
+    assert resumed["epoch_train_metrics"]["microbatches"] == 3
     assert resumed["accumulation_health"]["aborted_groups"] == 1
     assert resumed["accumulation_health"]["discarded_finite_microbatches"] == 1

--- a/tests/test_primary_training_contract.py
+++ b/tests/test_primary_training_contract.py
@@ -12,10 +12,10 @@ from src.codonlm.training.primary_contract import (
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIGS = (
-    "corrected_primary_pilot_genome_seed1337_v2.yaml",
-    "corrected_primary_genome_seed1337_v2.yaml",
-    "corrected_primary_genome_seed2027_v2.yaml",
-    "corrected_primary_genus_seed1337_v2.yaml",
+    "corrected_primary_pilot_genome_seed1337_v3.yaml",
+    "corrected_primary_genome_seed1337_v3.yaml",
+    "corrected_primary_genome_seed2027_v3.yaml",
+    "corrected_primary_genus_seed1337_v3.yaml",
 )
 
 
@@ -26,7 +26,7 @@ def test_tracked_primary_configs_pass_contract(name):
 
 
 def _genome_config():
-    path = ROOT / "configs" / "corrected_primary_genome_seed1337_v2.yaml"
+    path = ROOT / "configs" / "corrected_primary_genome_seed1337_v3.yaml"
     return yaml.safe_load(path.read_text())
 
 
@@ -62,10 +62,10 @@ def test_contract_rejects_undeclared_objective_or_architecture_key():
 
 def test_genome_replicates_differ_only_in_seed_identity():
     first = yaml.safe_load(
-        (ROOT / "configs" / "corrected_primary_genome_seed1337_v2.yaml").read_text()
+        (ROOT / "configs" / "corrected_primary_genome_seed1337_v3.yaml").read_text()
     )
     second = yaml.safe_load(
-        (ROOT / "configs" / "corrected_primary_genome_seed2027_v2.yaml").read_text()
+        (ROOT / "configs" / "corrected_primary_genome_seed2027_v3.yaml").read_text()
     )
     for cfg in (first, second):
         cfg.pop("seed")

--- a/tests/test_wall_time.py
+++ b/tests/test_wall_time.py
@@ -1,10 +1,9 @@
-import os
 import sys
 import yaml
 import numpy as np
-import pytest
 import subprocess
 import json
+import torch
 from pathlib import Path
 
 def test_train_codon_lm_wall_time_limit(tmp_path):
@@ -17,7 +16,7 @@ def test_train_codon_lm_wall_time_limit(tmp_path):
         "n_embd": 16,
         "dropout": 0.0,
         "batch_size": 1,
-        "grad_accum_steps": 1,
+        "grad_accum_steps": 4,
         "lr": 0.001,
         "weight_decay": 0.0,
         "epochs": 10,
@@ -90,6 +89,11 @@ def test_train_codon_lm_wall_time_limit(tmp_path):
         
         meta = json.loads(meta_json.read_text())
         assert meta["status"] == "stopped"
+        checkpoint = torch.load(last_pt, map_location="cpu", weights_only=False)
+        assert (
+            checkpoint["epoch_train_metrics"]["microbatches"]
+            == checkpoint["epoch_microbatch_idx"]
+        )
     finally:
         if runs_dir.exists():
             shutil.rmtree(runs_dir)


### PR DESCRIPTION
## Summary
- keep pending microbatch loss statistics outside resumable checkpoint state
- commit token and loss accounting atomically with each optimizer accumulation group
- discard pending metrics when a non-finite group is aborted
- add wall-time and non-finite regression assertions for committed metric boundaries
- version corrected primary configs as schema v3 so schema-v2 checkpoints cannot be resumed

## MPS evidence
The first schema-v2 segment verified the scheduler correction:
- 5,000-step horizon
- step 113 LR `2.99995e-4`
- zero invalid groups
- stable 1.16 GB tensor / 2.45 GB driver MPS peaks

It also found 3,645 metric microbatches at a 3,616-microbatch optimizer boundary. The extra 29 belonged to an uncommitted group and would have been replayed after resume. Schema v3 checkpoints only the 3,616 committed metrics.

## Verification
- `pytest -q` (301 passed, 1 skipped, 1 xpassed)
- Ruff passes
- all four schema-v3 config contracts pass

Tracks #92
