### PR TITLE
Report unsmoothed checkpoint perplexity

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -70,8 +70,11 @@ mismatch, or provenance failure.
 Interim seed-1337 intrinsic evaluation is recorded in
 `docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md`. It beats unigram but not bigram
 or trigram and therefore fails the promotion gate. Pause dependent downstream and
-generation evaluation while running the predeclared intrinsic diagnostics. The
-checklist remains open until all Phase 2 runs and matched evaluations are complete.
+generation evaluation. The mask audit passed; context ablation showed all useful
+gain saturating at four input tokens, with no gain from longer context and a paired
+`+0.13819` nats/token deficit to trigram. Run the predeclared regularization matrix
+before considering an architecture extension. The checklist remains open until all
+Phase 2 runs and matched evaluations are complete.
 
 - [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test
   tokens; report loss, perplexity, bits/codon, and improvement over the best baseline.

--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -2,10 +2,12 @@
 
 ## Status
 
-In progress. Dataset, evaluator, generation-protocol, MPS runtime, immutable
-primary-config, and bounded MPS pilot gates are complete. Full primary training is
-authorized next. Internal CodonLM extensions and the external ProteinCritic are
-gated later and cannot be silently enabled in the primary run.
+In progress, with the intrinsic gate paused for diagnosis. Dataset, evaluator,
+generation-protocol, MPS runtime, immutable primary-config, and bounded MPS pilot
+gates are complete. The genome seed-1337 primary run completed, but its unsmoothed
+test PPL `48.267` did not beat the trigram baseline `42.037`, and natural sequence
+was indistinguishable from the codon-order shuffle. Internal CodonLM extensions and
+the external ProteinCritic remain gated and cannot conceal this failure.
 
 ## Phase 0: Freeze Primary Contracts
 
@@ -52,7 +54,7 @@ counter/provenance mismatch, or an unexplained loss anomaly.
 
 ## Phase 2: Train the Primary Basic Model
 
-- [ ] Train the genome-held-out primary model at seed `1337`.
+- [x] Train the genome-held-out primary model at seed `1337`.
 - [ ] Train the identical genome-held-out primary model at seed `2027`.
 - [ ] Train the separately labelled genus-held-out primary model from random
   initialization.
@@ -64,6 +66,12 @@ Exit gate: all primary runs finish without leakage, OOM, invalid update, counter
 mismatch, or provenance failure.
 
 ## Phase 3: Evaluate and Decide on the Primary Model
+
+Interim seed-1337 intrinsic evaluation is recorded in
+`docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md`. It beats unigram but not bigram
+or trigram and therefore fails the promotion gate. Pause dependent downstream and
+generation evaluation while running the predeclared intrinsic diagnostics. The
+checklist remains open until all Phase 2 runs and matched evaluations are complete.
 
 - [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test
   tokens; report loss, perplexity, bits/codon, and improvement over the best baseline.

--- a/configs/corrected_regularization_ablation.yaml
+++ b/configs/corrected_regularization_ablation.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+experiment: corrected-codonlm-v1-regularization-ablation
+base_config: configs/corrected_primary_genome_seed1337_v3.yaml
+seed: 1337
+epochs: 2
+scheduler_total_steps: 1000
+expected_nonpad_tokens: 50476876
+allowed_overrides:
+  - label_smoothing
+  - dropout
+  - tie_embeddings
+variants:
+  - name: reference
+    overrides:
+      label_smoothing: 0.05
+      dropout: 0.10
+      tie_embeddings: true
+  - name: no_smoothing
+    overrides:
+      label_smoothing: 0.00
+      dropout: 0.10
+      tie_embeddings: true
+  - name: no_smoothing_low_dropout
+    overrides:
+      label_smoothing: 0.00
+      dropout: 0.05
+      tie_embeddings: true
+  - name: no_smoothing_low_dropout_untied
+    overrides:
+      label_smoothing: 0.00
+      dropout: 0.05
+      tie_embeddings: false

--- a/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
+++ b/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
@@ -1,0 +1,99 @@
+# Context Learning Diagnostics
+
+## Markov Comparisons
+
+A Markov baseline predicts the next token from a deliberately limited history:
+
+- unigram: no preceding token, only global target frequencies;
+- bigram: the current input token, which is the target's immediately preceding token;
+- trigram: the target's two immediately preceding tokens.
+
+These models establish whether a Transformer provides value beyond short transition
+tables. They are fitted only on the training split and evaluated on the same
+manifest-bound held-out tokens as CodonLM.
+
+Markov history resets after `<SEP>` to match CodonLM's attention contract. In
+particular, the trigram must not use a token from the preceding CDS when predicting
+the first token after `<SEP>`.
+
+## Diagnostic Command
+
+```bash
+caffeinate -i python -m scripts.diagnose_context_learning \
+  --run-dir runs/corrected-codonlm-v1-genome-seed1337 \
+  --checkpoint-name best.pt \
+  --train data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz \
+  --test data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz \
+  --manifest data/processed/corrected/corrected-codonlm-v1/genome/manifest.json \
+  --itos data/processed/corrected/corrected-codonlm-v1/genome/itos.txt \
+  --packing-tsv data/processed/corrected/corrected-codonlm-v1/genome/test_packing.tsv \
+  --context-windows 1,2,4,8,32,128,full \
+  --batch-size 4 \
+  --device mps \
+  --output-prefix runs/corrected-codonlm-v1-genome-seed1337/diagnostics/context_learning
+```
+
+An attention window includes the current input token:
+
+| Window | Target history available |
+| ---: | --- |
+| 1 | immediately preceding target token; bigram-like |
+| 2 | two preceding target tokens; trigram-like |
+| 4+ | progressively longer local history |
+| full | complete causal history within the current segment |
+
+The command:
+
+- verifies the causal and separator mask against an independently constructed mask;
+- reruns segment-aware uniform/unigram/bigram/trigram baselines;
+- measures checkpoint NLL at each context window;
+- decomposes full-context loss by target class, segment position, boundary, and
+  windows containing chunk continuations;
+- bootstraps the paired CodonLM-minus-trigram NLL difference over packed windows;
+- binds the checkpoint, vocabulary, manifest, token arrays, and packing metadata.
+
+## Regularization Ablation
+
+Materialize the predeclared matched configs:
+
+```bash
+python -m scripts.materialize_regularization_ablation \
+  --matrix configs/corrected_regularization_ablation.yaml \
+  --output-dir runs/corrected-regularization-ablation/configs
+```
+
+The matrix contains four two-epoch, random-initialized conditions:
+
+1. current label smoothing, dropout, and tied embeddings;
+2. no label smoothing;
+3. no label smoothing with dropout reduced to 0.05;
+4. no label smoothing, dropout 0.05, and untied input/output embeddings.
+
+All other data, architecture, optimizer, seed, exposure, and scheduler fields remain
+identical. These runs are diagnostics, not primary replicates, and their generated
+configs intentionally omit `primary_training_contract`.
+
+Do not run the matrix until the context and mask diagnostic completes. A masking or
+packing defect invalidates a regularization comparison.
+
+## Local Convolution Versus `n+x`
+
+A causal convolutional branch summarizes recent input tokens before the ordinary
+next-token prediction:
+
+```text
+recent past -> local convolution -> n+1 logits
+```
+
+The earlier `n+x` heads use a shared causal representation to predict more distant
+future targets:
+
+```text
+past -> Transformer -> separate n+4, n+8, ... heads
+```
+
+They are complementary but not equivalent. A local convolution supplies an
+inductive bias for short motifs and transitions. `n+x` objectives provide auxiliary
+supervision about longer-range future tokens. Adding `n+x` cannot repair a model
+that has not demonstrated bigram-level contextual learning, so it remains gated
+until the basic next-token diagnostic passes.

--- a/docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md
+++ b/docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md
@@ -1,0 +1,83 @@
+# Corrected Primary Intrinsic Evaluation
+
+## Status
+
+Interim seed-1337 result recorded on 2026-07-25. The first corrected primary
+genome-holdout model completed training, but it did not pass the predeclared
+intrinsic promotion gate. Expensive downstream and generation claims are paused
+pending diagnosis.
+
+This is not the final multi-seed primary result. Genome seed 2027 and the separately
+labelled genus-holdout run have not yet been trained.
+
+## Checkpoints
+
+| Checkpoint | Epoch | SHA-256 |
+| --- | ---: | --- |
+| Selected best | 4 | `095327417fdcc72a27473a0ac091356c0c8a6bd12ff4cfcd127c2ccacf9b2a1f` |
+| Final | 10 | `1df89cf815624f259f18eaf7e4b2fc49c72e00f212ca4ec09a3a9983881de932` |
+
+Training applied exactly 5,000 optimizer/scheduler steps and 252,384,380 non-PAD
+tokens with zero non-finite microbatches, aborted groups, or discarded finite
+microbatches. The smoothed validation selector chose epoch 4.
+
+## Frozen Test Results
+
+All rows use the same 2,228,589 non-PAD tokens from the frozen genome-held-out test
+artifact. CodonLM perplexity is computed from ordinary unsmoothed cross-entropy;
+the label-smoothed training objective is recorded separately.
+
+| Model | NLL (nats/codon) | PPL | Bits/codon |
+| --- | ---: | ---: | ---: |
+| Uniform | 4.204693 | 67.000 | 6.0661 |
+| Unigram | 3.895213 | 49.167 | 5.6196 |
+| Bigram | 3.779984 | 43.815 | 5.4534 |
+| Trigram | 3.738549 | 42.037 | 5.3936 |
+| CodonLM epoch 4 | 3.876740 | 48.267 | 5.593 |
+| CodonLM epoch 10 | 3.885411 | 48.687 | 5.605 |
+
+The selected CodonLM beats unigram by 0.01847 nats/codon and 0.90 PPL, but trails
+bigram by 0.09676 nats/codon and trigram by 0.13819 nats/codon. Epoch 10 is worse
+than epoch 4 on unsmoothed test NLL, so the selected checkpoint remains correct.
+
+## Sequence Controls
+
+The selected epoch-4 checkpoint was evaluated on deterministic controls derived
+from the same frozen test artifact:
+
+| Input | NLL (nats/codon) | PPL |
+| --- | ---: | ---: |
+| Natural | 3.876740 | 48.267 |
+| Codons shuffled within each CDS span | 3.876587 | 48.259 |
+| Uniform synonymous recoding | 4.217718 | 67.878 |
+| Protein-order shuffle plus synonymous recoding | 4.217216 | 67.844 |
+
+The codon-shuffle control preserves each span's exact codon multiset while
+destroying order. Its likelihood is effectively identical to natural sequence,
+which indicates that the model's current test advantage is dominated by codon
+composition rather than sequential ordering. The synonymous control shows strong
+sensitivity to native codon usage. The protein-shuffle control is not an isolated
+protein-order test because its construction also chooses random synonymous codons.
+
+## Decision
+
+The Phase 3 promotion criterion requires CodonLM to outperform the best simple
+intrinsic baseline on identical held-out tokens. Seed 1337 fails that criterion.
+Do not use this checkpoint to support corrected downstream or generative claims yet.
+
+Before deciding between retraining and architectural changes:
+
+1. Produce token-class, position, and CDS-span loss decompositions for CodonLM and
+   the Markov baselines.
+2. Run matched context ablations that retain zero, one, two, and progressively more
+   preceding codons.
+3. Verify that packing spans and separator masks expose the intended within-CDS
+   context during training and evaluation.
+4. Quantify paired per-token uncertainty for CodonLM-minus-trigram NLL.
+5. Test a predeclared no-label-smoothing or reduced-label-smoothing training
+   ablation only if diagnostics show contextual signal is being suppressed rather
+   than absent from the data.
+
+Genome seed 2027 should not be treated as a remedy for this effect: replication can
+estimate variance, but it is unlikely to close a 0.138-nat/codon gap without a
+corrected hypothesis.

--- a/docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md
+++ b/docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md
@@ -59,24 +59,60 @@ composition rather than sequential ordering. The synonymous control shows strong
 sensitivity to native codon usage. The protein-shuffle control is not an isolated
 protein-order test because its construction also chooses random synonymous codons.
 
+## Context Diagnosis
+
+The manifest-bound context sweep passed the independently reconstructed causal and
+separator-mask audit. Resetting trigram history after `<SEP>` did not change its
+aggregate result to six decimals, so the original cross-boundary trigram defect was
+real but too rare to explain the baseline gap.
+
+| Input attention window | NLL | PPL |
+| ---: | ---: | ---: |
+| 1 | 3.938233 | 51.328 |
+| 2 | 3.880021 | 48.425 |
+| 4 | 3.876767 | 48.268 |
+| 8 | 3.876762 | 48.268 |
+| 32 | 3.876746 | 48.267 |
+| 128 | 3.876747 | 48.267 |
+| Full | 3.876740 | 48.267 |
+
+The checkpoint uses short context: increasing the window from one to two input
+tokens improves PPL by 2.90, and four tokens capture essentially the entire
+full-context result. There is no measurable benefit beyond four input tokens.
+Despite using local context, CodonLM remains worse than the explicit bigram and
+trigram estimators.
+
+The paired CodonLM-minus-trigram difference is `+0.138191` nats/token with a 95%
+packed-window bootstrap interval of `[+0.136469, +0.139874]`. This excludes run
+noise as an explanation.
+
+Boundary losses are disproportionately high:
+
+- prediction immediately after `<SEP>`: PPL `993.5` over 2,160 tokens;
+- all segment starts: PPL `107.6` over 7,872 tokens;
+- stop codons: PPL `473.9` over 8,387 tokens;
+- ordinary codons: PPL `47.36` over 2,159,052 tokens.
+
+Those rare boundary classes do not account for the full baseline gap, but they
+identify a separate grammar weakness. Windows containing chunk continuations are
+not worse than other windows (`47.42` versus `48.87` PPL), so chunk continuation is
+not the immediate failure mode.
+
 ## Decision
 
 The Phase 3 promotion criterion requires CodonLM to outperform the best simple
 intrinsic baseline on identical held-out tokens. Seed 1337 fails that criterion.
 Do not use this checkpoint to support corrected downstream or generative claims yet.
 
-Before deciding between retraining and architectural changes:
+The mask, context, decomposition, and paired-uncertainty diagnostics are complete.
+They show connected but underused local context rather than a disconnected
+Transformer. The next experiment is the predeclared matched regularization matrix:
+current regularization, no label smoothing, no smoothing plus lower dropout, and
+the same condition with untied embeddings.
 
-1. Produce token-class, position, and CDS-span loss decompositions for CodonLM and
-   the Markov baselines.
-2. Run matched context ablations that retain zero, one, two, and progressively more
-   preceding codons.
-3. Verify that packing spans and separator masks expose the intended within-CDS
-   context during training and evaluation.
-4. Quantify paired per-token uncertainty for CodonLM-minus-trigram NLL.
-5. Test a predeclared no-label-smoothing or reduced-label-smoothing training
-   ablation only if diagnostics show contextual signal is being suppressed rather
-   than absent from the data.
+Do not add a convolutional branch, `n+x` heads, or another architecture extension
+until that matrix determines whether ordinary next-token optimization can beat the
+count baselines.
 
 Genome seed 2027 should not be treated as a remedy for this effect: replication can
 estimate variance, but it is unlikely to close a 0.138-nat/codon gap without a

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -784,6 +784,18 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     codon-composition learning without demonstrated sequential advantage. The
     primary promotion gate is paused for context, packing/mask, loss-decomposition,
     and paired-uncertainty diagnostics before downstream or extension claims.
+*   **Primary Context Diagnosis (2026-07-25):** Corrected the trigram evaluator to
+    reset history after `<SEP>`; the aggregate baseline remained PPL 42.037, showing
+    the rare cross-boundary defect did not explain the gap. The checkpoint passed an
+    independent causal/segment-mask audit. Evaluation-only attention windows gave
+    PPL 51.328 at one input token, 48.425 at two, 48.268 at four, and 48.267 at full
+    context. CodonLM therefore uses a short neighborhood but gains nothing beyond
+    four tokens and remains decisively worse than trigram (`+0.138191` nats/token;
+    95% packed-window bootstrap CI `[+0.136469, +0.139874]`). Loss decomposition
+    also exposed severe post-separator and stop-codon weaknesses. Added a fail-closed
+    four-condition, two-epoch regularization matrix covering label smoothing,
+    dropout, and tied embeddings. Architecture extensions remain blocked until this
+    ordinary next-token optimization ablation is evaluated.
 
 ---
 *End of Log*

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -772,6 +772,18 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     and the LR remained aligned to the 5,000-step primary horizon. Phase 1 is complete
     and the immutable full genome seed-1337 run is authorized next. Compact evidence
     is stored in `docs/benchmarks/corrected_primary_pilot_genome_seed1337.json`.
+*   **Corrected Genome Seed-1337 Training and Intrinsic Gate (2026-07-25):**
+    Completed the ten-epoch random-initialized primary run with exactly 5,000
+    optimizer/scheduler steps, 252,384,380 committed non-PAD tokens, and zero
+    invalid accumulation groups. Smoothed validation selected epoch 4. A corrected
+    unsmoothed evaluation over 2,228,589 frozen genome-held-out test tokens gave PPL
+    48.267 for epoch 4 and 48.687 for epoch 10. Epoch 4 beats the unigram baseline
+    (49.167) but not bigram (43.815) or trigram (42.037). Its natural-sequence PPL
+    was indistinguishable from an exact-composition codon-order shuffle (48.259),
+    while uniform synonymous recoding increased PPL to 67.878. The result indicates
+    codon-composition learning without demonstrated sequential advantage. The
+    primary promotion gate is paused for context, packing/mask, loss-decomposition,
+    and paired-uncertainty diagnostics before downstream or extension claims.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -93,6 +93,12 @@ For every test evaluation, calculate and compare model performance against Unifo
    genus-held-out dataset and a distinct output prefix.
 2. Report the **excess bits per codon** ($\Delta H$) and the perplexity drop over the 2nd-order Markov (Trigram) baseline.
 
+The baseline evaluator resets trigram history after `<SEP>` so its accessible
+context matches the model's segment mask. If CodonLM does not beat bigram and
+trigram, run the context diagnostic in
+`docs/CONTEXT_LEARNING_DIAGNOSTICS.md` before downstream evaluation or extension
+training.
+
 Evaluate the corrected model on the same manifest-bound test artifact:
 
 ```bash

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -102,7 +102,20 @@ python -m scripts.evaluate_test \
 ```
 
 Corrected checkpoints fail if the explicit manifest is missing or if its dataset or
-vocabulary identity differs from the checkpoint.
+vocabulary identity differs from the checkpoint. `test_nll` and `test_ppl` are
+computed from ordinary unsmoothed cross-entropy and are directly comparable with the
+simple baselines. `test_objective_loss` separately records cross-entropy with the
+checkpoint's configured label smoothing.
+
+Evaluate a distinct final checkpoint without overwriting the selected-best result:
+
+```bash
+python -m scripts.evaluate_test \
+  --run_dir runs/<RUN_ID> \
+  --manifest data/processed/corrected/<FREEZE_ID>/genome/manifest.json \
+  --checkpoint-name last.pt \
+  --metric-prefix last_test
+```
 
 ---
 

--- a/scripts/diagnose_context_learning.py
+++ b/scripts/diagnose_context_learning.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Diagnose whether a CodonLM checkpoint uses context beyond token composition."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from scripts.eval_ppl_baselines import (
+    _probability,
+    evaluate_baselines,
+    fit_baselines,
+)
+from src.codonlm.checkpoints import build_codon_model_from_cfg, load_codon_checkpoint
+from src.codonlm.data_loading import MmapPackedDataset
+from src.codonlm.evaluation_provenance import (
+    artifact_provenance,
+    bind_checkpoint_dataset,
+    bind_dataset_manifest,
+)
+from src.codonlm.training.vocabulary import resolve_vocabulary_contract
+
+PAD_ID = 0
+
+
+def _device(name: str) -> torch.device:
+    if name == "mps":
+        if not torch.backends.mps.is_available():
+            raise RuntimeError("MPS requested but unavailable")
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def _parse_windows(value: str) -> list[int | None]:
+    windows: list[int | None] = []
+    for raw in value.split(","):
+        item = raw.strip().lower()
+        window = None if item == "full" else int(item)
+        if window is not None and window < 1:
+            raise ValueError("context windows must be positive or 'full'")
+        if window not in windows:
+            windows.append(window)
+    if not windows:
+        raise ValueError("at least one context window is required")
+    return windows
+
+
+def _packing_window_flags(path: Path | None, n_windows: int) -> np.ndarray:
+    flags = np.zeros(n_windows, dtype=bool)
+    if path is None:
+        return flags
+    with path.open() as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            index = int(row["window_index"])
+            if index < 0 or index >= n_windows:
+                raise ValueError(f"packing metadata window index out of range: {index}")
+            flags[index] |= row["continues_from_previous"] == "1"
+            flags[index] |= row["continues_to_next"] == "1"
+    return flags
+
+
+def _trigram_nll(
+    x: np.ndarray,
+    y: np.ndarray,
+    trigram: dict,
+    bigram: dict,
+    *,
+    alpha: float,
+    active_size: int,
+    reset_token_ids: frozenset[int],
+) -> np.ndarray:
+    result = np.zeros(len(y), dtype=np.float64)
+    for position, target_value in enumerate(y):
+        target = int(target_value)
+        if target == PAD_ID:
+            continue
+        previous = int(x[position])
+        previous2 = (
+            PAD_ID
+            if position == 0 or previous in reset_token_ids
+            else int(x[position - 1])
+        )
+        counts = trigram.get((previous2, previous))
+        if counts is None:
+            counts = bigram.get(previous)
+        result[position] = -math.log(
+            _probability(counts, target, alpha, active_size)
+        )
+    return result
+
+
+def _position_bin(position: int) -> str:
+    if position == 0:
+        return "segment_position_0"
+    if position < 4:
+        return "segment_position_1_3"
+    if position < 16:
+        return "segment_position_4_15"
+    if position < 64:
+        return "segment_position_16_63"
+    return "segment_position_64_plus"
+
+
+def _token_class(token: str) -> str:
+    if token.startswith("<"):
+        return "special"
+    if token == "ATG":
+        return "start_codon"
+    if token in {"TAA", "TAG", "TGA"}:
+        return "stop_codon"
+    return "ordinary_codon"
+
+
+def _add_slice(
+    slices: dict[str, list[float]], name: str, losses: np.ndarray, mask: np.ndarray
+) -> None:
+    selected = losses[mask]
+    if selected.size:
+        slices[name][0] += float(selected.sum())
+        slices[name][1] += int(selected.size)
+
+
+def _bootstrap_paired_rows(
+    model_rows: np.ndarray,
+    baseline_rows: np.ndarray,
+    row_tokens: np.ndarray,
+    *,
+    seed: int,
+    samples: int,
+) -> dict:
+    valid = row_tokens > 0
+    differences = model_rows[valid] - baseline_rows[valid]
+    tokens = row_tokens[valid]
+    observed = float(differences.sum() / tokens.sum())
+    rng = np.random.default_rng(seed)
+    estimates = np.empty(samples, dtype=np.float64)
+    for sample in range(samples):
+        indices = rng.integers(0, len(tokens), size=len(tokens))
+        estimates[sample] = differences[indices].sum() / tokens[indices].sum()
+    low, high = np.quantile(estimates, [0.025, 0.975])
+    return {
+        "codonlm_minus_trigram_nats_per_token": observed,
+        "ci95": [float(low), float(high)],
+        "bootstrap_unit": "packed_window",
+        "bootstrap_samples": samples,
+        "seed": seed,
+    }
+
+
+def _mask_audit(model, dataset: MmapPackedDataset, sample_windows: int) -> dict:
+    checked_queries = 0
+    reset_queries = 0
+    for index in range(min(sample_windows, len(dataset))):
+        x, _ = dataset.fetch_batch([index])
+        mask = model.build_attention_mask(x)[0, 0].cpu()
+        segment = torch.cumsum(x[0] == int(model.sep_id), dim=0)
+        expected = (
+            torch.arange(x.size(1)).unsqueeze(1)
+            >= torch.arange(x.size(1)).unsqueeze(0)
+        ) & (segment.unsqueeze(1) == segment.unsqueeze(0))
+        if not torch.equal(mask, expected):
+            raise AssertionError(f"attention mask mismatch in packed window {index}")
+        for query in range(x.size(1)):
+            if int(x[0, query]) == PAD_ID:
+                continue
+            checked_queries += 1
+            if query and int(x[0, query]) == int(model.sep_id):
+                reset_queries += 1
+                if bool(mask[query, query - 1]):
+                    raise AssertionError("separator query can attend across reset boundary")
+            elif query and not bool(mask[query, query - 1]):
+                raise AssertionError("within-segment query cannot attend previous token")
+    return {
+        "sampled_windows": min(sample_windows, len(dataset)),
+        "checked_nonpad_queries": checked_queries,
+        "separator_reset_queries": reset_queries,
+        "status": "passed",
+    }
+
+
+@torch.no_grad()
+def diagnose(args: argparse.Namespace) -> dict:
+    train_path = args.train.expanduser().resolve()
+    test_path = args.test.expanduser().resolve()
+    _, manifest_provenance = bind_dataset_manifest(
+        args.manifest,
+        expected_artifacts={"train_tokens": train_path, "test_tokens": test_path},
+    )
+    contract = resolve_vocabulary_contract(
+        [train_path, test_path],
+        configured_path=args.itos,
+        configured_size=None,
+    )
+    reset_token_ids = frozenset(
+        index for index, token in enumerate(contract.tokens) if token == "<SEP>"
+    )
+    if len(reset_token_ids) != 1:
+        raise ValueError("diagnostic requires exactly one <SEP> token")
+
+    state_dict, cfg, checkpoint_path = load_codon_checkpoint(
+        args.run_dir, ckpt_name=args.checkpoint_name
+    )
+    checkpoint_dataset = bind_checkpoint_dataset(cfg, manifest_provenance)
+    model = build_codon_model_from_cfg(cfg)
+    model.load_state_dict(state_dict, strict=True)
+    device = _device(args.device)
+    model.to(device).eval()
+
+    dataset = MmapPackedDataset(test_path)
+    if dataset.is_dynamic:
+        raise ValueError("packing-aware context diagnostics currently require fixed windows")
+    chunked_windows = _packing_window_flags(args.packing_tsv, len(dataset))
+    mask_audit = _mask_audit(model, dataset, args.mask_audit_windows)
+
+    counts = fit_baselines(
+        train_path,
+        contract.size,
+        args.alpha,
+        reset_token_ids=reset_token_ids,
+    )
+    baseline_results, baseline_tokens, best_simple = evaluate_baselines(
+        test_path,
+        counts,
+        contract.size,
+        args.alpha,
+        reset_token_ids=reset_token_ids,
+    )
+    _, bigram, trigram = counts
+
+    windows = _parse_windows(args.context_windows)
+    context_results = {}
+    full_losses: list[np.ndarray] = []
+    full_targets: list[np.ndarray] = []
+    full_inputs: list[np.ndarray] = []
+    full_rows: list[int] = []
+    row_model = np.zeros(len(dataset), dtype=np.float64)
+    row_trigram = np.zeros(len(dataset), dtype=np.float64)
+    row_tokens = np.zeros(len(dataset), dtype=np.int64)
+
+    for window in windows:
+        label = "full" if window is None else str(window)
+        print(f"[context] evaluating attention window {label}", flush=True)
+        total_nll = 0.0
+        total_tokens = 0
+        for start in range(0, len(dataset), args.batch_size):
+            indices = np.arange(start, min(start + args.batch_size, len(dataset)))
+            xb, yb = dataset.fetch_batch(indices)
+            logits, _ = model(
+                xb.to(device),
+                attention_window=window,
+            )
+            losses = F.cross_entropy(
+                logits.float().reshape(-1, logits.size(-1)),
+                yb.to(device).reshape(-1),
+                ignore_index=PAD_ID,
+                reduction="none",
+            ).reshape(yb.shape)
+            losses_np = losses.cpu().numpy()
+            y_np = yb.numpy()
+            valid = y_np != PAD_ID
+            total_nll += float(losses_np[valid].sum())
+            total_tokens += int(valid.sum())
+            if window is None:
+                x_np = xb.numpy()
+                for row_offset, dataset_index in enumerate(indices):
+                    valid_row = valid[row_offset]
+                    model_row_losses = losses_np[row_offset]
+                    trigram_losses = _trigram_nll(
+                        x_np[row_offset],
+                        y_np[row_offset],
+                        trigram,
+                        bigram,
+                        alpha=args.alpha,
+                        active_size=contract.size - 1,
+                        reset_token_ids=reset_token_ids,
+                    )
+                    row_model[dataset_index] = float(model_row_losses[valid_row].sum())
+                    row_trigram[dataset_index] = float(trigram_losses[valid_row].sum())
+                    row_tokens[dataset_index] = int(valid_row.sum())
+                    full_losses.append(model_row_losses)
+                    full_targets.append(y_np[row_offset])
+                    full_inputs.append(x_np[row_offset])
+                    full_rows.append(int(dataset_index))
+        mean_nll = total_nll / total_tokens
+        context_results[label] = {
+            "attention_window_input_tokens": window,
+            "target_history_interpretation": (
+                "full" if window is None else f"up_to_{window}_tokens_including_current_input"
+            ),
+            "nll": mean_nll,
+            "perplexity": math.exp(mean_nll),
+            "evaluated_tokens": total_tokens,
+        }
+        print(
+            f"[context] window {label}: nll={mean_nll:.6f} "
+            f"ppl={math.exp(mean_nll):.3f}",
+            flush=True,
+        )
+
+    if "full" not in context_results:
+        raise ValueError("context windows must include 'full' for decomposition")
+
+    slices: dict[str, list[float]] = defaultdict(lambda: [0.0, 0])
+    sep_id = next(iter(reset_token_ids))
+    for losses, targets, inputs, row_index in zip(
+        full_losses, full_targets, full_inputs, full_rows, strict=True
+    ):
+        valid = targets != PAD_ID
+        _add_slice(slices, "all", losses, valid)
+        _add_slice(slices, "after_separator", losses, valid & (inputs == sep_id))
+        _add_slice(
+            slices,
+            "window_with_chunk_continuation",
+            losses,
+            valid & np.full(len(valid), chunked_windows[row_index]),
+        )
+        _add_slice(
+            slices,
+            "window_without_chunk_continuation",
+            losses,
+            valid & np.full(len(valid), not chunked_windows[row_index]),
+        )
+        segment_position = 0
+        position_masks: dict[str, np.ndarray] = {}
+        for position in range(len(targets)):
+            if not valid[position]:
+                continue
+            if int(inputs[position]) == sep_id:
+                segment_position = 0
+            name = _position_bin(segment_position)
+            position_masks.setdefault(name, np.zeros(len(valid), dtype=bool))[position] = True
+            segment_position += 1
+        for name, mask in position_masks.items():
+            _add_slice(slices, name, losses, mask)
+        for token_id, token in enumerate(contract.tokens):
+            mask = valid & (targets == token_id)
+            if mask.any():
+                _add_slice(slices, f"target_class_{_token_class(token)}", losses, mask)
+
+    decomposition = {
+        name: {
+            "nll": values[0] / values[1],
+            "perplexity": math.exp(values[0] / values[1]),
+            "tokens": values[1],
+        }
+        for name, values in sorted(slices.items())
+        if values[1]
+    }
+    paired = _bootstrap_paired_rows(
+        row_model,
+        row_trigram,
+        row_tokens,
+        seed=args.seed,
+        samples=args.bootstrap_samples,
+    )
+    return {
+        "schema_version": 1,
+        "status": "diagnostic_complete",
+        "checkpoint": artifact_provenance(checkpoint_path),
+        "checkpoint_dataset": checkpoint_dataset,
+        "dataset_manifest": manifest_provenance,
+        "vocabulary": contract.provenance(),
+        "packing": {
+            "metadata": artifact_provenance(args.packing_tsv)
+            if args.packing_tsv
+            else None,
+            "windows_with_chunk_continuation": int(chunked_windows.sum()),
+            "total_windows": len(dataset),
+        },
+        "attention_mask_audit": mask_audit,
+        "markov": {
+            "history_reset_token_ids": sorted(reset_token_ids),
+            "history_reset_tokens": [contract.tokens[index] for index in reset_token_ids],
+            "evaluated_tokens": baseline_tokens,
+            "best_simple_baseline": best_simple,
+            "results": baseline_results,
+        },
+        "context_ablation": context_results,
+        "loss_decomposition": decomposition,
+        "paired_codonlm_vs_trigram": paired,
+    }
+
+
+def _markdown(report: dict) -> str:
+    lines = [
+        "# Context Learning Diagnostic",
+        "",
+        "## Context Ablation",
+        "",
+        "| Input attention window | NLL | PPL |",
+        "| ---: | ---: | ---: |",
+    ]
+    for name, result in report["context_ablation"].items():
+        lines.append(f"| {name} | {result['nll']:.6f} | {result['perplexity']:.3f} |")
+    lines.extend(
+        [
+            "",
+            "## Segment-Aware Markov Baselines",
+            "",
+            "| Model | NLL | PPL |",
+            "| --- | ---: | ---: |",
+        ]
+    )
+    for name, result in report["markov"]["results"].items():
+        lines.append(
+            f"| {name} | {result['cross_entropy_nats']:.6f} | {result['perplexity']:.3f} |"
+        )
+    paired = report["paired_codonlm_vs_trigram"]
+    lines.extend(
+        [
+            "",
+            "## Paired Gate",
+            "",
+            f"CodonLM minus trigram: `{paired['codonlm_minus_trigram_nats_per_token']:.6f}` "
+            f"nats/token (95% packed-window bootstrap CI "
+            f"`[{paired['ci95'][0]:.6f}, {paired['ci95'][1]:.6f}]`).",
+            "",
+            "## Loss Decomposition",
+            "",
+            "| Slice | Tokens | NLL | PPL |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for name, result in report["loss_decomposition"].items():
+        lines.append(
+            f"| {name} | {result['tokens']} | {result['nll']:.6f} | "
+            f"{result['perplexity']:.3f} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--checkpoint-name", default="best.pt")
+    parser.add_argument("--train", type=Path, required=True)
+    parser.add_argument("--test", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--itos", type=Path)
+    parser.add_argument("--packing-tsv", type=Path)
+    parser.add_argument("--context-windows", default="1,2,4,8,32,128,full")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--device", choices=("cpu", "mps"), default="cpu")
+    parser.add_argument("--alpha", type=float, default=0.01)
+    parser.add_argument("--bootstrap-samples", type=int, default=2000)
+    parser.add_argument("--mask-audit-windows", type=int, default=32)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--output-prefix", type=Path, required=True)
+    args = parser.parse_args()
+
+    report = diagnose(args)
+    args.output_prefix.parent.mkdir(parents=True, exist_ok=True)
+    args.output_prefix.with_suffix(".json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    args.output_prefix.with_suffix(".md").write_text(_markdown(report))
+    print(_markdown(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_ppl_baselines.py
+++ b/scripts/eval_ppl_baselines.py
@@ -51,7 +51,20 @@ def _artifact_hashes(path: Path) -> dict[str, str]:
     return {str(file.resolve()): _hash(file) for file in files if file.exists()}
 
 
-def fit_baselines(train_path: Path, vocab_size: int, alpha: float = 0.01):
+def _previous2(x: np.ndarray, position: int, reset_token_ids: frozenset[int]) -> int:
+    previous = int(x[position])
+    if position == 0 or previous in reset_token_ids:
+        return PAD_ID
+    return int(x[position - 1])
+
+
+def fit_baselines(
+    train_path: Path,
+    vocab_size: int,
+    alpha: float = 0.01,
+    *,
+    reset_token_ids: frozenset[int] = frozenset(),
+):
     if alpha <= 0:
         raise ValueError("alpha must be positive")
     unigram = np.zeros(vocab_size, dtype=np.int64)
@@ -64,7 +77,7 @@ def fit_baselines(train_path: Path, vocab_size: int, alpha: float = 0.01):
                 continue
             unigram[target] += 1
             bigram[previous][target] += 1
-            previous2 = int(x[position - 1]) if position else PAD_ID
+            previous2 = _previous2(x, position, reset_token_ids)
             trigram[(previous2, previous)][target] += 1
     if int(unigram.sum()) == 0:
         raise ValueError(f"training dataset has no evaluable non-PAD targets: {train_path}")
@@ -77,7 +90,14 @@ def _probability(counts, target: int, alpha: float, active_size: int) -> float:
     return (count + alpha) / (total + alpha * active_size)
 
 
-def evaluate_baselines(test_path, counts, vocab_size: int, alpha: float = 0.01):
+def evaluate_baselines(
+    test_path,
+    counts,
+    vocab_size: int,
+    alpha: float = 0.01,
+    *,
+    reset_token_ids: frozenset[int] = frozenset(),
+):
     unigram, bigram, trigram = counts
     active_size = vocab_size - 1
     nll = {name: 0.0 for name in MODEL_NAMES}
@@ -88,7 +108,7 @@ def evaluate_baselines(test_path, counts, vocab_size: int, alpha: float = 0.01):
             if target == PAD_ID:
                 continue
             tokens += 1
-            previous2 = int(x[position - 1]) if position else PAD_ID
+            previous2 = _previous2(x, position, reset_token_ids)
             nll["Uniform"] += math.log(active_size)
             nll["Unigram"] -= math.log(_probability(unigram, target, alpha, active_size))
             nll["Bigram"] -= math.log(
@@ -151,8 +171,22 @@ def main() -> None:
     contract = resolve_vocabulary_contract(
         [train, test], configured_path=args.itos, configured_size=None
     )
-    counts = fit_baselines(train, contract.size, args.alpha)
-    results, tokens, best = evaluate_baselines(test, counts, contract.size, args.alpha)
+    reset_token_ids = frozenset(
+        index for index, token in enumerate(contract.tokens) if token == "<SEP>"
+    )
+    counts = fit_baselines(
+        train,
+        contract.size,
+        args.alpha,
+        reset_token_ids=reset_token_ids,
+    )
+    results, tokens, best = evaluate_baselines(
+        test,
+        counts,
+        contract.size,
+        args.alpha,
+        reset_token_ids=reset_token_ids,
+    )
     report = {
         "schema_version": 1,
         "train": str(train.resolve()),
@@ -166,6 +200,11 @@ def main() -> None:
         "dataset_manifest": manifest_provenance,
         "vocabulary": contract.provenance(),
         "smoothing": {"method": "additive", "alpha": args.alpha},
+        "context_boundary": {
+            "method": "reset_history_after_tokens",
+            "token_ids": sorted(reset_token_ids),
+            "tokens": [contract.tokens[index] for index in sorted(reset_token_ids)],
+        },
         "evaluated_tokens": tokens,
         "best_simple_baseline": best,
         "results": results,

--- a/scripts/evaluate_test.py
+++ b/scripts/evaluate_test.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from src.codonlm.checkpoints import build_codon_model_from_cfg, load_codon_checkpoint
@@ -73,23 +74,46 @@ def _find_test_npz(
 
 @torch.no_grad()
 def evaluate(
-    model: torch.nn.Module, device: torch.device, loader: DataLoader
-) -> tuple[float, float, int]:
-    total_loss = 0.0
+    model: torch.nn.Module,
+    device: torch.device,
+    loader: DataLoader,
+    *,
+    label_smoothing: float = 0.0,
+) -> tuple[float, float, float, int]:
+    total_nll = 0.0
+    total_objective = 0.0
     total_tokens = 0
     for xb, yb in loader:
         xb = xb.to(device)
         yb = yb.to(device)
-        logits, loss = model(xb, yb)
-        if loss is None:
-            continue
-        # reconstruct valid token count (ignore_index=0)
+        logits, _ = model(xb)
         valid = (yb != 0).sum().item()
-        total_loss += float(loss.item()) * max(1, valid)
-        total_tokens += max(1, valid)
-    mean_nll = total_loss / max(1, total_tokens)
+        if valid == 0:
+            continue
+        flat_logits = logits.float().reshape(-1, logits.size(-1))
+        flat_targets = yb.reshape(-1)
+        total_nll += float(
+            F.cross_entropy(
+                flat_logits,
+                flat_targets,
+                ignore_index=0,
+                reduction="sum",
+            ).item()
+        )
+        total_objective += float(
+            F.cross_entropy(
+                flat_logits,
+                flat_targets,
+                ignore_index=0,
+                reduction="sum",
+                label_smoothing=float(label_smoothing),
+            ).item()
+        )
+        total_tokens += valid
+    mean_nll = total_nll / max(1, total_tokens)
+    mean_objective = total_objective / max(1, total_tokens)
     ppl = float(math.exp(min(20.0, mean_nll)))
-    return mean_nll, ppl, total_tokens
+    return mean_nll, ppl, mean_objective, total_tokens
 
 
 def main() -> None:
@@ -110,14 +134,28 @@ def main() -> None:
         type=Path,
         help="Provenance sidecar when --test_npz is derived from the frozen test set.",
     )
+    ap.add_argument(
+        "--checkpoint-name",
+        default="best.pt",
+        help="Checkpoint filename under the run directory (default: best.pt).",
+    )
+    ap.add_argument(
+        "--metric-prefix",
+        default="test",
+        help="Metrics key prefix, for example 'test' or 'last_test'.",
+    )
     ap.add_argument("--batch_size", type=int, default=None, help="evaluation batch size")
     args = ap.parse_args()
+    if not args.metric_prefix.replace("_", "").isalnum():
+        raise ValueError("--metric-prefix must contain only letters, numbers, and underscores")
 
     # accept run_id or run_dir
     run_id, run_dir = resolve_run(args.run_id, args.run_dir)
     repo_root = Path(__file__).resolve().parents[1]
 
-    state_dict, cfg, checkpoint_path = load_codon_checkpoint(run_dir)
+    state_dict, cfg, checkpoint_path = load_codon_checkpoint(
+        run_dir, ckpt_name=args.checkpoint_name
+    )
     model = build_codon_model_from_cfg(cfg)
     model.load_state_dict(state_dict, strict=False)
     model.to(dev()).eval()
@@ -154,19 +192,37 @@ def main() -> None:
     if batch_size is None:
         batch_size = int(cfg.get("eval_batch_size", 16 if dev().type == "mps" else 64))
     loader = DataLoader(ds, batch_size=batch_size, collate_fn=collate_fn)
-    nll, ppl, evaluated_tokens = evaluate(model, dev(), loader)
-    print(f"[test] loss={nll:.4f} ppl={ppl:.2f}")
+    label_smoothing = float(cfg.get("label_smoothing", 0.0))
+    nll, ppl, objective_loss, evaluated_tokens = evaluate(
+        model,
+        dev(),
+        loader,
+        label_smoothing=label_smoothing,
+    )
+    print(
+        f"[test] nll={nll:.4f} ppl={ppl:.2f} "
+        f"objective={objective_loss:.4f} label_smoothing={label_smoothing:.4f}"
+    )
 
     metrics_path = run_dir / "scores" / "metrics.json"
+    prefix = args.metric_prefix
 
     write_merge_metrics(
         metrics_path,
         {
-            "test_loss": float(nll),
-            "test_ppl": float(ppl),
-            "test_evaluated_tokens": int(evaluated_tokens),
-            "test_evaluation_provenance": {
-                "schema_version": 1,
+            f"{prefix}_loss": float(nll),
+            f"{prefix}_nll": float(nll),
+            f"{prefix}_ppl": float(ppl),
+            f"{prefix}_objective_loss": float(objective_loss),
+            f"{prefix}_label_smoothing": label_smoothing,
+            f"{prefix}_evaluated_tokens": int(evaluated_tokens),
+            f"{prefix}_evaluation_provenance": {
+                "schema_version": 2,
+                "loss_definition": {
+                    "nll": "unsmoothed_cross_entropy",
+                    "perplexity": "exp(unsmoothed_cross_entropy)",
+                    "objective": "cross_entropy_with_configured_label_smoothing",
+                },
                 "dataset_manifest": manifest_provenance or {"status": "legacy_unverified"},
                 "checkpoint_dataset": checkpoint_dataset,
                 "checkpoint": artifact_provenance(checkpoint_path),

--- a/scripts/materialize_regularization_ablation.py
+++ b/scripts/materialize_regularization_ablation.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Materialize matched diagnostic configs without mutating primary contracts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from src.codonlm.training.primary_contract import validate_primary_training_config
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def materialize(matrix_path: Path, output_dir: Path) -> dict:
+    matrix_path = matrix_path.expanduser().resolve()
+    matrix = yaml.safe_load(matrix_path.read_text())
+    if int(matrix.get("schema_version", 0)) != 1:
+        raise ValueError("unsupported regularization-ablation schema")
+    base_path = Path(matrix["base_config"])
+    if not base_path.is_absolute():
+        base_path = Path.cwd() / base_path
+    base_path = base_path.resolve()
+    base = yaml.safe_load(base_path.read_text())
+    validate_primary_training_config(base)
+
+    allowed = frozenset(matrix["allowed_overrides"])
+    expected_allowed = frozenset({"label_smoothing", "dropout", "tie_embeddings"})
+    if allowed != expected_allowed:
+        raise ValueError(
+            f"allowed_overrides must be exactly {sorted(expected_allowed)}"
+        )
+    epochs = int(matrix["epochs"])
+    total_steps = int(matrix["scheduler_total_steps"])
+    if epochs < 1 or total_steps != epochs * 500:
+        raise ValueError("diagnostic scheduler horizon must equal epochs * 500")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    resolved = []
+    names = set()
+    for variant in matrix["variants"]:
+        name = str(variant["name"])
+        if not re.fullmatch(r"[a-z0-9_]+", name) or name in names:
+            raise ValueError(f"invalid or duplicate variant name: {name}")
+        names.add(name)
+        overrides = dict(variant["overrides"])
+        unexpected = set(overrides) - allowed
+        if unexpected:
+            raise ValueError(f"variant {name} has undeclared overrides: {sorted(unexpected)}")
+
+        config = dict(base)
+        primary_contract = config.pop("primary_training_contract")
+        config["diagnostic_experiment_contract"] = {
+            "schema_version": 1,
+            "experiment": matrix["experiment"],
+            "variant": name,
+            "base_config": str(base_path),
+            "base_config_sha256": _sha256(base_path),
+            "base_primary_contract": primary_contract,
+            "matrix": str(matrix_path),
+            "matrix_sha256": _sha256(matrix_path),
+            "expected_nonpad_tokens": int(matrix["expected_nonpad_tokens"]),
+            "allowed_overrides": sorted(allowed),
+        }
+        config.update(overrides)
+        config["run_id"] = f"{matrix['experiment']}-{name}"
+        config["seed"] = int(matrix["seed"])
+        config["dataloader_seed"] = int(matrix["seed"])
+        config["epochs"] = epochs
+        config["scheduler_total_steps"] = total_steps
+        config["max_time_minutes"] = None
+        config["early_stop_patience"] = 0
+        config["save_epochs"] = False
+        config["transfer_from"] = None
+
+        output = output_dir / f"{name}.yaml"
+        output.write_text(yaml.safe_dump(config, sort_keys=False))
+        resolved.append(
+            {
+                "name": name,
+                "config": str(output.resolve()),
+                "sha256": _sha256(output),
+                "run_id": config["run_id"],
+                "overrides": overrides,
+            }
+        )
+
+    report = {
+        "schema_version": 1,
+        "experiment": matrix["experiment"],
+        "matrix": str(matrix_path),
+        "matrix_sha256": _sha256(matrix_path),
+        "base_config": str(base_path),
+        "base_config_sha256": _sha256(base_path),
+        "epochs": epochs,
+        "scheduler_total_steps": total_steps,
+        "expected_nonpad_tokens": int(matrix["expected_nonpad_tokens"]),
+        "variants": resolved,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        default=Path("configs/corrected_regularization_ablation.yaml"),
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    report = materialize(args.matrix, args.output_dir)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codonlm/model_tiny_gpt.py
+++ b/src/codonlm/model_tiny_gpt.py
@@ -270,7 +270,38 @@ class TinyGPT(nn.Module):
             "use_shape_guidance": bool(self.use_shape_guidance),
         }
 
-    def forward(self, idx, targets=None, return_aux: bool = False, shape_embeddings=None):
+    def build_attention_mask(
+        self, idx: torch.Tensor, attention_window: int | None = None
+    ) -> torch.Tensor | None:
+        """Build the same causal/segment mask used by forward, optionally local."""
+        _, length = idx.shape
+        if attention_window is not None and int(attention_window) < 1:
+            raise ValueError("attention_window must be at least 1")
+        if self.sep_id is None and attention_window is None:
+            return None
+
+        positions = torch.arange(length, device=idx.device)
+        distance = positions.unsqueeze(1) - positions.unsqueeze(0)
+        causal_mask = distance >= 0
+        if attention_window is not None:
+            causal_mask = causal_mask & (distance < int(attention_window))
+        attn_mask = causal_mask.unsqueeze(0).unsqueeze(0)
+        if self.sep_id is not None:
+            segment_ids = torch.cumsum(idx == int(self.sep_id), dim=1)
+            segment_mask = (
+                segment_ids.unsqueeze(-1) == segment_ids.unsqueeze(-2)
+            ).unsqueeze(1)
+            attn_mask = attn_mask & segment_mask
+        return attn_mask
+
+    def forward(
+        self,
+        idx,
+        targets=None,
+        return_aux: bool = False,
+        shape_embeddings=None,
+        attention_window: int | None = None,
+    ):
         B, T = idx.shape
         x = self.tok_emb(idx)
         if not self.use_rope:
@@ -280,13 +311,7 @@ class TinyGPT(nn.Module):
             x = x + self.shape_proj(shape_embeddings)
         x = self.drop(x)
 
-        attn_mask = None
-        if self.sep_id is not None:
-            sep = (idx == int(self.sep_id))
-            seg = torch.cumsum(sep, dim=1)
-            seg_mask = (seg.unsqueeze(-1) == seg.unsqueeze(-2)).unsqueeze(1)  # (B,1,T,T)
-            causal_mask = torch.tril(torch.ones(T, T, device=idx.device)).unsqueeze(0).unsqueeze(0) > 0  # (1,1,T,T)
-            attn_mask = causal_mask & seg_mask  # Pre-combined mask (B,1,T,T)
+        attn_mask = self.build_attention_mask(idx, attention_window)
 
         if self.use_checkpoint and self.training:
             for blk in self.blocks:
@@ -326,7 +351,9 @@ class TinyGPT(nn.Module):
             return logits, loss, aux
         return logits, loss
 
-    def forward_hidden(self, idx, shape_embeddings=None):
+    def forward_hidden(
+        self, idx, shape_embeddings=None, attention_window: int | None = None
+    ):
         B, T = idx.shape
         x = self.tok_emb(idx)
         if not self.use_rope:
@@ -336,13 +363,7 @@ class TinyGPT(nn.Module):
             x = x + self.shape_proj(shape_embeddings)
         x = self.drop(x)
 
-        attn_mask = None
-        if self.sep_id is not None:
-            sep = (idx == int(self.sep_id))
-            seg = torch.cumsum(sep, dim=1)
-            seg_mask = (seg.unsqueeze(-1) == seg.unsqueeze(-2)).unsqueeze(1)  # (B,1,T,T)
-            causal_mask = torch.tril(torch.ones(T, T, device=idx.device)).unsqueeze(0).unsqueeze(0) > 0  # (1,1,T,T)
-            attn_mask = causal_mask & seg_mask  # Pre-combined mask (B,1,T,T)
+        attn_mask = self.build_attention_mask(idx, attention_window)
 
         for blk in self.blocks:
             x = blk(x, attn_mask=attn_mask)

--- a/tests/test_context_diagnostics.py
+++ b/tests/test_context_diagnostics.py
@@ -1,0 +1,77 @@
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scripts.diagnose_context_learning import (
+    _bootstrap_paired_rows,
+    _packing_window_flags,
+    _parse_windows,
+    _trigram_nll,
+)
+
+
+def test_context_window_parser_preserves_full_and_rejects_zero():
+    assert _parse_windows("1,2,full,2") == [1, 2, None]
+    with pytest.raises(ValueError, match="positive"):
+        _parse_windows("0,full")
+
+
+def test_packing_window_flags_identify_continuations(tmp_path: Path):
+    path = tmp_path / "packing.tsv"
+    fields = [
+        "window_index",
+        "continues_from_previous",
+        "continues_to_next",
+    ]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t")
+        writer.writeheader()
+        writer.writerow(
+            {
+                "window_index": 0,
+                "continues_from_previous": 0,
+                "continues_to_next": 0,
+            }
+        )
+        writer.writerow(
+            {
+                "window_index": 1,
+                "continues_from_previous": 1,
+                "continues_to_next": 0,
+            }
+        )
+    assert _packing_window_flags(path, 2).tolist() == [False, True]
+
+
+def test_segment_aware_trigram_ignores_pre_separator_token():
+    counts = np.zeros(6, dtype=np.int64)
+    counts[2] = 10
+    trigram = {(0, 4): counts}
+    x_a = np.array([1, 4])
+    x_b = np.array([5, 4])
+    y = np.array([0, 2])
+    kwargs = {
+        "trigram": trigram,
+        "bigram": {},
+        "alpha": 0.01,
+        "active_size": 5,
+        "reset_token_ids": frozenset({4}),
+    }
+    assert np.array_equal(
+        _trigram_nll(x_a, y, **kwargs),
+        _trigram_nll(x_b, y, **kwargs),
+    )
+
+
+def test_paired_bootstrap_reports_positive_model_gap():
+    result = _bootstrap_paired_rows(
+        np.array([3.0, 6.0]),
+        np.array([2.0, 4.0]),
+        np.array([1, 2]),
+        seed=7,
+        samples=100,
+    )
+    assert result["codonlm_minus_trigram_nats_per_token"] == pytest.approx(1.0)
+    assert result["ci95"][0] > 0

--- a/tests/test_evaluation_provenance.py
+++ b/tests/test_evaluation_provenance.py
@@ -126,6 +126,9 @@ def test_corrected_test_evaluation_emits_frozen_provenance(tmp_path):
     assert provenance["dataset_manifest"]["dataset_id"] == manifest["dataset"]["id"]
     assert provenance["checkpoint_dataset"]["status"] == "checkpoint_manifest_verified"
     assert report["test_evaluated_tokens"] > 0
+    assert report["test_loss"] == report["test_nll"]
+    assert report["test_ppl"] == pytest.approx(np.exp(report["test_nll"]))
+    assert provenance["loss_definition"]["nll"] == "unsmoothed_cross_entropy"
 
     without_manifest = subprocess.run(
         command[:5] + command[7:],
@@ -135,6 +138,39 @@ def test_corrected_test_evaluation_emits_frozen_provenance(tmp_path):
     )
     assert without_manifest.returncode != 0
     assert "explicit frozen dataset manifest" in without_manifest.stderr
+
+
+def test_corrected_test_evaluation_namespaces_checkpoint_metrics(tmp_path):
+    manifest_path, _, run_dir = _corrected_run(tmp_path)
+    best = torch.load(run_dir / "checkpoints" / "best.pt", map_location="cpu")
+    torch.save(best, run_dir / "checkpoints" / "last.pt")
+    command = [
+        "python",
+        "-m",
+        "scripts.evaluate_test",
+        "--run_dir",
+        str(run_dir),
+        "--manifest",
+        str(manifest_path),
+        "--checkpoint-name",
+        "last.pt",
+        "--metric-prefix",
+        "last_test",
+        "--batch_size",
+        "2",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FORCE_CPU": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads((run_dir / "scores" / "metrics.json").read_text())
+    assert report["last_test_ppl"] == pytest.approx(np.exp(report["last_test_nll"]))
+    checkpoint = report["last_test_evaluation_provenance"]["checkpoint"]
+    assert checkpoint["path"].endswith("last.pt")
 
 
 def test_corrected_test_evaluation_accepts_verified_derived_control(tmp_path):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from src.codonlm.model_tiny_gpt import TinyGPT
 
@@ -23,6 +24,31 @@ def test_tinygpt_sdpa():
     logits, loss = m(x, y)
     assert logits.shape == (B, T, vocab)
     assert loss is not None and torch.isfinite(loss)
+
+
+def test_attention_window_and_separator_mask_match_context_contract():
+    model = TinyGPT(
+        vocab_size=8,
+        block_size=5,
+        n_layer=1,
+        n_head=1,
+        n_embd=8,
+        dropout=0.0,
+        sep_id=3,
+    )
+    tokens = torch.tensor([[1, 4, 3, 5, 6]])
+
+    full = model.build_attention_mask(tokens)[0, 0]
+    assert full[1, 0]
+    assert not full[3, 1]
+    assert full[3, 2]
+    assert full[4, 2]
+
+    local = model.build_attention_mask(tokens, attention_window=1)[0, 0]
+    assert torch.equal(local, torch.eye(5, dtype=torch.bool))
+
+    with pytest.raises(ValueError, match="at least 1"):
+        model.build_attention_mask(tokens, attention_window=0)
 
 
 def test_tinygpt_swiglu_shapes():
@@ -59,4 +85,3 @@ def test_tinygpt_rope_shapes():
     logits, loss = m(x, x)
     assert logits.shape == (B, T, vocab)
     assert loss is not None and torch.isfinite(loss)
-

--- a/tests/test_ppl_baselines.py
+++ b/tests/test_ppl_baselines.py
@@ -66,3 +66,31 @@ def test_unseen_contexts_are_smoothed(tmp_path):
     results, tokens, _ = evaluate_baselines(test, fit_baselines(train, 6), 6)
     assert tokens == 1
     assert all(np.isfinite(item["perplexity"]) for item in results.values())
+
+
+def test_trigram_history_resets_after_separator(tmp_path):
+    train = tmp_path / "train.npz"
+    first = np.array([[1, 4]], dtype=np.int32)
+    second = np.array([[5, 4]], dtype=np.int32)
+    targets = np.array([[0, 2]], dtype=np.int32)
+    np.savez(train, X=first, Y=targets)
+    reset = frozenset({4})
+
+    reset_counts = fit_baselines(train, 6, reset_token_ids=reset)
+    leaked_counts = fit_baselines(train, 6)
+
+    reset_key = (0, 4)
+    assert reset_counts[2][reset_key][2] == 1
+    assert (1, 4) in leaked_counts[2]
+
+    test_a = tmp_path / "test_a.npz"
+    test_b = tmp_path / "test_b.npz"
+    np.savez(test_a, X=first, Y=targets)
+    np.savez(test_b, X=second, Y=targets)
+    result_a, _, _ = evaluate_baselines(
+        test_a, reset_counts, 6, reset_token_ids=reset
+    )
+    result_b, _, _ = evaluate_baselines(
+        test_b, reset_counts, 6, reset_token_ids=reset
+    )
+    assert result_a["Trigram"] == result_b["Trigram"]

--- a/tests/test_regularization_ablation.py
+++ b/tests/test_regularization_ablation.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.materialize_regularization_ablation import materialize
+
+
+def test_regularization_ablation_materializes_only_declared_differences(tmp_path):
+    report = materialize(
+        Path("configs/corrected_regularization_ablation.yaml"),
+        tmp_path,
+    )
+    assert len(report["variants"]) == 4
+    assert report["expected_nonpad_tokens"] == 50_476_876
+
+    configs = [
+        yaml.safe_load(Path(item["config"]).read_text())
+        for item in report["variants"]
+    ]
+    for config in configs:
+        assert "primary_training_contract" not in config
+        assert config["diagnostic_experiment_contract"]["base_primary_contract"]
+        assert config["epochs"] == 2
+        assert config["scheduler_total_steps"] == 1000
+        assert config["transfer_from"] is None
+
+    ignored = {
+        "diagnostic_experiment_contract",
+        "run_id",
+        "label_smoothing",
+        "dropout",
+        "tie_embeddings",
+    }
+    reference = {key: value for key, value in configs[0].items() if key not in ignored}
+    for config in configs[1:]:
+        comparable = {key: value for key, value in config.items() if key not in ignored}
+        assert comparable == reference
+
+
+def test_regularization_ablation_rejects_undeclared_override(tmp_path):
+    source = yaml.safe_load(
+        Path("configs/corrected_regularization_ablation.yaml").read_text()
+    )
+    source["variants"][0]["overrides"]["n_layer"] = 11
+    matrix = tmp_path / "invalid.yaml"
+    matrix.write_text(yaml.safe_dump(source))
+    with pytest.raises(ValueError, match="undeclared overrides"):
+        materialize(matrix, tmp_path / "out")


### PR DESCRIPTION
## Summary
- compute checkpoint NLL and perplexity from unsmoothed cross-entropy so they are comparable with unigram and Markov baselines
- retain the configured label-smoothed objective as a separate diagnostic metric
- support distinct checkpoint names and metric prefixes for auditable best-versus-last comparisons
- document the corrected evaluation workflow

## Verification
- `ruff check scripts/evaluate_test.py tests/test_evaluation_provenance.py`
- `pytest -q tests/test_evaluation_provenance.py` (8 passed)
- `git diff --check`

## Initial corrected result
On the frozen genome-held-out test set, epoch-4 `best.pt` has unsmoothed PPL 48.267 and epoch-10 `last.pt` has PPL 48.687 over 2,228,589 identical tokens. The trigram baseline is 42.037, so the primary intrinsic promotion gate is not met and requires diagnosis before downstream promotion.