### PR TITLE
Evaluate regularization ablation on validation split

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -85,6 +85,14 @@ an architectural intervention.
 
 - [x] Complete the matched regularization ablation and evaluate best checkpoints
   with manifest-bound unsmoothed validation NLL.
+- [~] Run the token-matched effective-batch ablation. Reuse the completed
+  batch-128 untied condition and train random-initialized batch-64 and batch-32
+  conditions at 2,000 and 4,000 optimizer steps respectively. Keep physical batch,
+  seed, data order, model, learning rate, two-epoch token exposure, and validation
+  selection fixed.
+- [ ] If optimization still trails trigram, predeclare a zero-initialized local
+  causal-convolution ablation before testing broader architecture changes. Keep any
+  explicit Markov-logit residual separately labelled as a hybrid model.
 - [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test
   tokens; report loss, perplexity, bits/codon, and improvement over the best baseline.
 - [ ] Extract causal embeddings with dataset/checkpoint/vocabulary/code provenance.

--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -76,6 +76,15 @@ gain saturating at four input tokens, with no gain from longer context and a pai
 before considering an architecture extension. The checklist remains open until all
 Phase 2 runs and matched evaluations are complete.
 
+The four-condition regularization matrix is complete. At identical two-epoch
+exposure, the untied/no-smoothing/dropout-0.05 variant reached validation PPL
+`45.210`, compared with `49.167` for the reference. It remains behind the validation
+bigram (`43.927`) and trigram (`42.459`), so the primary gate remains failed. Carry
+the untied variant into a matched effective-batch-size ablation before considering
+an architectural intervention.
+
+- [x] Complete the matched regularization ablation and evaluate best checkpoints
+  with manifest-bound unsmoothed validation NLL.
 - [ ] Evaluate uniform, unigram, bigram, trigram, and CodonLM on identical test
   tokens; report loss, perplexity, bits/codon, and improvement over the best baseline.
 - [ ] Extract causal embeddings with dataset/checkpoint/vocabulary/code provenance.

--- a/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
+++ b/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
@@ -76,6 +76,28 @@ configs intentionally omit `primary_training_contract`.
 Do not run the matrix until the context and mask diagnostic completes. A masking or
 packing defect invalidates a regularization comparison.
 
+### Result
+
+All four variants completed 1,000 optimizer steps and `50,476,876` non-PAD
+training tokens from random initialization. Manifest-bound unsmoothed evaluation
+used the same `3,228,255` validation targets:
+
+| Variant | Validation NLL | Validation PPL |
+| --- | ---: | ---: |
+| Reference | 3.895214 | 49.167 |
+| No smoothing | 3.891479 | 48.983 |
+| No smoothing, dropout 0.05 | 3.910927 | 49.945 |
+| No smoothing, dropout 0.05, untied embeddings | 3.811323 | 45.210 |
+| Bigram baseline | 3.782536 | 43.927 |
+| Trigram baseline | 3.748532 | 42.459 |
+
+Untying the input and output embeddings produced the only substantial improvement,
+reducing PPL by about 8% relative to the reference. Removing smoothing alone was
+nearly neutral, and lower dropout with tied embeddings was worse. The selected
+diagnostic variant still trails both Markov baselines, so it is an optimization
+candidate rather than a promoted primary model. Exact checkpoint and dataset hashes
+are recorded in `docs/benchmarks/corrected_regularization_ablation.json`.
+
 ## Local Convolution Versus `n+x`
 
 A causal convolutional branch summarizes recent input tokens before the ordinary

--- a/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
+++ b/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
@@ -98,6 +98,97 @@ diagnostic variant still trails both Markov baselines, so it is an optimization
 candidate rather than a promoted primary model. Exact checkpoint and dataset hashes
 are recorded in `docs/benchmarks/corrected_regularization_ablation.json`.
 
+## Effective-Batch Ablation
+
+The selected regularization condition fixes:
+
+```yaml
+label_smoothing: 0.0
+dropout: 0.05
+tie_embeddings: false
+batch_size: 4
+```
+
+The completed effective-batch-128 condition is reused as the anchor. Two additional
+random-initialized conditions change only accumulation and the token-aligned
+scheduler horizon:
+
+| Effective batch | Accumulation | Optimizer steps over two epochs |
+| ---: | ---: | ---: |
+| 128 | 32 | 1,000 |
+| 64 | 16 | 2,000 |
+| 32 | 8 | 4,000 |
+
+Every condition uses seed 1337 and processes `50,476,876` non-PAD tokens. Physical
+batch size remains four, so device activation memory is approximately matched.
+This is a token- and compute-exposure comparison: smaller effective batches receive
+more frequent, noisier optimizer updates. It does not establish that a smaller
+batch has a universally better asymptotic optimum.
+
+Selection uses manifest-bound unsmoothed validation NLL. The frozen test split
+remains unavailable. A useful result must improve on the batch-128 PPL of `45.210`;
+the primary promotion gate additionally requires beating validation bigram
+(`43.927`) and trigram (`42.459`).
+
+## Candidate Architecture Interventions
+
+Architecture changes remain gated on the effective-batch result. The proposed order
+is:
+
+1. Add a zero-initialized causal convolutional residual with local kernels such as
+   3, 5, and 9 codons. This directly represents short transitions while preserving
+   the initial Transformer function.
+2. Evaluate a separately labelled Markov-residual hybrid that adds a learned
+   Transformer correction to fixed trigram logits. This is useful for practical PPL
+   but cannot demonstrate that the Transformer independently learned trigram
+   structure.
+3. Factor next-codon probability into next-amino-acid and synonymous-codon terms.
+   Report both components so protein-sequence prediction is not conflated with
+   organism-specific synonymous choice.
+4. Consider multi-scale local/global attention and segment-relative position resets
+   only after the narrower local intervention is measured.
+
+Multi-offset `n+x` heads supervise distant targets and are not a substitute for
+learning the ordinary next-token transition. Width, depth, RoPE, and SwiGLU do not
+specifically target the observed failure and remain lower priority.
+
+## Biological Context Length
+
+There is no single biological correlation length. The trigram estimator models
+`P(x_t | x_(t-2), x_(t-1))`: two preceding codons, or six preceding nucleotides,
+condition the next codon. This is a minimal test of context-dependent sequence
+grammar, not a structural model.
+
+Relevant scales differ by mechanism:
+
+| Mechanism | Representative scale |
+| --- | --- |
+| Codon-pair preference | Two adjacent codons |
+| Local DNA shape | A sliding pentamer, about 5 bp |
+| Ribosome-protected mRNA | Roughly 20-30 nt, about 7-10 codons |
+| Local protein secondary-structure prediction | Commonly local windows around 13-17 residues |
+| Protein tertiary contacts | Often tens to hundreds of residues apart |
+| RNA secondary structure | Can pair positions tens to hundreds of nucleotides apart |
+
+Primary studies support non-random adjacent codon preferences and context-dependent
+translation speed ([Buchan et al., 2006](https://pmc.ncbi.nlm.nih.gov/articles/PMC1363775/);
+[Chevance et al., 2014](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1004392)).
+The DNAshape method predicts local shape from sliding pentamers
+([Zhou et al., 2013](https://pmc.ncbi.nlm.nih.gov/articles/PMC3692085/)).
+Ribosome profiling observes protected fragments around 20-30 nt, but footprint
+length is not itself a statistical correlation length
+([Lareau et al., 2014](https://pmc.ncbi.nlm.nih.gov/articles/PMC4052883/)).
+Protein secondary structure contains short-range information, while complete folds
+depend strongly on nonlocal contacts
+([Crooks and Brenner, 2004](https://academic.oup.com/bioinformatics/article/20/10/1603/237316);
+[Adhikari et al., 2017](https://link.springer.com/article/10.1186/s12859-017-1807-5)).
+
+Lower PPL is therefore necessary for demonstrating improved sequence modeling but
+is not evidence of structural recovery by itself. The structural hypothesis must be
+tested through order-destroying sequence controls, context ablations, grouped
+DNA-shape baselines, homology-controlled protein evaluations, and explicit controls
+for amino-acid, codon, GC, and taxonomic composition.
+
 ## Local Convolution Versus `n+x`
 
 A causal convolutional branch summarizes recent input tokens before the ordinary

--- a/docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md
+++ b/docs/CORRECTED_PRIMARY_INTRINSIC_EVALUATION.md
@@ -1,5 +1,18 @@
 # Corrected Primary Intrinsic Evaluation
 
+For checkpoint or hyperparameter selection, evaluate the frozen validation split
+without touching the final test split:
+
+```bash
+python -m scripts.evaluate_test \
+  --run_dir runs/<run-id> \
+  --split validation \
+  --manifest data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+```
+
+This records ordinary unsmoothed NLL and perplexity under `validation_*` keys and
+binds the selected file to the manifest's `val_tokens` artifact.
+
 ## Status
 
 Interim seed-1337 result recorded on 2026-07-25. The first corrected primary

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -796,6 +796,16 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     four-condition, two-epoch regularization matrix covering label smoothing,
     dropout, and tied embeddings. Architecture extensions remain blocked until this
     ordinary next-token optimization ablation is evaluated.
+*   **Corrected Regularization Ablation (2026-07-27):** Completed four
+    random-initialized, two-epoch runs at exactly 1,000 optimizer steps and
+    50,476,876 non-PAD tokens each, with no invalid accumulation groups. Added
+    manifest-bound validation evaluation so hyperparameters can be selected without
+    exposing the final test split. Unsmoothed validation PPL was 49.167 for the
+    reference, 48.983 without smoothing, 49.945 without smoothing at dropout 0.05,
+    and 45.210 for the dropout-0.05 untied-embedding variant. The selected variant
+    improves materially but remains behind validation bigram (43.927) and trigram
+    (42.459), so the primary promotion gate remains failed. The next diagnostic is
+    an effective-batch-size ablation using the untied configuration.
 
 ---
 *End of Log*

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -806,6 +806,16 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     improves materially but remains behind validation bigram (43.927) and trigram
     (42.459), so the primary promotion gate remains failed. The next diagnostic is
     an effective-batch-size ablation using the untied configuration.
+*   **Effective-Batch Diagnostic Launch (2026-07-27):** Reused the completed
+    no-smoothing, dropout-0.05, untied effective-batch-128 run as the matched anchor
+    and launched effective-batch-64 and effective-batch-32 conditions sequentially
+    on MPS. Physical batch remains four; accumulation changes from 32 to 16 and 8,
+    while the two-epoch scheduler horizons change from 1,000 to 2,000 and 4,000
+    optimizer steps. All conditions use seed 1337 and exactly 50,476,876 expected
+    non-PAD tokens. Selection remains validation-only. Documented the next
+    architecture decision order and the distinction between short codon/DNA-shape
+    context and long-range protein/RNA structure; lower PPL is treated as necessary
+    sequence-model evidence rather than sufficient structural validation.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_regularization_ablation.json
+++ b/docs/benchmarks/corrected_regularization_ablation.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "experiment": "corrected-codonlm-v1-regularization-ablation",
+  "evaluation_split": "validation",
+  "evaluated_tokens": 3228255,
+  "expected_train_nonpad_tokens_per_variant": 50476876,
+  "optimizer_steps_per_variant": 1000,
+  "matrix_sha256": "eecab64e722b343b7194c2f4ba2133a7208351ae5e476cd620908e88f92e146b",
+  "validation_tokens_sha256": "7b2cf01adaac41f13b2bedce1e15da2370b703bae449092d92d4e51939a8f142",
+  "results": {
+    "reference": {
+      "checkpoint_sha256": "c8d23568eab040c28fd71f8bec896912c6114f84fbc4afa5349cb78d7b8e3ba7",
+      "dropout": 0.1,
+      "label_smoothing": 0.05,
+      "tie_embeddings": true,
+      "validation_nll": 3.8952135440383038,
+      "validation_objective_loss": 3.9291823231029612,
+      "validation_ppl": 49.16655146568979
+    },
+    "no_smoothing": {
+      "checkpoint_sha256": "d6c97d8ebb6e28da3d8431bce5c9d1975811de4be13fee058719c5d56e3a88d1",
+      "dropout": 0.1,
+      "label_smoothing": 0.0,
+      "tie_embeddings": true,
+      "validation_nll": 3.8914789055929595,
+      "validation_objective_loss": 3.8914789055929595,
+      "validation_ppl": 48.98327462175625
+    },
+    "no_smoothing_low_dropout": {
+      "checkpoint_sha256": "7b0c1f75e0cf9509d31118433c78b67de25528ad8dc6088cecf670be536c9dd5",
+      "dropout": 0.05,
+      "label_smoothing": 0.0,
+      "tie_embeddings": true,
+      "validation_nll": 3.91092660317358,
+      "validation_objective_loss": 3.91092660317358,
+      "validation_ppl": 49.945209928739104
+    },
+    "no_smoothing_low_dropout_untied": {
+      "checkpoint_sha256": "d93fc328b048e377fae8bcebcf3ee2e6d4bfb8b4321a082a72553f3e4d60cc67",
+      "dropout": 0.05,
+      "label_smoothing": 0.0,
+      "tie_embeddings": false,
+      "validation_nll": 3.8113232964190407,
+      "validation_objective_loss": 3.8113232964190407,
+      "validation_ppl": 45.21022582960136
+    }
+  },
+  "validation_baselines": {
+    "bigram_nll": 3.7825355020478693,
+    "bigram_ppl": 43.92727835987551,
+    "trigram_nll": 3.7485324057200664,
+    "trigram_ppl": 42.458724072604106,
+    "unigram_nll": 3.8921827504970525,
+    "unigram_ppl": 49.01776338593121
+  },
+  "decision": {
+    "selected_variant": "no_smoothing_low_dropout_untied",
+    "status": "optimization_candidate_only",
+    "primary_gate_passed": false,
+    "next_step": "matched effective-batch-size ablation"
+  }
+}

--- a/scripts/eval_ppl_baselines.py
+++ b/scripts/eval_ppl_baselines.py
@@ -154,6 +154,12 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--train", "--train_npz", dest="train", required=True)
     parser.add_argument("--test", "--test_npz", dest="test", required=True)
+    parser.add_argument(
+        "--split",
+        choices=("test", "validation"),
+        default="test",
+        help="Manifest role of the evaluation input (default: test).",
+    )
     parser.add_argument("--itos", help="Vocabulary artifact; defaults to dataset-adjacent itos.txt")
     parser.add_argument("--manifest", type=Path, help="Dataset manifest to hash into provenance")
     parser.add_argument("--config", type=Path, help="Evaluation/run config to hash into provenance")
@@ -163,9 +169,12 @@ def main() -> None:
     train, test = Path(args.train), Path(args.test)
     manifest_provenance = {"status": "legacy_unverified"}
     if args.manifest is not None:
+        evaluation_role = (
+            "val_tokens" if args.split == "validation" else "test_tokens"
+        )
         _, manifest_provenance = bind_dataset_manifest(
             args.manifest,
-            expected_artifacts={"train_tokens": train, "test_tokens": test},
+            expected_artifacts={"train_tokens": train, evaluation_role: test},
             require_scientific=False,
         )
     contract = resolve_vocabulary_contract(
@@ -189,6 +198,7 @@ def main() -> None:
     )
     report = {
         "schema_version": 1,
+        "evaluation_split": args.split,
         "train": str(train.resolve()),
         "test": str(test.resolve()),
         "dataset_sha256": {**_artifact_hashes(train), **_artifact_hashes(test)},

--- a/scripts/evaluate_test.py
+++ b/scripts/evaluate_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Evaluate test cross-entropy and perplexity for a trained run.
+Evaluate validation or test cross-entropy and perplexity for a trained run.
 
 Usage:
   python -m scripts.evaluate_test --run_dir outputs/checkpoints/<RUN_ID>
@@ -72,6 +72,16 @@ def _find_test_npz(
     return repo_root / f"data/processed/test_bs{cfg['block_size']}.npz"
 
 
+def _find_validation_npz(cfg: dict, repo_root: Path) -> Path:
+    val_npz_cfg = cfg.get("val_npz")
+    if isinstance(val_npz_cfg, list) and val_npz_cfg:
+        val_npz_cfg = val_npz_cfg[0]
+    if not val_npz_cfg:
+        raise ValueError("validation evaluation requires val_npz in the run config")
+    path = Path(val_npz_cfg)
+    return path if path.is_absolute() else repo_root / path
+
+
 @torch.no_grad()
 def evaluate(
     model: torch.nn.Module,
@@ -121,6 +131,12 @@ def main() -> None:
     ap.add_argument("--run_dir", help="outputs/checkpoints/<RUN_ID>")
     ap.add_argument("--run_id", help="Run id (alternative to --run_dir)")
     ap.add_argument(
+        "--split",
+        choices=("test", "validation"),
+        default="test",
+        help="Frozen dataset split to evaluate (default: test).",
+    )
+    ap.add_argument(
         "--data_dir", help="override test NPZ directory (contains test_bs*.npz)"
     )
     ap.add_argument("--test_npz", type=Path, help="explicit test or control dataset")
@@ -141,13 +157,18 @@ def main() -> None:
     )
     ap.add_argument(
         "--metric-prefix",
-        default="test",
-        help="Metrics key prefix, for example 'test' or 'last_test'.",
+        default=None,
+        help="Metrics key prefix; defaults to the selected split name.",
     )
     ap.add_argument("--batch_size", type=int, default=None, help="evaluation batch size")
     args = ap.parse_args()
-    if not args.metric_prefix.replace("_", "").isalnum():
+    metric_prefix = args.metric_prefix or args.split
+    if not metric_prefix.replace("_", "").isalnum():
         raise ValueError("--metric-prefix must contain only letters, numbers, and underscores")
+    if args.split == "validation" and args.test_npz is not None:
+        raise ValueError("--test_npz cannot be used with --split validation")
+    if args.split == "validation" and args.derived_provenance is not None:
+        raise ValueError("--derived_provenance is only supported for the test split")
 
     # accept run_id or run_dir
     run_id, run_dir = resolve_run(args.run_id, args.run_dir)
@@ -161,14 +182,21 @@ def main() -> None:
     model.to(dev()).eval()
 
     data_dir_opt = Path(args.data_dir) if args.data_dir else None
-    test_npz = args.test_npz or _find_test_npz(run_id, cfg, repo_root, data_dir_opt)
-    test_npz = test_npz.expanduser().resolve()
+    if args.split == "validation":
+        evaluation_npz = _find_validation_npz(cfg, repo_root)
+        artifact_role = "val_tokens"
+    else:
+        evaluation_npz = args.test_npz or _find_test_npz(
+            run_id, cfg, repo_root, data_dir_opt
+        )
+        artifact_role = "test_tokens"
+    evaluation_npz = evaluation_npz.expanduser().resolve()
     manifest_provenance = None
     derived_provenance = None
     if args.manifest is not None:
         if args.derived_provenance is None:
             _, manifest_provenance = bind_dataset_manifest(
-                args.manifest, expected_artifacts={"test_tokens": test_npz}
+                args.manifest, expected_artifacts={artifact_role: evaluation_npz}
             )
         else:
             manifest, manifest_provenance = bind_dataset_manifest(args.manifest)
@@ -176,7 +204,7 @@ def main() -> None:
                 manifest, args.manifest.expanduser().resolve(), "test_tokens"
             )
             derived_provenance = bind_derived_dataset(
-                test_npz,
+                evaluation_npz,
                 args.derived_provenance,
                 manifest_provenance=manifest_provenance,
                 source_artifact_path=source_test,
@@ -184,7 +212,7 @@ def main() -> None:
     elif args.derived_provenance is not None:
         raise ValueError("--derived_provenance requires --manifest")
     checkpoint_dataset = bind_checkpoint_dataset(cfg, manifest_provenance)
-    ds = PackedDataset(test_npz)
+    ds = PackedDataset(evaluation_npz)
 
     collate_fn = dynamic_lm_collate_fn if getattr(ds, "is_dynamic", False) else None
 
@@ -200,12 +228,12 @@ def main() -> None:
         label_smoothing=label_smoothing,
     )
     print(
-        f"[test] nll={nll:.4f} ppl={ppl:.2f} "
+        f"[{args.split}] nll={nll:.4f} ppl={ppl:.2f} "
         f"objective={objective_loss:.4f} label_smoothing={label_smoothing:.4f}"
     )
 
     metrics_path = run_dir / "scores" / "metrics.json"
-    prefix = args.metric_prefix
+    prefix = metric_prefix
 
     write_merge_metrics(
         metrics_path,
@@ -226,7 +254,7 @@ def main() -> None:
                 "dataset_manifest": manifest_provenance or {"status": "legacy_unverified"},
                 "checkpoint_dataset": checkpoint_dataset,
                 "checkpoint": artifact_provenance(checkpoint_path),
-                "test_tokens": artifact_provenance(test_npz),
+                artifact_role: artifact_provenance(evaluation_npz),
                 "derived_dataset": derived_provenance,
             },
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/tests/test_evaluation_provenance.py
+++ b/tests/test_evaluation_provenance.py
@@ -34,6 +34,7 @@ def _corrected_run(tmp_path: Path):
         "n_embd": 16,
         "dropout": 0.0,
         "use_sdpa": True,
+        "val_npz": [str(manifest_path.parent / "val.npz")],
         "test_npz": [str(manifest_path.parent / "test.npz")],
         "dataset_manifest": {
             "dataset_id": manifest["dataset"]["id"],
@@ -171,6 +172,40 @@ def test_corrected_test_evaluation_namespaces_checkpoint_metrics(tmp_path):
     assert report["last_test_ppl"] == pytest.approx(np.exp(report["last_test_nll"]))
     checkpoint = report["last_test_evaluation_provenance"]["checkpoint"]
     assert checkpoint["path"].endswith("last.pt")
+
+
+def test_corrected_validation_evaluation_binds_validation_artifact(tmp_path):
+    manifest_path, manifest, run_dir = _corrected_run(tmp_path)
+    command = [
+        "python",
+        "-m",
+        "scripts.evaluate_test",
+        "--run_dir",
+        str(run_dir),
+        "--split",
+        "validation",
+        "--manifest",
+        str(manifest_path),
+        "--batch_size",
+        "2",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FORCE_CPU": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads((run_dir / "scores" / "metrics.json").read_text())
+    assert report["validation_ppl"] == pytest.approx(
+        np.exp(report["validation_nll"])
+    )
+    provenance = report["validation_evaluation_provenance"]
+    assert provenance["dataset_manifest"]["dataset_id"] == manifest["dataset"]["id"]
+    assert set(provenance["dataset_manifest"]["bound_artifacts"]) == {"val_tokens"}
+    assert provenance["val_tokens"]["path"].endswith("val.npz")
+    assert "test_tokens" not in provenance
 
 
 def test_corrected_test_evaluation_accepts_verified_derived_control(tmp_path):

--- a/tests/test_ppl_baselines.py
+++ b/tests/test_ppl_baselines.py
@@ -1,10 +1,12 @@
 import json
+import sys
 from pathlib import Path
 
 import numpy as np
 import pytest
 
-from scripts.eval_ppl_baselines import evaluate_baselines, fit_baselines
+from scripts.eval_ppl_baselines import evaluate_baselines, fit_baselines, main
+from scripts.training_preflight import _write_fixture
 from src.codonlm.training.vocabulary import (
     VocabularyContractError,
     resolve_vocabulary_contract,
@@ -94,3 +96,38 @@ def test_trigram_history_resets_after_separator(tmp_path):
         test_b, reset_counts, 6, reset_token_ids=reset
     )
     assert result_a["Trigram"] == result_b["Trigram"]
+
+
+def test_validation_baselines_bind_validation_manifest_artifact(
+    tmp_path, monkeypatch
+):
+    manifest_path, _ = _write_fixture(tmp_path / "freeze")
+    output = tmp_path / "validation_baselines"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "eval_ppl_baselines.py",
+            "--train",
+            str(manifest_path.parent / "train.npz"),
+            "--test",
+            str(manifest_path.parent / "val.npz"),
+            "--split",
+            "validation",
+            "--itos",
+            str(manifest_path.parent / "itos.txt"),
+            "--manifest",
+            str(manifest_path),
+            "--output-prefix",
+            str(output),
+        ],
+    )
+
+    main()
+
+    report = json.loads(output.with_suffix(".json").read_text())
+    assert report["evaluation_split"] == "validation"
+    assert set(report["dataset_manifest"]["bound_artifacts"]) == {
+        "train_tokens",
+        "val_tokens",
+    }


### PR DESCRIPTION
## Summary
- add manifest-bound validation split support to CodonLM and Markov perplexity evaluators
- evaluate all four completed regularization variants without exposing the frozen test set
- record exact validation metrics, checkpoint hashes, and the failed Markov promotion gate
- update the corrected training track and development documentation

## Result
The no-smoothing, dropout-0.05, untied-embedding variant reached validation PPL 45.210 versus 49.167 for the reference. It remains behind bigram (43.927) and trigram (42.459), so it is selected only for the next effective-batch diagnostic.

## Testing
- `python -m pytest -q` (312 passed, 1 skipped, 1 xpassed)
- `ruff check scripts/evaluate_test.py scripts/eval_ppl_baselines.py tests/test_evaluation_provenance.py tests/test_ppl_baselines.py`
- `git diff --check`