### PR TITLE
Add adaptive warmup for batch experiments

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -90,9 +90,10 @@ an architectural intervention.
   conditions at 2,000 and 4,000 optimizer steps respectively. Keep physical batch,
   seed, data order, model, learning rate, two-epoch token exposure, and validation
   selection fixed.
-- [ ] Run a narrow effective-batch-64 learning-rate ablation. The `3e-4` condition
-  beats bigram at epoch 1 but regresses at epoch 2; compare lower predeclared rates
-  at matched seed, token exposure, scheduler shape, and validation-only selection.
+- [~] Run a narrow effective-batch-64 learning-rate ablation. Compare peak rates
+  `3e-4`, `2.25e-4`, and `1.5e-4` in fresh runs. Use scheduler-relative 10% warmup
+  (200/2,000 steps), scale embedding and minimum rates with the backbone rate, and
+  hold seed, token exposure, scheduler shape, and validation-only selection fixed.
 - [x] Run validation context ablation and a paired packed-window trigram comparison
   for the selected batch-64 checkpoint. Context gains continue through 32-128
   codons; the trigram deficit is `+0.015280` nats/token with 95% CI

--- a/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
+++ b/docs/CONTEXT_LEARNING_DIAGNOSTICS.md
@@ -156,6 +156,32 @@ justify a narrow learning-rate ablation at effective batch 64 before introducing
 new architecture. Exact results and checkpoint hashes are recorded in
 `docs/benchmarks/corrected_effective_batch_ablation.json`.
 
+### Adaptive warmup and learning-rate sweep
+
+Fixed warmup steps are not comparable when accumulation changes the number of
+optimizer updates per token. Training now supports `warmup_fraction` as a
+fail-closed alternative to `warmup_steps`. The resolved count is:
+
+```text
+round(scheduler_total_steps * warmup_fraction)
+```
+
+The two fields cannot be configured together. A 10% policy gives 100, 200, and 400
+warmup steps for the 1,000-, 2,000-, and 4,000-step horizons, keeping warmup aligned
+to training exposure.
+
+The active batch-64 learning-rate matrix uses three fresh random-initialized runs:
+
+| Peak LR | Minimum LR | Warmup | Total steps |
+| ---: | ---: | ---: | ---: |
+| 3.00e-4 | 3.00e-5 | 200 | 2,000 |
+| 2.25e-4 | 2.25e-5 | 200 | 2,000 |
+| 1.50e-4 | 1.50e-5 | 200 | 2,000 |
+
+Both backbone and embedding learning rates change together, and minimum LR remains
+10% of peak so the cosine scheduler shape is matched. The earlier `3e-4` batch-64
+checkpoint is not reused as the anchor because it used only 100 warmup steps.
+
 ### Selected-checkpoint context diagnosis
 
 The batch-64 winner changes the earlier context conclusion:

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -835,6 +835,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     windows are not worse, while stop-codon PPL remains high at 484.316. The next
     step remains batch-64 learning-rate optimization; architecture changes must
     preserve the newly demonstrated long-context gain.
+*   **Adaptive Warmup and Batch-64 LR Sweep (2026-07-28):** Added
+    `warmup_fraction` as a mutually exclusive alternative to fixed `warmup_steps`.
+    It resolves against the scheduler horizon and records the result in checkpoint
+    configuration, allowing 10% warmup to scale from 100 to 200 to 400 updates as
+    token-matched effective-batch experiments move from 1,000 to 2,000 to 4,000
+    steps. Launched three fresh batch-64 MPS runs at peak learning rates `3e-4`,
+    `2.25e-4`, and `1.5e-4`, all with 200/2,000 warmup steps. Embedding LR changes
+    with backbone LR and minimum LR stays at 10% of peak. The earlier batch-64 run
+    is not reused because its fixed 100-step warmup is not matched.
 
 ---
 *End of Log*

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -64,7 +64,12 @@ You can configure training runs using YAML files under `configs/`. Complete temp
     *   `lr`: Peak learning rate.
     *   `min_lr`: End-of-cycle minimum learning rate for cosine scheduler.
     *   `weight_decay`: L2 regularization decay strength.
-    *   `warmup_steps`: Iterations of linear learning rate warmup.
+    *   `warmup_steps`: Fixed optimizer updates of linear learning-rate warmup.
+    *   `warmup_fraction`: Alternative scheduler-relative warmup in `[0, 1)`.
+        Configure only one of these fields. A fraction preserves the same warmup
+        share when effective batch size changes the scheduler horizon; for example,
+        `0.10` resolves to 100, 200, and 400 updates for horizons of 1,000, 2,000,
+        and 4,000 steps.
 *   **Training Loops:**
     *   `batch_size`: Physical batch size per device step.
     *   `grad_accum_steps`: Accumulate gradients over this many steps to simulate large batch sizes.

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -63,6 +63,26 @@ class NonfiniteGroupLimitError(RuntimeError):
     """Raised when aborted accumulation groups exceed the configured tolerance."""
 
 
+def resolve_warmup_steps(cfg: dict, total_steps: int) -> int:
+    """Resolve a fixed or scheduler-relative warmup without ambiguous precedence."""
+    if total_steps <= 0:
+        raise ValueError("scheduler_total_steps must be positive")
+    fraction = cfg.get("warmup_fraction")
+    if fraction is None:
+        steps = int(cfg.get("warmup_steps", 200))
+        if steps < 0:
+            raise ValueError("warmup_steps must be non-negative")
+        return steps
+    if "warmup_steps" in cfg:
+        raise ValueError("configure only one of warmup_steps or warmup_fraction")
+    fraction = float(fraction)
+    if not 0.0 <= fraction < 1.0:
+        raise ValueError("warmup_fraction must be in [0, 1)")
+    if fraction == 0.0:
+        return 0
+    return max(1, int(round(total_steps * fraction)))
+
+
 @dataclass
 class AccumulationHealth:
     """Checkpointable counters for gradient-accumulation group integrity."""
@@ -656,7 +676,6 @@ def run_training(cfg: dict, args) -> None:
     max_nonfinite_groups = int(cfg.get("max_nonfinite_accumulation_groups", 3))
     if max_nonfinite_groups < -1:
         raise ValueError("max_nonfinite_accumulation_groups must be -1 or greater")
-    warmup_steps = int(cfg.get("warmup_steps", 200))
     min_lr = float(cfg.get("min_lr", 1e-5))
     base_lr = float(cfg["lr"])
 
@@ -680,6 +699,13 @@ def run_training(cfg: dict, args) -> None:
     total_steps = int(cfg.get("scheduler_total_steps", computed_total_steps))
     if total_steps <= 0:
         raise ValueError("scheduler_total_steps must be positive")
+    warmup_steps = resolve_warmup_steps(cfg, total_steps)
+    cfg["resolved_warmup_steps"] = warmup_steps
+    if "warmup_fraction" in cfg:
+        print(
+            f"[scheduler] warmup_fraction={float(cfg['warmup_fraction']):.6f} "
+            f"resolved_warmup_steps={warmup_steps}/{total_steps}"
+        )
     use_cosine = scheduler_name == "cosine"
     if use_cosine:
         warmup_for_lambda = max(1, warmup_steps)

--- a/tests/test_warmup_schedule.py
+++ b/tests/test_warmup_schedule.py
@@ -1,0 +1,28 @@
+import pytest
+
+from src.codonlm.training.loop import resolve_warmup_steps
+
+
+def test_fixed_warmup_steps_remain_backward_compatible():
+    assert resolve_warmup_steps({"warmup_steps": 100}, 1000) == 100
+    assert resolve_warmup_steps({}, 1000) == 200
+
+
+@pytest.mark.parametrize(
+    ("total_steps", "expected"),
+    [(1000, 100), (2000, 200), (4000, 400)],
+)
+def test_fractional_warmup_tracks_scheduler_horizon(total_steps, expected):
+    assert resolve_warmup_steps({"warmup_fraction": 0.1}, total_steps) == expected
+
+
+def test_warmup_configuration_fails_closed():
+    with pytest.raises(ValueError, match="only one"):
+        resolve_warmup_steps(
+            {"warmup_steps": 100, "warmup_fraction": 0.1},
+            1000,
+        )
+    with pytest.raises(ValueError, match=r"\[0, 1\)"):
+        resolve_warmup_steps({"warmup_fraction": 1.0}, 1000)
+    with pytest.raises(ValueError, match="non-negative"):
+        resolve_warmup_steps({"warmup_steps": -1}, 1000)


### PR DESCRIPTION
## Summary
- add fail-closed `warmup_fraction` support resolved against scheduler total steps
- reject configs that specify both fixed and fractional warmup
- record the resolved warmup count in runtime checkpoint configuration
- document and launch fresh batch-64 LR runs at 3e-4, 2.25e-4, and 1.5e-4 with matched 10% warmup

## Experiment
All three runs use effective batch 64, seed 1337, two epochs, 2,000 optimizer steps, 50,476,876 expected non-PAD tokens, and 200 warmup steps. Embedding and backbone LR change together; minimum LR remains 10% of peak.

## Testing
- `python -m pytest -q` (318 passed, 1 skipped, 1 xpassed)
- `ruff check src/codonlm/training/loop.py tests/test_warmup_schedule.py`
- `git diff --check`

## Dependency
Stacked on #126; retarget to `main` after #126 merges.