### PR TITLE
Explain CodonLM perplexity baselines

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -94,8 +94,8 @@ an architectural intervention.
   `3e-4`, `2.25e-4`, and `1.5e-4` in fresh runs. Use scheduler-relative 10% warmup
   (200/2,000 steps), scale embedding and minimum rates with the backbone rate, and
   hold seed, token exposure, scheduler shape, and validation-only selection fixed.
-- [ ] Replicate the selected batch-64, LR `1.5e-4` condition with another declared
-  seed. The seed-1337 checkpoint reaches validation PPL `40.961`, below trigram
+- [~] Replicate the selected batch-64, LR `1.5e-4` condition with declared seed
+  2027. The seed-1337 checkpoint reaches validation PPL `40.961`, below trigram
   `42.459`; promotion still requires replication and final frozen-test evaluation.
 - [x] Run validation context ablation and a paired packed-window trigram comparison
   for the selected batch-64 checkpoint. Context gains continue through 32-128

--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -90,10 +90,13 @@ an architectural intervention.
   conditions at 2,000 and 4,000 optimizer steps respectively. Keep physical batch,
   seed, data order, model, learning rate, two-epoch token exposure, and validation
   selection fixed.
-- [~] Run a narrow effective-batch-64 learning-rate ablation. Compare peak rates
+- [x] Run a narrow effective-batch-64 learning-rate ablation. Compare peak rates
   `3e-4`, `2.25e-4`, and `1.5e-4` in fresh runs. Use scheduler-relative 10% warmup
   (200/2,000 steps), scale embedding and minimum rates with the backbone rate, and
   hold seed, token exposure, scheduler shape, and validation-only selection fixed.
+- [ ] Replicate the selected batch-64, LR `1.5e-4` condition with another declared
+  seed. The seed-1337 checkpoint reaches validation PPL `40.961`, below trigram
+  `42.459`; promotion still requires replication and final frozen-test evaluation.
 - [x] Run validation context ablation and a paired packed-window trigram comparison
   for the selected batch-64 checkpoint. Context gains continue through 32-128
   codons; the trigram deficit is `+0.015280` nats/token with 95% CI

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -852,6 +852,13 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     0.035919 nats/token. Added `docs/PERPLEXITY_BASELINES.md` to distinguish the
     theoretical uniform threshold from empirical Markov thresholds and to state
     what crossing each threshold does and does not establish.
+*   **Batch-64 LR `1.5e-4` Replication Launch (2026-07-29):** Launched a fresh
+    seed-2027 replication of the selected seed-1337 checkpoint on MPS. The frozen
+    dataset, two-epoch 50,476,876-token exposure, effective batch 64, untied
+    embeddings, zero label smoothing, dropout 0.05, LR `1.5e-4`, minimum LR
+    `1.5e-5`, and 200/2,000 adaptive warmup schedule are unchanged. Only model and
+    data-loader seeds, run ID, and provenance contract differ. Validation remains
+    the selection split and the frozen test split remains untouched.
 
 ---
 *End of Log*

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -844,6 +844,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     `2.25e-4`, and `1.5e-4`, all with 200/2,000 warmup steps. Embedding LR changes
     with backbone LR and minimum LR stays at 10% of peak. The earlier batch-64 run
     is not reused because its fixed 100-step warmup is not matched.
+*   **Batch-64 LR Sweep Result (2026-07-29):** All three adaptive-warmup runs
+    completed 2,000 optimizer steps and 50,476,876 non-PAD tokens with zero invalid
+    accumulation groups. Independent unsmoothed validation PPL was 46.157 at
+    `3e-4`, 46.103 at `2.25e-4`, and 40.961 at `1.5e-4`. The selected epoch-1
+    `1.5e-4` checkpoint beats the segment-aware trigram baseline (42.459) by
+    0.035919 nats/token. Added `docs/PERPLEXITY_BASELINES.md` to distinguish the
+    theoretical uniform threshold from empirical Markov thresholds and to state
+    what crossing each threshold does and does not establish.
 
 ---
 *End of Log*

--- a/docs/PERPLEXITY_BASELINES.md
+++ b/docs/PERPLEXITY_BASELINES.md
@@ -1,0 +1,82 @@
+# Interpreting CodonLM Perplexity
+
+## Calculation
+
+For held-out target codons \(y_1,\ldots,y_N\), negative log-likelihood and
+perplexity are:
+
+\[
+\mathrm{NLL}=-\frac{1}{N}\sum_{i=1}^{N}\log p(y_i\mid\text{allowed context}),
+\qquad
+\mathrm{PPL}=e^{\mathrm{NLL}}.
+\]
+
+PAD targets are excluded. Lower PPL means the model assigns more probability to
+the observed continuation. PPL can be read as an effective average number of
+plausible next choices, but it is not literally the number of choices at every
+position.
+
+Only the uniform threshold is theoretical from vocabulary size. There are 68
+tokens including PAD, so uniform prediction over the 67 evaluable targets gives:
+
+\[
+\mathrm{PPL}_{uniform}=67.
+\]
+
+The other thresholds are empirical Markov baselines. Their probabilities are
+estimated from the frozen training split with additive smoothing and evaluated on
+exactly the same held-out tokens as CodonLM:
+
+| Baseline | Prediction | What beating it demonstrates |
+| --- | --- | --- |
+| Uniform | \(P(x_t)=1/67\) | Learned that targets are not equally frequent |
+| Unigram | \(P(x_t)\) | Learned information beyond global token composition |
+| Bigram | \(P(x_t\mid x_{t-1})\) | Uses context better than the previous-token table |
+| Trigram | \(P(x_t\mid x_{t-2},x_{t-1})\) | Uses information beyond the previous two-token table |
+
+Bigram and trigram histories reset after `<SEP>`, matching the model's segment
+boundary. All probabilities are fitted on training data; no validation or test
+targets are used to estimate them.
+
+## Current Validation Result
+
+The frozen genome validation comparison uses `3,228,255` non-PAD targets:
+
+| Model | NLL | PPL |
+| --- | ---: | ---: |
+| Uniform | 4.204693 | 67.000 |
+| Unigram | 3.892183 | 49.018 |
+| Bigram | 3.782536 | 43.927 |
+| Trigram | 3.748532 | 42.459 |
+| CodonLM, batch 64, LR `1.5e-4` | **3.712613** | **40.961** |
+
+The selected CodonLM now beats trigram by `0.035919` nats/token. Its context
+ablation also improves through 32-128 codons, so the gain is consistent with using
+information unavailable to a two-codon Markov table.
+
+## What PPL Says the Model Learned
+
+Crossing these thresholds gives increasingly strong evidence:
+
+1. Below uniform: target-frequency structure.
+2. Below unigram: conditional sequence structure, not only codon abundance.
+3. Below bigram/trigram: useful context beyond their fixed Markov histories, or a
+   better way to generalize those histories.
+4. Improvement with longer allowed context: information distributed across longer
+   codon spans.
+
+For coding sequence, that information may include amino-acid motifs, synonymous
+codon choice, GC context, gene position, taxonomic patterns, translation-related
+signals, and other sequence regularities.
+
+PPL alone does **not** prove that the hidden states recover DNA shape, RNA folding,
+protein secondary structure, tertiary contacts, function, or fitness. A model can
+lower PPL through composition or taxonomy shortcuts. Structural claims therefore
+require order-destroying controls, grouped/homology-controlled evaluations,
+context ablations, simple sequence baselines, and direct structural targets.
+
+The correct interpretation is:
+
+> Beating trigram establishes that CodonLM learned predictive sequence information
+> beyond a two-codon count model. It makes structural learning more plausible and
+> worth testing, but does not establish it.


### PR DESCRIPTION
## Summary
- explain uniform, unigram, bigram, and trigram PPL calculations
- state what crossing each threshold demonstrates about codon-sequence learning
- document limitations of using PPL as evidence for DNA or protein structure
- record the completed adaptive-warmup LR sweep and its new trigram-beating result

## Result
The batch-64, LR 1.5e-4 checkpoint reaches validation NLL 3.712613 / PPL 40.961, compared with trigram NLL 3.748532 / PPL 42.459. Replication remains required before promotion.

## Validation
- `git diff --check`
- documentation-only change