### PR TITLE
Prepare leakage-controlled downstream evaluations

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -116,6 +116,11 @@ an architectural intervention.
 - [ ] Extract causal embeddings with dataset/checkpoint/vocabulary/code provenance.
 - [ ] Run EC, essentiality, AMR, and DNA-shape evaluations with controlled splits and
   shared controls.
+  EC preflight is currently blocked: all 6,617 matched legacy EC annotations occur
+  in pretraining-train genomes and none in pretraining-test genomes. The controlled
+  CARD AMR protein-cluster split passes its exact-pretraining-overlap gate after
+  quarantine (3,733 train/1,285 test across six classes). Its report discloses 34
+  protein clusters shared with pretraining.
 - [ ] Run raw and syntax-constrained generation with memorization and nucleotide/
   protein nearest-neighbor audits; do not use critic scores for promotion yet.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and

--- a/docs/CORRECTED_DOWNSTREAM_EVALUATION_READINESS.md
+++ b/docs/CORRECTED_DOWNSTREAM_EVALUATION_READINESS.md
@@ -1,0 +1,94 @@
+# Corrected Downstream Evaluation Readiness
+
+This document records whether downstream datasets are eligible for evaluation
+with the corrected genome-held-out CodonLM. A stronger checkpoint does not repair
+an invalid downstream split.
+
+## EC
+
+**Status: blocked pending a separately sourced controlled corpus.**
+
+The legacy EC preparation performs a random record-level split. The corrected
+preflight instead joins EC annotations to the frozen pretraining
+`cds_meta.tsv`/`cds_dna.txt`, preserves its genome assignments, clusters translated
+proteins with MMseqs2, and requires test clusters to be absent from LM training.
+
+On `corrected-codonlm-v1`, 6,617 EC-labelled records matched the frozen CDS
+metadata, but all 6,617 belong to pretraining-train genomes. None belong to the two
+pretraining-test genomes. Consequently, no held-out EC test class exists and no
+corrected EC score should be reported from the legacy corpus.
+
+Reproduce the gate:
+
+```bash
+python -m scripts.prepare_controlled_ec_dataset \
+  --cds-meta data/processed/corrected/corrected-codonlm-v1/genome/cds_meta.tsv \
+  --cds-dna data/processed/corrected/corrected-codonlm-v1/genome/cds_dna.txt \
+  --uniprot-metadata data/processed/uniprot_metadata_full.csv \
+  --out-dir data/processed/downstream/corrected-codonlm-v1/ec_genome_protein_holdout \
+  --mmseqs-executable mmseqs \
+  --min-protein-identity 0.3 \
+  --min-coverage 0.8
+```
+
+The command fails closed and writes `split_report.json` with the class and split
+counts. The next valid EC route is a separately frozen annotated corpus whose
+accessions are audited against the LM pretraining manifest.
+
+## AMR
+
+**Status: controlled split and pretraining-overlap audit passed.**
+
+The CARD protein-homolog dataset was prepared with an MMseqs2
+protein-cluster-held-out split at 30% minimum identity and 80% coverage:
+
+- 5,098 valid labelled records after filtering;
+- eight internal-stop/ambiguous protein translations quarantined;
+- 25 exact matches to LM-training CDSs quarantined before splitting;
+- six drug classes, all present in train and test;
+- 3,733 train and 1,285 test records;
+- 185 protein clusters;
+- achieved test fraction 25.61%;
+- MMseqs2 version `18-8cc5c`.
+
+Reproduce:
+
+```bash
+python -m scripts.prepare_amr_dataset \
+  --out_dir data/processed/downstream/corrected-codonlm-v1/amr \
+  --protocol protein_cluster_held_out \
+  --mmseqs-executable mmseqs \
+  --min-protein-identity 0.3 \
+  --min-coverage 0.8 \
+  --threads 4 \
+  --seed 42 \
+  --pretraining-cds-meta \
+    data/processed/corrected/corrected-codonlm-v1/genome/cds_meta.tsv \
+  --pretraining-cds-dna \
+    data/processed/corrected/corrected-codonlm-v1/genome/cds_dna.txt
+```
+
+The generated `split_report.json` records input checksums, MMseqs2 version and
+command, thresholds, class distributions, achieved split fraction, and cluster
+counts.
+
+The independent post-build audit compares all 1,285 AMR test records with 74,600
+frozen LM-training CDSs. It passes with zero exact full-CDS duplicates. It reports
+34 shared protein clusters, 98.60% nearest-protein hit coverage, median nearest
+protein identity 37.2%, and 95th percentile identity 73.9%. These homology
+statistics must accompany the AMR result because pretraining on related proteins
+may help representation quality even though exact sequence memorization is
+excluded.
+
+```bash
+python -m scripts.audit_downstream_pretraining \
+  --cds-meta data/processed/corrected/corrected-codonlm-v1/genome/cds_meta.tsv \
+  --cds-dna data/processed/corrected/corrected-codonlm-v1/genome/cds_dna.txt \
+  --downstream-seqs \
+    data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr_seqs.csv \
+  --output \
+    data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/pretraining_overlap_audit.json \
+  --mmseqs-executable mmseqs \
+  --minimap2-executable minimap2 \
+  --threads 4
+```

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -879,6 +879,18 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     gate and can proceed to causal embedding extraction and controlled downstream
     evaluation. This result does not by itself validate structural or functional
     representations.
+*   **Corrected Downstream Readiness Audit (2026-07-29):** Added a fail-closed EC
+    builder aligned to frozen pretraining genome assignments and MMseqs2 protein
+    clusters. All 6,617 matched EC annotations occur in pretraining-train genomes;
+    none occur in pretraining-test genomes, so the legacy EC corpus cannot produce
+    a corrected held-out score. Built the independent CARD AMR split at 30%
+    protein identity and 80% coverage. Quarantined eight invalid internal-stop
+    translations and 25 exact LM-training matches before clustering. The final
+    corpus contains 3,733 train and 1,285 test records across six classes and 185
+    clusters. Its post-build audit against 74,600 LM-training CDSs passes with zero
+    exact duplicates and reports 34 shared protein clusters, median nearest-protein
+    identity 37.2%, and 95th percentile identity 73.9%. AMR is ready for
+    provenance-bound embedding extraction; EC remains blocked on a new corpus.
 
 ---
 *End of Log*

--- a/scripts/audit_downstream_pretraining.py
+++ b/scripts/audit_downstream_pretraining.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Audit a downstream test set against frozen CodonLM training records."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+from src.codonlm.leakage_audit import audit_source_records
+
+
+def _load_pretraining(meta_path: Path, dna_path: Path) -> list[dict]:
+    sequences = dna_path.read_text().splitlines()
+    records = []
+    with meta_path.open(newline="") as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            if row.get("split") != "train":
+                continue
+            line_idx = int(row["line_idx"])
+            if line_idx >= len(sequences):
+                raise ValueError(f"line_idx {line_idx} exceeds {dna_path}")
+            records.append(
+                {
+                    "source_id": f"pretraining:{row['source_id']}",
+                    "split": "train",
+                    "sequence": sequences[line_idx],
+                }
+            )
+    return records
+
+
+def _load_downstream(path: Path, id_column: str, sequence_column: str) -> list[dict]:
+    records = []
+    with path.open(newline="") as handle:
+        for index, row in enumerate(csv.DictReader(handle)):
+            sequence = row.get(sequence_column, "").strip()
+            if not sequence:
+                continue
+            source_id = row.get(id_column, "").strip() or f"row-{index}"
+            records.append(
+                {
+                    "source_id": f"downstream:{source_id}",
+                    "split": "test",
+                    "sequence": sequence,
+                }
+            )
+    return records
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cds-meta", type=Path, required=True)
+    parser.add_argument("--cds-dna", type=Path, required=True)
+    parser.add_argument("--downstream-seqs", type=Path, required=True)
+    parser.add_argument("--id-column", default="id")
+    parser.add_argument("--sequence-column", default="seq")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument("--minimap2-executable", default="minimap2")
+    parser.add_argument("--min-protein-identity", type=float, default=0.3)
+    parser.add_argument("--min-coverage", type=float, default=0.8)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--nearest-query-batch-size", type=int, default=4096)
+    args = parser.parse_args(argv)
+
+    pretraining = _load_pretraining(args.cds_meta, args.cds_dna)
+    downstream = _load_downstream(
+        args.downstream_seqs, args.id_column, args.sequence_column
+    )
+    if not pretraining:
+        raise ValueError("no frozen pretraining-train records were loaded")
+    if not downstream:
+        raise ValueError("no downstream test records were loaded")
+    report = audit_source_records(
+        pretraining + downstream,
+        args.output,
+        min_protein_identity=args.min_protein_identity,
+        min_coverage=args.min_coverage,
+        threads=args.threads,
+        executable=args.mmseqs_executable,
+        protein_homology_policy="report",
+        nucleotide_executable=args.minimap2_executable,
+        nearest_query_batch_size=args.nearest_query_batch_size,
+    )
+    report["scope"] = {
+        "pretraining_train_records": len(pretraining),
+        "downstream_test_records": len(downstream),
+        "downstream_sequences": str(args.downstream_seqs.resolve()),
+    }
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(
+        f"[downstream-audit] status={report['status']} "
+        f"exact={report['exact_duplicates']['count']} "
+        f"protein_clusters={report['protein_homology']['cross_split_cluster_count']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_amr_dataset.py
+++ b/scripts/prepare_amr_dataset.py
@@ -201,6 +201,21 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _pretraining_train_hashes(meta_path: Path, dna_path: Path) -> set[str]:
+    sequences = dna_path.read_text().splitlines()
+    hashes = set()
+    with meta_path.open(newline="") as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            if row.get("split") != "train":
+                continue
+            line_idx = int(row["line_idx"])
+            if line_idx >= len(sequences):
+                raise ValueError(f"line_idx {line_idx} exceeds {dna_path}")
+            normalized = sequences[line_idx].strip().upper().replace("U", "T")
+            hashes.add(hashlib.sha256(normalized.encode("ascii")).hexdigest())
+    return hashes
+
+
 def _cluster_proteins(records, work_dir, executable, min_identity, coverage, threads):
     resolved = shutil.which(executable)
     if resolved is None:
@@ -211,7 +226,7 @@ def _cluster_proteins(records, work_dir, executable, min_identity, coverage, thr
         for index, record in enumerate(records):
             source_key = f"record-{index}"
             record["source_key"] = source_key
-            protein = translate_cds(record["dna"])
+            protein = record.get("protein") or translate_cds(record["dna"])
             if not protein or "X" in protein:
                 raise ValueError(f"invalid translated protein for {record['id']}")
             handle.write(f">{source_key}\n{protein}\n")
@@ -294,6 +309,8 @@ def main(argv=None) -> None:
     ap.add_argument("--min-protein-identity", type=float, default=0.3)
     ap.add_argument("--min-coverage", type=float, default=0.8)
     ap.add_argument("--threads", type=int, default=1)
+    ap.add_argument("--pretraining-cds-meta", type=Path)
+    ap.add_argument("--pretraining-cds-dna", type=Path)
     ap.add_argument("--min_examples", type=int, default=60,
                     help="Minimum gene examples per drug class to include")
     ap.add_argument("--top_n_classes", type=int, default=8,
@@ -307,12 +324,21 @@ def main(argv=None) -> None:
         ap.error("--min-protein-identity must be between 0 and 1")
     if not 0.0 < args.min_coverage <= 1.0:
         ap.error("--min-coverage must be in (0, 1]")
+    if (args.pretraining_cds_meta is None) != (args.pretraining_cds_dna is None):
+        ap.error("--pretraining-cds-meta and --pretraining-cds-dna must be used together")
 
     fasta_path = Path(args.fasta)
     aro_path = Path(args.aro_index)
     out_root = Path(args.out_dir)
     out_dir = out_root / args.protocol
     out_dir.mkdir(parents=True, exist_ok=True)
+    pretraining_hashes = (
+        _pretraining_train_hashes(
+            args.pretraining_cds_meta, args.pretraining_cds_dna
+        )
+        if args.pretraining_cds_meta is not None
+        else set()
+    )
 
     # 1. Load ARO → drug class & family mapping
     print("[amr] Loading ARO index...")
@@ -322,7 +348,14 @@ def main(argv=None) -> None:
     # 2. Parse FASTA and join to drug class & family
     print(f"[amr] Parsing FASTA: {fasta_path}")
     records: list[dict] = []
-    stats = Counter(skipped_no_aro=0, skipped_no_class=0, skipped_too_short=0, skipped_invalid=0, kept=0)
+    stats = Counter(
+        skipped_no_aro=0,
+        skipped_no_class=0,
+        skipped_too_short=0,
+        skipped_invalid=0,
+        skipped_pretraining_exact=0,
+        kept=0,
+    )
 
     for header, seq_parts in _parse_fasta(fasta_path):
         seq = "".join(seq_parts)
@@ -341,12 +374,21 @@ def main(argv=None) -> None:
             continue
         if len(codons) > MAX_CODONS:
             codons = codons[:MAX_CODONS]
+        dna = "".join(codons)
+        protein = translate_cds(dna)
+        if not protein or "X" in protein:
+            stats["skipped_invalid"] += 1
+            continue
+        if hashlib.sha256(dna.encode("ascii")).hexdigest() in pretraining_hashes:
+            stats["skipped_pretraining_exact"] += 1
+            continue
         records.append({
             "id": header.split("|")[1] if "|" in header else header[:40],
             "aro": aro,
             "family": family,
             "sequence": " ".join(codons),
-            "dna": "".join(codons),
+            "dna": dna,
+            "protein": protein,
             "n_codons": len(codons),
             "drug_class": drug_class,
         })
@@ -445,6 +487,22 @@ def main(argv=None) -> None:
             "inputs": {
                 "fasta": {"path": str(fasta_path.resolve()), "sha256": _sha256(fasta_path)},
                 "aro_index": {"path": str(aro_path.resolve()), "sha256": _sha256(aro_path)},
+                "pretraining_cds_meta": (
+                    {
+                        "path": str(args.pretraining_cds_meta.resolve()),
+                        "sha256": _sha256(args.pretraining_cds_meta),
+                    }
+                    if args.pretraining_cds_meta is not None
+                    else None
+                ),
+                "pretraining_cds_dna": (
+                    {
+                        "path": str(args.pretraining_cds_dna.resolve()),
+                        "sha256": _sha256(args.pretraining_cds_dna),
+                    }
+                    if args.pretraining_cds_dna is not None
+                    else None
+                ),
             },
             "clustering": clustering,
             "filtering": dict(stats),

--- a/scripts/prepare_controlled_ec_dataset.py
+++ b/scripts/prepare_controlled_ec_dataset.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Build an EC probe dataset aligned to a frozen CodonLM genome split."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import subprocess
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_ec_labels(path: Path) -> dict[str, int]:
+    labels: dict[str, int] = {}
+    with path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            protein_id = str(row.get("ncbi_id", "")).strip()
+            ec = str(row.get("ec", "")).strip()
+            if protein_id and ec and ec[0].isdigit() and 1 <= int(ec[0]) <= 7:
+                labels[protein_id] = int(ec[0])
+    return labels
+
+
+def _load_records(meta_path: Path, dna_path: Path, labels: dict[str, int]) -> list[dict]:
+    dna = dna_path.read_text().splitlines()
+    records = []
+    with meta_path.open(newline="") as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            protein_id = row.get("protein_id", "").strip()
+            label = labels.get(protein_id)
+            split = row.get("split", "").strip()
+            if label is None or split not in {"train", "test"}:
+                continue
+            line_idx = int(row["line_idx"])
+            if line_idx >= len(dna):
+                raise ValueError(f"line_idx {line_idx} exceeds {dna_path}")
+            sequence = dna[line_idx].strip().upper()
+            protein = row.get("translation", "").strip().upper()
+            if not sequence or not protein or "X" in protein or "*" in protein:
+                continue
+            records.append(
+                {
+                    "id": row["source_id"],
+                    "protein_id": protein_id,
+                    "genome": row["genome"],
+                    "pretraining_split": split,
+                    "dna": sequence,
+                    "protein": protein,
+                    "label": label,
+                }
+            )
+    return records
+
+
+def _cluster(records: list[dict], work_dir: Path, args) -> dict:
+    executable = shutil.which(args.mmseqs_executable)
+    if executable is None:
+        raise RuntimeError(f"MMseqs2 executable not found: {args.mmseqs_executable}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    fasta = work_dir / "ec_proteins.fasta"
+    with fasta.open("w") as handle:
+        for index, record in enumerate(records):
+            key = f"record-{index}"
+            record["cluster_key"] = key
+            handle.write(f">{key}\n{record['protein']}\n")
+    prefix = work_dir / "clusters"
+    command = [
+        executable,
+        "easy-cluster",
+        str(fasta),
+        str(prefix),
+        str(work_dir / "tmp"),
+        "--min-seq-id",
+        str(args.min_protein_identity),
+        "-c",
+        str(args.min_coverage),
+        "--cov-mode",
+        "0",
+        "--cluster-mode",
+        "0",
+        "--threads",
+        str(args.threads),
+    ]
+    version = subprocess.run(
+        [executable, "version"], check=True, capture_output=True, text=True
+    )
+    subprocess.run(command, check=True, capture_output=True, text=True)
+    cluster_path = Path(f"{prefix}_cluster.tsv")
+    assignments = {}
+    with cluster_path.open() as handle:
+        for line in handle:
+            representative, member = line.rstrip("\n").split("\t")[:2]
+            assignments[member] = representative
+    for record in records:
+        try:
+            record["protein_cluster"] = assignments[record["cluster_key"]]
+        except KeyError as exc:
+            raise RuntimeError(f"MMseqs2 omitted {record['cluster_key']}") from exc
+    return {
+        "tool": {
+            "executable": executable,
+            "version": (version.stdout or version.stderr).strip(),
+        },
+        "command": command,
+        "thresholds": {
+            "min_sequence_identity": args.min_protein_identity,
+            "min_coverage": args.min_coverage,
+            "coverage_mode": 0,
+        },
+        "protein_fasta_sha256": _sha256(fasta),
+        "cluster_assignments_sha256": _sha256(cluster_path),
+        "cluster_count": len(set(assignments.values())),
+    }
+
+
+def _write_csvs(out_dir: Path, split: str, records: list[dict]) -> None:
+    with (out_dir / f"{split}_ec.csv").open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id", "label"])
+        writer.writerows((record["id"], record["label"]) for record in records)
+    with (out_dir / f"{split}_ec_seqs.csv").open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id", "seq"])
+        writer.writerows((record["id"], record["dna"]) for record in records)
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cds-meta", type=Path, required=True)
+    parser.add_argument("--cds-dna", type=Path, required=True)
+    parser.add_argument("--uniprot-metadata", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument("--min-protein-identity", type=float, default=0.3)
+    parser.add_argument("--min-coverage", type=float, default=0.8)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--min-train-per-class", type=int, default=20)
+    parser.add_argument("--min-test-per-class", type=int, default=5)
+    args = parser.parse_args(argv)
+
+    labels = _load_ec_labels(args.uniprot_metadata)
+    records = _load_records(args.cds_meta, args.cds_dna, labels)
+    if not records:
+        raise ValueError("no EC-labelled records matched the frozen CDS metadata")
+    clustering = _cluster(records, args.out_dir / "clustering", args)
+
+    by_cluster: dict[str, list[dict]] = defaultdict(list)
+    for record in records:
+        by_cluster[record["protein_cluster"]].append(record)
+    crossing = {
+        cluster
+        for cluster, members in by_cluster.items()
+        if {member["pretraining_split"] for member in members} == {"train", "test"}
+    }
+
+    train = [
+        record
+        for record in records
+        if record["pretraining_split"] == "train" and record["protein_cluster"] not in crossing
+    ]
+    test = [
+        record
+        for record in records
+        if record["pretraining_split"] == "test" and record["protein_cluster"] not in crossing
+    ]
+    train_counts, test_counts = Counter(r["label"] for r in train), Counter(
+        r["label"] for r in test
+    )
+    eligible = {
+        label
+        for label in set(train_counts) & set(test_counts)
+        if train_counts[label] >= args.min_train_per_class
+        and test_counts[label] >= args.min_test_per_class
+    }
+    train = [record for record in train if record["label"] in eligible]
+    test = [record for record in test if record["label"] in eligible]
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    if len(eligible) < 2:
+        failure_report = {
+            "protocol": "pretraining_genome_and_protein_cluster_held_out",
+            "status": "failed",
+            "reason": "fewer_than_two_eligible_ec_classes",
+            "matched_records": len(records),
+            "records_by_pretraining_split": dict(
+                sorted(Counter(r["pretraining_split"] for r in records).items())
+            ),
+            "records_after_crossing_cluster_quarantine": {
+                "train": sum(train_counts.values()),
+                "test": sum(test_counts.values()),
+            },
+            "records_per_class_after_quarantine": {
+                "train": dict(sorted(train_counts.items())),
+                "test": dict(sorted(test_counts.items())),
+            },
+            "quarantined_cross_split_clusters": len(crossing),
+            "thresholds": {
+                "min_train_per_class": args.min_train_per_class,
+                "min_test_per_class": args.min_test_per_class,
+            },
+            "clustering": clustering,
+        }
+        (args.out_dir / "split_report.json").write_text(
+            json.dumps(failure_report, indent=2, sort_keys=True) + "\n"
+        )
+        raise ValueError(
+            "fewer than two EC classes survive genome and protein-cluster holdouts"
+        )
+    if {r["protein_cluster"] for r in train} & {r["protein_cluster"] for r in test}:
+        raise AssertionError("protein clusters overlap between train and test")
+
+    _write_csvs(args.out_dir, "train", train)
+    _write_csvs(args.out_dir, "test", test)
+    with (args.out_dir / "split_assignments.tsv").open("w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(
+            ["id", "protein_id", "genome", "label", "protein_cluster", "split"]
+        )
+        for split, members in (("train", train), ("test", test)):
+            for record in members:
+                writer.writerow(
+                    [
+                        record["id"],
+                        record["protein_id"],
+                        record["genome"],
+                        record["label"],
+                        record["protein_cluster"],
+                        split,
+                    ]
+                )
+    report = {
+        "protocol": "pretraining_genome_and_protein_cluster_held_out",
+        "inputs": {
+            "cds_meta": {"path": str(args.cds_meta.resolve()), "sha256": _sha256(args.cds_meta)},
+            "cds_dna": {"path": str(args.cds_dna.resolve()), "sha256": _sha256(args.cds_dna)},
+            "uniprot_metadata": {
+                "path": str(args.uniprot_metadata.resolve()),
+                "sha256": _sha256(args.uniprot_metadata),
+            },
+        },
+        "clustering": clustering,
+        "matched_records": len(records),
+        "quarantined_cross_split_clusters": len(crossing),
+        "eligible_classes": sorted(eligible),
+        "train": {
+            "records": len(train),
+            "records_per_class": dict(sorted(Counter(r["label"] for r in train).items())),
+            "genomes": sorted({r["genome"] for r in train}),
+            "protein_clusters": len({r["protein_cluster"] for r in train}),
+        },
+        "test": {
+            "records": len(test),
+            "records_per_class": dict(sorted(Counter(r["label"] for r in test).items())),
+            "genomes": sorted({r["genome"] for r in test}),
+            "protein_clusters": len({r["protein_cluster"] for r in test}),
+        },
+        "cross_split_protein_clusters": 0,
+    }
+    (args.out_dir / "split_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    print(
+        f"[ec] wrote {len(train)} train and {len(test)} test records "
+        f"across {len(eligible)} classes"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_controlled_ec_dataset.py
+++ b/tests/test_controlled_ec_dataset.py
@@ -1,0 +1,106 @@
+import csv
+import json
+
+import pytest
+
+from scripts.audit_downstream_pretraining import main as audit_downstream
+from scripts.prepare_controlled_ec_dataset import main
+from src.codonlm.leakage_audit import LeakageAuditError
+from tests.test_leakage_audit import _write_fake_minimap2, _write_fake_mmseqs
+
+
+def test_controlled_ec_split_respects_pretraining_and_protein_clusters(tmp_path):
+    metadata = tmp_path / "cds_meta.tsv"
+    dna = tmp_path / "cds_dna.txt"
+    uniprot = tmp_path / "uniprot.csv"
+    rows = [
+        ("train-a1", "p1", "g-train", "train", "MAAAAA", "ATG" + "GCT" * 5, 1),
+        ("test-a1", "p2", "g-test", "test", "MAAAAA", "ATG" + "GCT" * 5, 1),
+        ("train-a2", "p3", "g-train", "train", "MCCCCC", "ATG" + "TGT" * 5, 1),
+        ("test-a2", "p4", "g-test", "test", "MDDDDD", "ATG" + "GAT" * 5, 1),
+        ("train-b1", "p5", "g-train", "train", "MEEEEE", "ATG" + "GAA" * 5, 2),
+        ("test-b1", "p6", "g-test", "test", "MFFFFF", "ATG" + "TTT" * 5, 2),
+    ]
+    with metadata.open("w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(
+            ["line_idx", "split", "source_id", "genome", "protein_id", "translation"]
+        )
+        for index, row in enumerate(rows):
+            writer.writerow([index, row[3], row[0], row[2], row[1], row[4]])
+    dna.write_text("\n".join(row[5] for row in rows) + "\n")
+    with uniprot.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["ncbi_id", "ec"])
+        for row in rows:
+            writer.writerow([row[1], f"{row[6]}.1.1.1"])
+
+    fake_mmseqs = tmp_path / "mmseqs"
+    _write_fake_mmseqs(fake_mmseqs)
+    out = tmp_path / "controlled"
+    main(
+        [
+            "--cds-meta",
+            str(metadata),
+            "--cds-dna",
+            str(dna),
+            "--uniprot-metadata",
+            str(uniprot),
+            "--out-dir",
+            str(out),
+            "--mmseqs-executable",
+            str(fake_mmseqs),
+            "--min-train-per-class",
+            "1",
+            "--min-test-per-class",
+            "1",
+        ]
+    )
+
+    report = json.loads((out / "split_report.json").read_text())
+    assert report["protocol"] == "pretraining_genome_and_protein_cluster_held_out"
+    assert report["cross_split_protein_clusters"] == 0
+    assert report["quarantined_cross_split_clusters"] == 1
+    assert report["train"]["genomes"] == ["g-train"]
+    assert report["test"]["genomes"] == ["g-test"]
+    with (out / "train_ec.csv").open() as handle:
+        train_ids = {row["id"] for row in csv.DictReader(handle)}
+    with (out / "test_ec.csv").open() as handle:
+        test_ids = {row["id"] for row in csv.DictReader(handle)}
+    assert "train-a1" not in train_ids
+    assert "test-a1" not in test_ids
+
+
+def test_downstream_audit_blocks_exact_pretraining_duplicates(tmp_path):
+    metadata = tmp_path / "cds_meta.tsv"
+    metadata.write_text("line_idx\tsplit\tsource_id\n0\ttrain\ttrain-a\n")
+    dna = tmp_path / "cds_dna.txt"
+    dna.write_text("ATGGCTGCTTAA\n")
+    downstream = tmp_path / "test.csv"
+    downstream.write_text("id,seq\ntest-a,ATGGCTGCTTAA\n")
+    mmseqs, minimap2 = tmp_path / "mmseqs", tmp_path / "minimap2"
+    _write_fake_mmseqs(mmseqs)
+    _write_fake_minimap2(minimap2)
+    output = tmp_path / "audit.json"
+
+    with pytest.raises(LeakageAuditError, match="cross_split_exact_duplicates"):
+        audit_downstream(
+            [
+                "--cds-meta",
+                str(metadata),
+                "--cds-dna",
+                str(dna),
+                "--downstream-seqs",
+                str(downstream),
+                "--output",
+                str(output),
+                "--mmseqs-executable",
+                str(mmseqs),
+                "--minimap2-executable",
+                str(minimap2),
+            ]
+        )
+
+    report = json.loads(output.read_text())
+    assert report["status"] == "failed"
+    assert report["exact_duplicates"]["count"] == 1


### PR DESCRIPTION
## Summary
- add a fail-closed EC builder aligned to frozen pretraining genome assignments and MMseqs2 protein clusters
- quarantine invalid translations and exact LM-training matches during controlled CARD AMR preparation
- add a reusable downstream-versus-pretraining exact, homology, and nearest-neighbor audit
- document the EC failed gate and the validated AMR preparation protocol

## Scientific results
- EC is blocked: all 6,617 matched annotations occur in LM-training genomes and none in held-out genomes
- AMR final corpus: 3,733 train / 1,285 test records, six classes, 185 within-AMR protein clusters
- quarantined eight invalid translations and 25 exact LM-training matches
- post-build audit passes with zero exact test/training CDS duplicates
- 34 protein clusters overlap pretraining; median nearest-protein identity is 37.2% and p95 is 73.9%, reported as exposure covariates

## Validation
- targeted Ruff: passed
- pytest -q: 320 passed, 1 skipped, 1 xpassed
- git diff --check: passed

Repository-wide Ruff still reports pre-existing violations in unrelated legacy files.