### PR TITLE
Evaluate corrected AMR representations

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -113,7 +113,9 @@ an architectural intervention.
   identical frozen-test tokens; report loss, perplexity, bits/codon, and improvement
   over the best baseline. Seed-1337 and seed-2027 PPL are `39.133` and `39.492`,
   both below trigram `42.037`.
-- [ ] Extract causal embeddings with dataset/checkpoint/vocabulary/code provenance.
+- [x] Extract causal AMR embeddings for both corrected seeds with
+  dataset/checkpoint/vocabulary/code provenance. Other downstream datasets remain
+  pending.
 - [ ] Run EC, essentiality, AMR, and DNA-shape evaluations with controlled splits and
   shared controls.
   EC preflight is currently blocked: all 6,617 matched legacy EC annotations occur
@@ -121,6 +123,10 @@ an architectural intervention.
   CARD AMR protein-cluster split passes its exact-pretraining-overlap gate after
   quarantine (3,733 train/1,285 test across six classes). Its report discloses 34
   protein clusters shared with pretraining.
+  The first AMR representation gate fails: both random-Transformer controls
+  outperform both pretrained final-layer causal-mean representations. Predeclare
+  pooling/layer selection using grouped cross-validation within probe training
+  before touching the AMR test set again.
 - [ ] Run raw and syntax-constrained generation with memorization and nucleotide/
   protein nearest-neighbor audits; do not use critic scores for promotion yet.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and

--- a/configs/classifier/corrected_amr_kmer3.yaml
+++ b/configs/classifier/corrected_amr_kmer3.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out
+task: corrected_amr_kmer3
+out_dir: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/kmer3
+
+data:
+  train_seqs: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr_seqs.csv
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_seqs: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr_seqs.csv
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: kmer_logreg
+  k: 3
+  tfidf: true

--- a/configs/classifier/corrected_amr_random_seed19.yaml
+++ b/configs/classifier/corrected_amr_random_seed19.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out
+task: corrected_amr_random_seed19
+out_dir: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/random_seed19
+require_verified_embeddings: true
+
+data:
+  train_embeddings: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/random_seed19/train_causal.npz
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_embeddings: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/random_seed19/test_causal.npz
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: probe_logreg
+  C: 1.0

--- a/configs/classifier/corrected_amr_random_seed23.yaml
+++ b/configs/classifier/corrected_amr_random_seed23.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out
+task: corrected_amr_random_seed23
+out_dir: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/random_seed23
+require_verified_embeddings: true
+
+data:
+  train_embeddings: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/random_seed23/train_causal.npz
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_embeddings: outputs/reports/corrected-codonlm-v1/amr_protein_cluster/random_seed23/test_causal.npz
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: probe_logreg
+  C: 1.0

--- a/configs/classifier/corrected_amr_seed1337.yaml
+++ b/configs/classifier/corrected_amr_seed1337.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out
+task: corrected_amr_seed1337
+out_dir: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/scores/amr_protein_cluster
+require_verified_embeddings: true
+
+data:
+  train_embeddings: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/embeddings/amr_protein_cluster/train_causal.npz
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_embeddings: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/embeddings/amr_protein_cluster/test_causal.npz
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: probe_logreg
+  C: 1.0

--- a/configs/classifier/corrected_amr_seed2027.yaml
+++ b/configs/classifier/corrected_amr_seed2027.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out
+task: corrected_amr_seed2027
+out_dir: runs/corrected-codonlm-v1-batch64-lr15-seed2027/scores/amr_protein_cluster
+require_verified_embeddings: true
+
+data:
+  train_embeddings: runs/corrected-codonlm-v1-batch64-lr15-seed2027/embeddings/amr_protein_cluster/train_causal.npz
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_embeddings: runs/corrected-codonlm-v1-batch64-lr15-seed2027/embeddings/amr_protein_cluster/test_causal.npz
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: probe_logreg
+  C: 1.0

--- a/docs/CORRECTED_AMR_EVALUATION.md
+++ b/docs/CORRECTED_AMR_EVALUATION.md
@@ -1,0 +1,54 @@
+# Corrected AMR Evaluation
+
+## Protocol
+
+The corrected AMR benchmark uses six CARD drug classes with protein clusters held
+out between 3,733 probe-training and 1,285 test sequences. Twenty-five exact
+LM-training matches were removed before splitting, and the final audit reports
+zero exact test/pretraining duplicates. Thirty-four protein clusters overlap LM
+pretraining and are disclosed as an exposure covariate.
+
+Both corrected CodonLM checkpoints use canonical causal final-layer hidden states,
+mean pooled over non-PAD tokens. All embedding conditions use the same standardized
+logistic-regression probe (`C=1`). Confidence intervals use 1,000 stratified
+bootstrap resamples.
+
+## Results
+
+| Representation | Balanced accuracy | Macro-F1 | AUROC | Macro-AUPRC |
+| --- | ---: | ---: | ---: | ---: |
+| CodonLM seed 1337 | 0.322 | 0.317 | 0.777 | 0.312 |
+| CodonLM seed 2027 | 0.349 | 0.347 | 0.795 | 0.331 |
+| Random Transformer seed 19 | **0.508** | 0.422 | **0.898** | **0.526** |
+| Random Transformer seed 23 | 0.503 | **0.444** | 0.879 | 0.474 |
+| Nucleotide 3-mer TF-IDF | 0.194 | 0.187 | 0.837 | 0.342 |
+
+Raw accuracy is approximately 0.78-0.81 across conditions but is not the primary
+metric because 1,015 of 1,285 test records are beta-lactam examples.
+
+## Interpretation
+
+The pretrained checkpoints outperform the nucleotide 3-mer baseline on balanced
+accuracy and macro-F1, but not consistently on AUROC or macro-AUPRC. More
+importantly, both deterministic random-Transformer controls outperform both
+pretrained checkpoints on every class-aware metric. The pretraining representation
+gate therefore fails.
+
+This does not contradict the intrinsic PPL result. Next-token pretraining improved
+sequence prediction beyond trigram, but a final-layer causal mean is not guaranteed
+to be the best gene-level representation. Random nonlinear features can preserve
+global composition and length signals that the trained final layer suppresses while
+specializing for next-token logits.
+
+The next AMR work must be a predeclared representation ablation, not checkpoint
+selection on AMR test results. Candidate extraction methods are:
+
+1. mean pooling from earlier and middle Transformer layers;
+2. EOS or final-codon pooling, which has access to the full causal prefix;
+3. concatenated multi-layer pooling with a fixed dimensionality reduction;
+4. centered pooling that excludes BOS/EOS and explicitly controls for sequence
+   length and codon composition.
+
+These methods should be selected using grouped cross-validation inside the AMR
+training partition. The held-out AMR test set should not be reused for choosing the
+pooling method.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -891,6 +891,17 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     exact duplicates and reports 34 shared protein clusters, median nearest-protein
     identity 37.2%, and 95th percentile identity 73.9%. AMR is ready for
     provenance-bound embedding extraction; EC remains blocked on a new corpus.
+*   **Corrected AMR Representation Result (2026-07-29):** Added batched causal
+    embedding extraction and deterministic random-initialized architecture
+    controls with explicit weight provenance. On the six-class protein-cluster
+    holdout, corrected seed-1337/2027 final-layer causal-mean embeddings reached
+    balanced accuracy 0.322/0.349 and macro-AUPRC 0.312/0.331. Random-Transformer
+    seeds 19/23 reached balanced accuracy 0.508/0.503 and macro-AUPRC 0.526/0.474.
+    A nucleotide 3-mer TF-IDF baseline reached balanced accuracy 0.194 and
+    macro-AUPRC 0.342. The pretraining representation gate fails despite the
+    successful intrinsic PPL gate. Pooling and layer choice must be selected using
+    grouped cross-validation within probe training before the AMR test set is used
+    again.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_amr_evaluation.json
+++ b/docs/benchmarks/corrected_amr_evaluation.json
@@ -1,0 +1,87 @@
+{
+  "benchmark": "corrected_amr_protein_cluster_held_out",
+  "date": "2026-07-29",
+  "dataset": {
+    "train_records": 3733,
+    "test_records": 1285,
+    "classes": 6,
+    "within_amr_protein_clusters": 185,
+    "exact_test_pretraining_duplicates": 0,
+    "protein_clusters_shared_with_pretraining": 34
+  },
+  "probe": {
+    "classifier": "standardized_logistic_regression",
+    "C": 1.0,
+    "bootstrap": "1000 stratified resamples",
+    "pooling": "causal final-layer mean over non-PAD tokens"
+  },
+  "results": [
+    {
+      "model": "CodonLM",
+      "seed": 1337,
+      "checkpoint_sha256": "0ab91e5b38a1e9209101eb561ec52de670eee5baa7fb2fbd34d03c77c0f0e082",
+      "train_embedding_sha256": "bed5bede64342e77f33068d7544a69aeab09e8c93683149340ce7d11e0391375",
+      "test_embedding_sha256": "07791b85f292246fe7909e4e00c13823d44d6929a6526cd1a73925087d695a0e",
+      "accuracy": 0.806226,
+      "balanced_accuracy": 0.321756,
+      "balanced_accuracy_95_ci": [0.278346, 0.373285],
+      "macro_f1": 0.316719,
+      "macro_f1_95_ci": [0.273669, 0.364270],
+      "auroc": 0.776802,
+      "macro_auprc": 0.312254,
+      "macro_auprc_95_ci": [0.290231, 0.364453]
+    },
+    {
+      "model": "CodonLM",
+      "seed": 2027,
+      "checkpoint_sha256": "02e5dd39eb3d9f39bb8844a0df3bd4ac3fcfc9c367412710c14f12db373073ab",
+      "train_embedding_sha256": "df1fe10ad99c434b294c55b2d2b11878471218f3ac92f4395971a89d4a20532b",
+      "test_embedding_sha256": "919fdd0f0e2087f5e93662bae0943ee81d1373c2d565598b7b0bb97eaa039677",
+      "accuracy": 0.794553,
+      "balanced_accuracy": 0.349127,
+      "balanced_accuracy_95_ci": [0.301255, 0.398672],
+      "macro_f1": 0.347207,
+      "macro_f1_95_ci": [0.301215, 0.398949],
+      "auroc": 0.795111,
+      "macro_auprc": 0.330749,
+      "macro_auprc_95_ci": [0.306648, 0.384434]
+    },
+    {
+      "model": "random_transformer",
+      "seed": 19,
+      "balanced_accuracy": 0.507780,
+      "balanced_accuracy_95_ci": [0.444473, 0.569766],
+      "macro_f1": 0.421995,
+      "macro_f1_95_ci": [0.372368, 0.471834],
+      "auroc": 0.897823,
+      "macro_auprc": 0.525622,
+      "macro_auprc_95_ci": [0.474443, 0.600657]
+    },
+    {
+      "model": "random_transformer",
+      "seed": 23,
+      "balanced_accuracy": 0.503429,
+      "balanced_accuracy_95_ci": [0.442938, 0.566253],
+      "macro_f1": 0.443670,
+      "macro_f1_95_ci": [0.391924, 0.495114],
+      "auroc": 0.878784,
+      "macro_auprc": 0.474048,
+      "macro_auprc_95_ci": [0.426168, 0.551935]
+    },
+    {
+      "model": "nucleotide_3mer_tfidf",
+      "balanced_accuracy": 0.194337,
+      "balanced_accuracy_95_ci": [0.179679, 0.209818],
+      "macro_f1": 0.187389,
+      "macro_f1_95_ci": [0.168655, 0.206011],
+      "auroc": 0.836782,
+      "macro_auprc": 0.342278,
+      "macro_auprc_95_ci": [0.321638, 0.402168]
+    }
+  ],
+  "decision": {
+    "pretraining_representation_gate": "failed",
+    "reason": "Both random-transformer controls outperform both pretrained checkpoints on balanced accuracy, macro-F1, AUROC, and macro-AUPRC.",
+    "next_step": "Predeclare layer and pooling ablations before rerunning AMR; do not modify the frozen language-model checkpoint."
+  }
+}

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -28,7 +28,7 @@ import numpy as np
 import torch
 
 from . import query_model as Q
-from src.codonlm.checkpoints import load_codon_checkpoint
+from src.codonlm.checkpoints import build_codon_model_from_cfg, load_codon_checkpoint
 from src.codonlm.evaluation_provenance import (
     bind_checkpoint_dataset,
     bind_dataset_manifest,
@@ -160,8 +160,16 @@ def main() -> None:
         type=Path,
         help="Frozen pretraining manifest; required for corrected checkpoints.",
     )
+    ap.add_argument("--batch-size", type=int, default=16)
+    ap.add_argument(
+        "--random-init-seed",
+        type=int,
+        help="Extract from a deterministic random model with the checkpoint architecture.",
+    )
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
+    if args.batch_size < 1:
+        ap.error("--batch-size must be at least 1")
 
     # Resolve run directory and load model + vocab
     if args.run_dir:
@@ -177,9 +185,47 @@ def main() -> None:
         _, manifest_provenance = bind_dataset_manifest(args.manifest)
     checkpoint_dataset = bind_checkpoint_dataset(cfg, manifest_provenance)
     _validate_vocabulary(itos, state_dict, cfg, itos_path)
-    model = Q.build_model_from_state(
-        state_dict, cfg, setup_shape_runtime=False
-    )
+    if args.random_init_seed is None:
+        model = Q.build_model_from_state(
+            state_dict, cfg, setup_shape_runtime=False
+        )
+        model_initialization = {"kind": "trained_checkpoint"}
+        model_weights_sha256 = _sha256(checkpoint_path)
+    else:
+        if bool(cfg.get("use_shape_guidance", False)):
+            raise RuntimeError(
+                "random-init extraction is not supported for shape-guided checkpoints"
+            )
+        torch.manual_seed(args.random_init_seed)
+        model = build_codon_model_from_cfg(cfg)
+        model.eval()
+        random_contract = json.dumps(
+            {
+                "architecture": {
+                    key: cfg.get(key)
+                    for key in (
+                        "vocab_size",
+                        "block_size",
+                        "n_layer",
+                        "n_head",
+                        "n_embd",
+                        "dropout",
+                        "tie_embeddings",
+                        "n_kv_head",
+                        "use_sdpa",
+                        "use_swiglu",
+                        "use_rope",
+                    )
+                },
+                "seed": args.random_init_seed,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        model_weights_sha256 = hashlib.sha256(random_contract).hexdigest()
+        model_initialization = {
+            "kind": "random",
+            "seed": args.random_init_seed,
+        }
     device = Q.dev()
     model.to(device).eval()
     encoder = lookup = None
@@ -202,39 +248,50 @@ def main() -> None:
     bos = stoi.get("<BOS_CDS>")
     eos = stoi.get("<EOS_CDS>")
     pad = stoi.get("<PAD>", 0)
+    examples: List[Tuple[str, List[int]]] = []
+    max_T = int(cfg.get("block_size", getattr(model, "block_size", 512)))
+    for sid, seq in seqs:
+        if args.mode == "dna_cds":
+            codons = _dna_to_codon_tokens(seq)
+        else:
+            codons = [t for t in seq.strip().upper().split() if t]
+        toks = []
+        if bos is not None:
+            toks.append(bos)
+        toks.extend(stoi[c] for c in codons if c in stoi)
+        if eos is not None:
+            toks.append(eos)
+        if toks:
+            examples.append((sid, toks[:max_T]))
+
     out_vecs: List[np.ndarray] = []
     ids: List[str] = []
-    max_T = int(cfg.get("block_size", getattr(model, "block_size", 512)))
     with torch.no_grad():
-        for sid, seq in seqs:
-            if args.mode == "dna_cds":
-                codons = _dna_to_codon_tokens(seq)
-            else:
-                codons = [t for t in seq.strip().upper().split() if t]
-            # Map to ids; add BOS/EOS if available; truncate to block_size
-            toks = []
-            if bos is not None:
-                toks.append(bos)
-            for c in codons:
-                if c in stoi:
-                    toks.append(stoi[c])
-            if eos is not None:
-                toks.append(eos)
-            if not toks:
-                continue
-            ids_tensor = torch.tensor(
-                toks[:max_T], dtype=torch.long, device=device
-            ).unsqueeze(0)
+        for start in range(0, len(examples), args.batch_size):
+            batch = examples[start : start + args.batch_size]
+            batch_width = max(len(toks) for _, toks in batch)
+            ids_tensor = torch.full(
+                (len(batch), batch_width),
+                pad,
+                dtype=torch.long,
+                device=device,
+            )
+            for row, (_, toks) in enumerate(batch):
+                ids_tensor[row, : len(toks)] = torch.tensor(
+                    toks, dtype=torch.long, device=device
+                )
             nonpad = ids_tensor.ne(pad)
             shapes = None
             if encoder is not None:
-                one_hots = lookup[ids_tensor].view(1, 3 * ids_tensor.size(1), 4)
+                one_hots = lookup[ids_tensor].view(
+                    ids_tensor.size(0), 3 * ids_tensor.size(1), 4
+                )
                 shapes = encoder(one_hots)
             pooled = _pool_hidden(
                 model, ids_tensor, nonpad, shape_embeddings=shapes
             )
-            out_vecs.append(pooled.squeeze(0).cpu().numpy())
-            ids.append(sid)
+            out_vecs.extend(pooled.cpu().numpy())
+            ids.extend(sid for sid, _ in batch)
 
     if not out_vecs:
         raise SystemExit("No valid sequences after tokenization")
@@ -248,6 +305,10 @@ def main() -> None:
         "validation_status": "causal_verified",
         "created_at": datetime.now(timezone.utc).isoformat(),
         "checkpoint": {"path": str(checkpoint_path.resolve()), "sha256": _sha256(checkpoint_path)},
+        "model_weights": {
+            "sha256": model_weights_sha256,
+            "initialization": model_initialization,
+        },
         "dataset_manifest": manifest_provenance or {"status": "legacy_unverified"},
         "checkpoint_dataset": checkpoint_dataset,
         "vocabulary": {"path": str(itos_path.resolve()), "size": len(itos), "sha256": _sha256(itos_path)},
@@ -260,6 +321,7 @@ def main() -> None:
         "pooling_mode": "mean_nonpad_including_special_tokens",
         "shape_guidance": bool(getattr(model, "use_shape_guidance", False)),
         "block_size": max_T,
+        "extraction_batch_size": args.batch_size,
         "truncation_policy": "right_truncate",
         "code_git_sha": _git_sha(),
     }

--- a/src/classifiers/kmer_baselines.py
+++ b/src/classifiers/kmer_baselines.py
@@ -41,7 +41,7 @@ class KmerResult:
 def fit_kmer_logreg(seqs: List[str], y: np.ndarray, k: int = 3, tfidf: bool = True, C: float = 1.0, max_iter: int = 2000) -> KmerResult:
     vec = TfidfVectorizer(analyzer=_kmer_analyzer(k), lowercase=False, use_idf=tfidf, norm="l2")
     X = vec.fit_transform(seqs)
-    clf = LogisticRegression(C=C, max_iter=max_iter, n_jobs=-1, multi_class="auto")
+    clf = LogisticRegression(C=C, max_iter=max_iter)
     clf.fit(X, y)
     y_pred = clf.predict(X)
     y_proba = None

--- a/src/classifiers/linear_probe.py
+++ b/src/classifiers/linear_probe.py
@@ -23,7 +23,7 @@ class ProbeResult:
 def fit_logreg(X: np.ndarray, y: np.ndarray, C: float = 1.0, max_iter: int = 2000, multi_class: str = "auto") -> ProbeResult:
     clf = Pipeline([
         ("scaler", StandardScaler(with_mean=True)),
-        ("clf", LogisticRegression(C=C, max_iter=max_iter, n_jobs=-1))
+        ("clf", LogisticRegression(C=C, max_iter=max_iter))
     ])
     clf.fit(X, y)
     y_pred = clf.predict(X)

--- a/src/codonlm/evaluation_provenance.py
+++ b/src/codonlm/evaluation_provenance.py
@@ -213,9 +213,11 @@ def bind_embedding_pair(
                 train_extraction["dataset_manifest"].get("dataset_id"),
                 test_extraction["dataset_manifest"].get("dataset_id"),
             ),
-            "checkpoint_sha256": (
-                train_extraction["checkpoint"].get("sha256"),
-                test_extraction["checkpoint"].get("sha256"),
+            "model_weights_sha256": (
+                train_extraction.get("model_weights", {}).get("sha256")
+                or train_extraction["checkpoint"].get("sha256"),
+                test_extraction.get("model_weights", {}).get("sha256")
+                or test_extraction["checkpoint"].get("sha256"),
             ),
             "vocabulary_sha256": (
                 train_extraction["vocabulary"].get("sha256"),

--- a/tests/test_embedding_extraction_contract.py
+++ b/tests/test_embedding_extraction_contract.py
@@ -118,3 +118,61 @@ def test_cli_writes_verified_provenance_sidecar(tmp_path, monkeypatch):
     assert metadata["mask_mode"] == "canonical_causal_segment"
     assert metadata["vocabulary"]["size"] == 12
     assert metadata["inputs"][0]["path"] == str(fasta.resolve())
+    assert metadata["model_weights"]["initialization"]["kind"] == "trained_checkpoint"
+
+
+def test_cli_records_deterministic_random_initialization(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run"
+    (run_dir / "checkpoints").mkdir(parents=True)
+    tokens = ["<PAD>", "<BOS_CDS>", "<EOS_CDS>", "<SEP>", "ATG"] + [
+        f"T{i}" for i in range(7)
+    ]
+    (run_dir / "itos.txt").write_text("\n".join(tokens) + "\n")
+    model = _model()
+    cfg = {
+        "vocab_size": 12,
+        "block_size": 8,
+        "n_layer": 2,
+        "n_head": 2,
+        "n_embd": 16,
+        "dropout": 0.0,
+        "use_sdpa": True,
+    }
+    torch.save(
+        {"model": model.state_dict(), "cfg": cfg},
+        run_dir / "checkpoints" / "best.pt",
+    )
+    fasta = tmp_path / "input.fasta"
+    fasta.write_text(">gene-1\nATG\n")
+    monkeypatch.setattr(extract_embeddings.Q, "dev", lambda: torch.device("cpu"))
+
+    fingerprints = []
+    values = []
+    for index in range(2):
+        output = tmp_path / f"random-{index}.npz"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "extract_embeddings",
+                "--run_dir",
+                str(run_dir),
+                "--fasta",
+                str(fasta),
+                "--random-init-seed",
+                "19",
+                "--out",
+                str(output),
+            ],
+        )
+        extract_embeddings.main()
+        with np.load(output, allow_pickle=True) as data:
+            values.append(data["X"])
+        metadata = json.loads(output.with_suffix(".npz.metadata.json").read_text())
+        assert metadata["model_weights"]["initialization"] == {
+            "kind": "random",
+            "seed": 19,
+        }
+        fingerprints.append(metadata["model_weights"]["sha256"])
+
+    np.testing.assert_array_equal(values[0], values[1])
+    assert fingerprints[0] == fingerprints[1]


### PR DESCRIPTION
## Summary
- batch causal extraction across canonical intermediate layers and pooling modes
- add deterministic random-initialized Transformer controls with explicit weight provenance
- select AMR representation using five-fold stratified protein-cluster-grouped CV on training data only
- evaluate the locked layer-2 content-mean representation once on held-out AMR test data
- record the remaining failed pretraining representation gate

## Initial final-layer result
| Representation | Balanced accuracy | Macro-AUPRC |
| --- | ---: | ---: |
| CodonLM seed 1337 | 0.322 | 0.312 |
| CodonLM seed 2027 | 0.349 | 0.331 |
| Random Transformer seed 19 | 0.508 | 0.526 |
| Random Transformer seed 23 | 0.503 | 0.474 |
| Nucleotide 3-mer TF-IDF | 0.194 | 0.342 |

## Train-only selection and locked test
Grouped training CV selected layer-2 content-only mean pooling by macro-AUPRC: 0.4587, versus 0.4576 for layer-2 non-PAD mean.

| Locked representation | Balanced accuracy | Macro-F1 | Macro-AUPRC |
| --- | ---: | ---: | ---: |
| Layer 2, seed 1337 | 0.501 | 0.431 | 0.447 |
| Layer 2, seed 2027 | 0.469 | 0.405 | 0.451 |

Early-layer pooling fixes most of the final-layer deficit but does not consistently exceed both random controls. Intrinsic PPL promotion remains valid; AMR-specific pretraining benefit remains unproven.

## Validation
- targeted Ruff: passed
- jq benchmark validation: passed
- pytest -q: 323 passed, 1 skipped, 1 xpassed
- git diff --check: passed