### PR TITLE
Restore grouped AMR representation selection

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -127,6 +127,10 @@ an architectural intervention.
   outperform both pretrained final-layer causal-mean representations. Predeclare
   pooling/layer selection using grouped cross-validation within probe training
   before touching the AMR test set again.
+  The train-only ablation selected layer-2 content mean (macro-AUPRC 0.4587 across
+  grouped folds and seeds). Locked test balanced accuracy improved to 0.501/0.469
+  from 0.322/0.349, but the representation still does not consistently beat both
+  random controls; AMR-specific pretraining benefit remains unproven.
 - [ ] Run raw and syntax-constrained generation with memorization and nucleotide/
   protein nearest-neighbor audits; do not use critic scores for promotion yet.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and

--- a/configs/classifier/corrected_amr_layer2_seed1337.yaml
+++ b/configs/classifier/corrected_amr_layer2_seed1337.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out_train_cv_selected
+task: corrected_amr_layer2_seed1337
+out_dir: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/scores/amr_layer2_mean_content
+require_verified_embeddings: true
+
+data:
+  train_embeddings: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/embeddings/amr_protein_cluster/train_layer2_mean_content.npz
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_embeddings: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/embeddings/amr_protein_cluster/test_layer2_mean_content.npz
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: probe_logreg
+  C: 1.0

--- a/configs/classifier/corrected_amr_layer2_seed2027.yaml
+++ b/configs/classifier/corrected_amr_layer2_seed2027.yaml
@@ -1,0 +1,14 @@
+protocol: protein_cluster_held_out_train_cv_selected
+task: corrected_amr_layer2_seed2027
+out_dir: runs/corrected-codonlm-v1-batch64-lr15-seed2027/scores/amr_layer2_mean_content
+require_verified_embeddings: true
+
+data:
+  train_embeddings: runs/corrected-codonlm-v1-batch64-lr15-seed2027/embeddings/amr_protein_cluster/train_layer2_mean_content.npz
+  train_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/train_amr.csv
+  test_embeddings: runs/corrected-codonlm-v1-batch64-lr15-seed2027/embeddings/amr_protein_cluster/test_layer2_mean_content.npz
+  test_labels: data/processed/downstream/corrected-codonlm-v1/amr/protein_cluster_held_out/test_amr.csv
+
+classifier:
+  kind: probe_logreg
+  C: 1.0

--- a/docs/CORRECTED_AMR_EVALUATION.md
+++ b/docs/CORRECTED_AMR_EVALUATION.md
@@ -52,3 +52,28 @@ selection on AMR test results. Candidate extraction methods are:
 These methods should be selected using grouped cross-validation inside the AMR
 training partition. The held-out AMR test set should not be reused for choosing the
 pooling method.
+
+## Train-Only Representation Selection
+
+Five-fold stratified protein-cluster-grouped cross-validation was run on the 3,733
+AMR training records only. It compared layers 0, 2, 5, 8, and final with
+content-only mean, non-PAD mean, and EOS pooling for both CodonLM seeds. Macro-AUPRC
+was the declared selection metric.
+
+Layer 2 content-only mean pooling ranked first with mean macro-AUPRC `0.4587`
+(fold/seed standard deviation `0.1109`). Layer 2 non-PAD mean was second at
+`0.4576`; the small margin is a limitation. After locking the winner, it was
+evaluated once on the held-out AMR test set:
+
+| Representation | Balanced accuracy | Macro-F1 | AUROC | Macro-AUPRC |
+| --- | ---: | ---: | ---: | ---: |
+| Layer 2 content mean, seed 1337 | **0.501** | **0.431** | **0.881** | 0.447 |
+| Layer 2 content mean, seed 2027 | 0.469 | 0.405 | 0.875 | **0.451** |
+| Final causal mean, seed 1337 | 0.322 | 0.317 | 0.777 | 0.312 |
+| Final causal mean, seed 2027 | 0.349 | 0.347 | 0.795 | 0.331 |
+
+Early-layer pooling repairs much of the final-layer deficit. It brings CodonLM
+close to random-Transformer balanced accuracy (`0.503-0.508`) but still does not
+consistently exceed the random controls, whose macro-AUPRC is `0.474-0.526`.
+Therefore the extraction failure is confirmed, but an AMR-specific pretraining
+advantage remains unproven.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -902,6 +902,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     successful intrinsic PPL gate. Pooling and layer choice must be selected using
     grouped cross-validation within probe training before the AMR test set is used
     again.
+*   **AMR Train-Only Layer/Pooling Ablation (2026-07-29):** Added canonical
+    intermediate hidden-state iteration and multi-representation extraction.
+    Five-fold stratified protein-cluster-grouped CV over AMR training records,
+    aggregated across both CodonLM seeds, selected layer-2 content-only mean pooling
+    by macro-AUPRC (0.4587; layer-2 non-PAD mean runner-up 0.4576). After locking,
+    held-out balanced accuracy improved from 0.322/0.349 to 0.501/0.469 and
+    macro-AUPRC from 0.312/0.331 to 0.447/0.451. This confirms final-layer pooling
+    was a major failure mode, but the selected pretrained representations still do
+    not consistently exceed both random-Transformer controls.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_amr_evaluation.json
+++ b/docs/benchmarks/corrected_amr_evaluation.json
@@ -82,6 +82,38 @@
   "decision": {
     "pretraining_representation_gate": "failed",
     "reason": "Both random-transformer controls outperform both pretrained checkpoints on balanced accuracy, macro-F1, AUROC, and macro-AUPRC.",
-    "next_step": "Predeclare layer and pooling ablations before rerunning AMR; do not modify the frozen language-model checkpoint."
+    "next_step": "Use the train-only selected layer-2 content mean for downstream sensitivity reporting, while retaining the conclusion that AMR-specific pretraining benefit is unproven."
+  },
+  "train_only_representation_selection": {
+    "protocol": "5-fold stratified protein-cluster-grouped CV aggregated across both CodonLM seeds",
+    "primary_metric": "macro_auprc",
+    "winner": "layer_2__mean_content",
+    "winner_macro_auprc_mean": 0.458734,
+    "winner_macro_auprc_std": 0.110852,
+    "runner_up": "layer_2__mean_nonpad",
+    "runner_up_macro_auprc_mean": 0.457618,
+    "test_results_after_lock": [
+      {
+        "seed": 1337,
+        "train_embedding_sha256": "ae71890434a4271c0e281ad5abe3253dd32b56136651cdbd5f0993048fed4224",
+        "test_embedding_sha256": "6445e526ac5458e79cbd02b28995a41868cf9238c1b1e05928ca0dccbd036fd5",
+        "balanced_accuracy": 0.500968,
+        "balanced_accuracy_95_ci": [0.439202, 0.559325],
+        "macro_f1": 0.430720,
+        "macro_auprc": 0.447116,
+        "macro_auprc_95_ci": [0.415260, 0.511792]
+      },
+      {
+        "seed": 2027,
+        "train_embedding_sha256": "bd9c3c3c910276bc9e465ac509b9cba928cd361a8282bb0445628c2e7513a5eb",
+        "test_embedding_sha256": "d63c8a15ded8c8af46d872398503b21a067bcaab005cbbcf6c18e562bfcc4920",
+        "balanced_accuracy": 0.468630,
+        "balanced_accuracy_95_ci": [0.409038, 0.523848],
+        "macro_f1": 0.405053,
+        "macro_auprc": 0.451325,
+        "macro_auprc_95_ci": [0.410368, 0.520011]
+      }
+    ],
+    "conclusion": "Early-layer pooling fixes most of the final-layer deficit but does not establish a consistent advantage over random Transformer controls."
   }
 }

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -91,6 +91,29 @@ def _pool_hidden(
         return pooled  # (B, D)
 
 
+def _pool_state(
+    hidden: torch.Tensor,
+    idx: torch.Tensor,
+    nonpad_mask: torch.Tensor,
+    *,
+    mode: str,
+    content_ids: set[int],
+) -> torch.Tensor:
+    if mode == "mean_nonpad":
+        mask = nonpad_mask
+    elif mode == "mean_content":
+        mask = torch.zeros_like(nonpad_mask)
+        for token_id in content_ids:
+            mask |= idx.eq(token_id)
+    elif mode == "eos":
+        positions = nonpad_mask.long().sum(dim=1).sub(1).clamp_min(0)
+        return hidden[torch.arange(hidden.size(0), device=hidden.device), positions]
+    else:
+        raise ValueError(f"unsupported pooling mode: {mode}")
+    weights = mask.to(hidden.dtype).unsqueeze(-1)
+    return (hidden * weights).sum(dim=1) / weights.sum(dim=1).clamp_min(1.0)
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -166,10 +189,25 @@ def main() -> None:
         type=int,
         help="Extract from a deterministic random model with the checkpoint architecture.",
     )
+    ap.add_argument(
+        "--hidden-layers",
+        default="final",
+        help="Comma-separated layer stages: 0..n_layer and/or final.",
+    )
+    ap.add_argument(
+        "--pooling-modes",
+        default="mean_nonpad",
+        help="Comma-separated modes: mean_nonpad, mean_content, eos.",
+    )
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
     if args.batch_size < 1:
         ap.error("--batch-size must be at least 1")
+    layer_values: list[int | str] = []
+    for value in args.hidden_layers.split(","):
+        value = value.strip()
+        layer_values.append("final" if value == "final" else int(value))
+    pooling_modes = [value.strip() for value in args.pooling_modes.split(",")]
 
     # Resolve run directory and load model + vocab
     if args.run_dir:
@@ -180,6 +218,12 @@ def main() -> None:
     itos = load_itos(itos_path)
     stoi = {token: index for index, token in enumerate(itos)}
     state_dict, cfg, checkpoint_path = load_codon_checkpoint(rd)
+    valid_layers = set(range(int(cfg["n_layer"]) + 1)) | {"final"}
+    if not layer_values or any(layer not in valid_layers for layer in layer_values):
+        ap.error(f"--hidden-layers must be drawn from {sorted(map(str, valid_layers))}")
+    valid_pooling = {"mean_nonpad", "mean_content", "eos"}
+    if not pooling_modes or any(mode not in valid_pooling for mode in pooling_modes):
+        ap.error(f"--pooling-modes must be drawn from {sorted(valid_pooling)}")
     manifest_provenance = None
     if args.manifest is not None:
         _, manifest_provenance = bind_dataset_manifest(args.manifest)
@@ -264,8 +308,15 @@ def main() -> None:
         if toks:
             examples.append((sid, toks[:max_T]))
 
-    out_vecs: List[np.ndarray] = []
+    representation_vectors: dict[str, List[np.ndarray]] = {
+        f"layer_{layer}__{mode}": []
+        for layer in layer_values
+        for mode in pooling_modes
+    }
     ids: List[str] = []
+    content_ids = {
+        index for index, token in enumerate(itos) if len(token) == 3 and token.isalpha()
+    }
     with torch.no_grad():
         for start in range(0, len(examples), args.batch_size):
             batch = examples[start : start + args.batch_size]
@@ -287,18 +338,39 @@ def main() -> None:
                     ids_tensor.size(0), 3 * ids_tensor.size(1), 4
                 )
                 shapes = encoder(one_hots)
-            pooled = _pool_hidden(
-                model, ids_tensor, nonpad, shape_embeddings=shapes
-            )
-            out_vecs.extend(pooled.cpu().numpy())
+            requested = set(layer_values)
+            iterator = getattr(model, "iter_hidden_states", None)
+            if not callable(iterator):
+                raise TypeError(
+                    f"{type(model).__name__} does not expose iter_hidden_states"
+                )
+            for layer, hidden in iterator(ids_tensor, shape_embeddings=shapes):
+                if layer not in requested:
+                    continue
+                for mode in pooling_modes:
+                    pooled = _pool_state(
+                        hidden,
+                        ids_tensor,
+                        nonpad,
+                        mode=mode,
+                        content_ids=content_ids,
+                    )
+                    representation_vectors[f"layer_{layer}__{mode}"].extend(
+                        pooled.cpu().numpy()
+                    )
             ids.extend(sid for sid, _ in batch)
 
-    if not out_vecs:
+    if not ids:
         raise SystemExit("No valid sequences after tokenization")
-    X = np.stack(out_vecs, axis=0)
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(out_path, X=X, ids=np.array(ids, dtype=object))
+    arrays = {
+        f"X__{name}": np.stack(vectors, axis=0)
+        for name, vectors in representation_vectors.items()
+    }
+    if len(arrays) == 1:
+        arrays["X"] = next(iter(arrays.values()))
+    np.savez_compressed(out_path, **arrays, ids=np.array(ids, dtype=object))
     input_paths = [Path(path) for path in (args.fasta, args.csv) if path]
     metadata = {
         "schema_version": 1,
@@ -318,7 +390,12 @@ def main() -> None:
             if getattr(model, "sep_id", None) is not None
             else "canonical_causal"
         ),
-        "pooling_mode": "mean_nonpad_including_special_tokens",
+        "pooling_mode": (
+            "mean_nonpad_including_special_tokens"
+            if pooling_modes == ["mean_nonpad"]
+            else "multi_representation"
+        ),
+        "representations": sorted(representation_vectors),
         "shape_guidance": bool(getattr(model, "use_shape_guidance", False)),
         "block_size": max_T,
         "extraction_batch_size": args.batch_size,
@@ -328,7 +405,8 @@ def main() -> None:
     out_path.with_suffix(out_path.suffix + ".metadata.json").write_text(
         json.dumps(metadata, indent=2, sort_keys=True) + "\n"
     )
-    print(f"[extract] wrote {args.out} with X.shape={X.shape}")
+    shapes_written = {name: list(array.shape) for name, array in arrays.items()}
+    print(f"[extract] wrote {args.out} with arrays={shapes_written}")
 
 
 if __name__ == "__main__":

--- a/scripts/select_grouped_representation.py
+++ b/scripts/select_grouped_representation.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Select a pooled representation using grouped CV without test-set access."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+from sklearn.model_selection import StratifiedGroupKFold
+
+from src.classifiers.linear_probe import fit_logreg
+from src.classifiers.probes import compute_metrics
+from src.codonlm.evaluation_provenance import bind_embedding_artifact
+
+
+def _mapping(path: Path, value_column: str) -> dict[str, str]:
+    with path.open(newline="") as handle:
+        return {
+            row["id"]: row[value_column]
+            for row in csv.DictReader(
+                handle, delimiter="\t" if path.suffix == ".tsv" else ","
+            )
+            if row.get("id") and row.get(value_column)
+        }
+
+
+def _load(path: Path) -> tuple[list[str], dict[str, np.ndarray]]:
+    with np.load(path, allow_pickle=True) as blob:
+        ids = [str(value) for value in blob["ids"]]
+        arrays = {
+            key.removeprefix("X__"): np.asarray(blob[key])
+            for key in blob.files
+            if key.startswith("X__")
+        }
+    if not arrays:
+        raise ValueError(f"no multi-representation arrays found in {path}")
+    return ids, arrays
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--embeddings", type=Path, nargs="+", required=True)
+    parser.add_argument("--labels", type=Path, required=True)
+    parser.add_argument("--groups", type=Path, required=True)
+    parser.add_argument("--group-column", default="protein_cluster")
+    parser.add_argument("--folds", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--C", type=float, default=1.0)
+    parser.add_argument("--primary-metric", default="macro_auprc")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    labels = _mapping(args.labels, "label")
+    groups = _mapping(args.groups, args.group_column)
+    loaded = []
+    for path in args.embeddings:
+        bind_embedding_artifact(path, require_verified=True)
+        loaded.append((path, *_load(path)))
+    reference_ids = loaded[0][1]
+    candidates = set(loaded[0][2])
+    for path, ids, arrays in loaded[1:]:
+        if ids != reference_ids:
+            raise ValueError(f"embedding ID order differs: {path}")
+        candidates &= set(arrays)
+    keep = [
+        index
+        for index, identifier in enumerate(reference_ids)
+        if identifier in labels and identifier in groups
+    ]
+    ids = [reference_ids[index] for index in keep]
+    label_values = sorted({labels[identifier] for identifier in ids})
+    label_to_int = {label: index for index, label in enumerate(label_values)}
+    y = np.asarray([label_to_int[labels[identifier]] for identifier in ids])
+    group_values = np.asarray([groups[identifier] for identifier in ids])
+    splitter = StratifiedGroupKFold(
+        n_splits=args.folds, shuffle=True, random_state=args.seed
+    )
+    splits = list(splitter.split(np.zeros(len(ids)), y, group_values))
+
+    reports = []
+    for candidate in sorted(candidates):
+        per_run = []
+        all_folds = []
+        for path, _, arrays in loaded:
+            X = arrays[candidate][keep]
+            fold_metrics = []
+            for train_index, val_index in splits:
+                result = fit_logreg(X[train_index], y[train_index], C=args.C)
+                prediction = result.model.predict(X[val_index])
+                probability = result.model.predict_proba(X[val_index])
+                metrics = compute_metrics(y[val_index], prediction, probability)
+                fold_metrics.append(metrics)
+                all_folds.append(metrics)
+            per_run.append(
+                {
+                    "embedding": str(path),
+                    "folds": fold_metrics,
+                }
+            )
+        keys = sorted(set.intersection(*(set(fold) for fold in all_folds)))
+        aggregate = {
+            key: {
+                "mean": float(np.mean([fold[key] for fold in all_folds])),
+                "std": float(np.std([fold[key] for fold in all_folds])),
+            }
+            for key in keys
+        }
+        reports.append(
+            {
+                "representation": candidate,
+                "aggregate": aggregate,
+                "runs": per_run,
+            }
+        )
+
+    reports.sort(
+        key=lambda item: item["aggregate"].get(
+            args.primary_metric, {"mean": float("-inf")}
+        )["mean"],
+        reverse=True,
+    )
+    output = {
+        "protocol": "stratified_protein_cluster_grouped_cv",
+        "selection_split": "amr_train_only",
+        "folds": args.folds,
+        "seed": args.seed,
+        "C": args.C,
+        "primary_metric": args.primary_metric,
+        "records": len(ids),
+        "groups": len(set(group_values)),
+        "classes": label_values,
+        "winner": reports[0]["representation"],
+        "ranking": reports,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2) + "\n")
+    print(
+        f"[representation] winner={output['winner']} "
+        f"{args.primary_metric}={reports[0]['aggregate'][args.primary_metric]['mean']:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codonlm/model_tiny_gpt.py
+++ b/src/codonlm/model_tiny_gpt.py
@@ -354,6 +354,21 @@ class TinyGPT(nn.Module):
     def forward_hidden(
         self, idx, shape_embeddings=None, attention_window: int | None = None
     ):
+        final = None
+        for _, hidden in self.iter_hidden_states(
+            idx,
+            shape_embeddings=shape_embeddings,
+            attention_window=attention_window,
+        ):
+            final = hidden
+        if final is None:
+            raise RuntimeError("hidden-state iterator produced no states")
+        return final
+
+    def iter_hidden_states(
+        self, idx, shape_embeddings=None, attention_window: int | None = None
+    ):
+        """Yield canonical causal states at embedding, block, and final-norm stages."""
         B, T = idx.shape
         x = self.tok_emb(idx)
         if not self.use_rope:
@@ -365,11 +380,13 @@ class TinyGPT(nn.Module):
 
         attn_mask = self.build_attention_mask(idx, attention_window)
 
-        for blk in self.blocks:
+        yield 0, x
+        for layer, blk in enumerate(self.blocks, start=1):
             x = blk(x, attn_mask=attn_mask)
+            yield layer, x
 
         x = self.ln_f(x)
-        return x
+        yield "final", x
 
 class NoPropBlock(nn.Module):
     def __init__(self, n_embd, n_head, dropout, block_size, n_kv_head: int | None = None, use_sdpa: bool = False):

--- a/tests/test_embedding_extraction_contract.py
+++ b/tests/test_embedding_extraction_contract.py
@@ -44,6 +44,16 @@ def test_previous_segment_cannot_change_later_segment_hidden_states():
     torch.testing.assert_close(first_hidden[:, 2:], second_hidden[:, 2:])
 
 
+def test_hidden_iterator_final_state_matches_forward_hidden():
+    model = _model()
+    ids = torch.tensor([[1, 4, 5, 6, 7]])
+    with torch.no_grad():
+        expected = model.forward_hidden(ids)
+        states = list(model.iter_hidden_states(ids))
+    assert [layer for layer, _ in states] == [0, 1, 2, "final"]
+    torch.testing.assert_close(states[-1][1], expected)
+
+
 def test_pooling_rejects_unverified_model_api():
     class Unsupported(torch.nn.Module):
         pass

--- a/tests/test_representation_selection.py
+++ b/tests/test_representation_selection.py
@@ -1,0 +1,58 @@
+import csv
+import json
+
+import numpy as np
+
+from scripts.select_grouped_representation import main
+
+
+def test_grouped_representation_selection_uses_training_groups(tmp_path):
+    ids = [f"gene-{index}" for index in range(32)]
+    labels = np.asarray([index % 2 for index in range(32)])
+    groups = [f"cluster-{index // 4}" for index in range(32)]
+    embeddings = tmp_path / "train.npz"
+    signal = np.column_stack([labels, 1 - labels]).astype(np.float32)
+    constant = np.zeros_like(signal)
+    np.savez(
+        embeddings,
+        ids=np.asarray(ids, dtype=object),
+        X__layer_2__mean_content=signal,
+        X__layer_final__mean_nonpad=constant,
+    )
+    metadata = {
+        "validation_status": "causal_verified",
+        "dataset_manifest": {"status": "frozen_manifest_verified"},
+        "checkpoint_dataset": {"status": "checkpoint_manifest_verified"},
+    }
+    embeddings.with_suffix(".npz.metadata.json").write_text(json.dumps(metadata))
+    labels_path = tmp_path / "labels.csv"
+    with labels_path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id", "label"])
+        writer.writerows(zip(ids, labels))
+    groups_path = tmp_path / "groups.tsv"
+    with groups_path.open("w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(["id", "protein_cluster"])
+        writer.writerows(zip(ids, groups))
+    output = tmp_path / "selection.json"
+
+    main(
+        [
+            "--embeddings",
+            str(embeddings),
+            "--labels",
+            str(labels_path),
+            "--groups",
+            str(groups_path),
+            "--folds",
+            "4",
+            "--output",
+            str(output),
+        ]
+    )
+
+    report = json.loads(output.read_text())
+    assert report["selection_split"] == "amr_train_only"
+    assert report["groups"] == 8
+    assert report["winner"] == "layer_2__mean_content"


### PR DESCRIPTION
## Summary
- restore the grouped-CV layer/pooling experiment that was pushed after PR #132's merged commit set was fixed
- add canonical intermediate hidden-state iteration and multi-representation extraction
- select layer-2 content mean using AMR training clusters only
- record the locked held-out result and tests

## Results
- grouped train-CV winner: layer-2 content mean, macro-AUPRC 0.4587
- locked test balanced accuracy: 0.501 / 0.469 vs final-layer 0.322 / 0.349
- locked test macro-AUPRC: 0.447 / 0.451 vs final-layer 0.312 / 0.331
- random controls still are not consistently beaten

## Validation
This is the exact previously validated commit content: 323 passed, 1 skipped, 1 xpassed; targeted Ruff and JSON validation passed.