### PR TITLE
Run corrected DNA-shape controls

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -131,6 +131,10 @@ an architectural intervention.
   grouped folds and seeds). Locked test balanced accuracy improved to 0.501/0.469
   from 0.322/0.349, but the representation still does not consistently beat both
   random controls; AMR-specific pretraining benefit remains unproven.
+  The corrected linear DNA-shape gate also fails. Across two checkpoint seeds,
+  final and layer-2 states are substantially worse than matched random-Transformer,
+  one-hot, and local-sequence controls under both two-genome transfer and
+  five-fold gene-grouped sensitivity protocols.
 - [ ] Run raw and syntax-constrained generation with memorization and nucleotide/
   protein nearest-neighbor audits; do not use critic scores for promotion yet.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and

--- a/docs/CORRECTED_DNA_SHAPE_EVALUATION.md
+++ b/docs/CORRECTED_DNA_SHAPE_EVALUATION.md
@@ -1,0 +1,88 @@
+# Corrected DNA-Shape Evaluation
+
+## Question
+
+Does the corrected basic CodonLM make local DNA-shape proxy values linearly
+recoverable from its causal codon states?
+
+The 14 targets are computed deterministically from local nucleotide sequence. They
+are not independent experimental structure measurements. Consequently, this
+benchmark measures representation decodability and shortcut resistance, not proof
+that the model learned physical DNA structure.
+
+## Protocol
+
+- Frozen genome-held-out test artifact only.
+- Deterministic sampling of 100 windows, balanced 50/50 across the two held-out
+  genomes.
+- 38,068 codon positions in the primary analysis.
+- Two-fold genome grouping: train the Ridge probe on one genome and test on the
+  other.
+- Five-fold gene grouping reported separately as a less stringent sensitivity
+  analysis.
+- Identical folds for one-hot codons, centered local 5-mer and 7-mer features,
+  random Transformer states, and pretrained states.
+- Corrected checkpoints seeds 1337 and 2027.
+- Random-model seed 19.
+- Final hidden states and layer 2. Layer 2 was motivated independently by the AMR
+  train-only experiment and was not selected using DNA-shape results.
+
+## Primary Genome-Grouped Result
+
+Mean R² is averaged across 14 shape properties.
+
+| Representation | Mean R² |
+| --- | ---: |
+| Centered local 5-mer | **0.767** |
+| One-hot codon | 0.445 |
+| Random Transformer, final | 0.334 |
+| Random Transformer, layer 2 | 0.344 |
+| CodonLM seed 2027, layer 2 | -0.640 |
+| CodonLM seed 2027, final | -0.660 |
+| CodonLM seed 1337, layer 2 | -0.670 |
+| CodonLM seed 1337, final | -0.677 |
+
+Negative R² means the fitted probe generalizes worse than predicting the held-out
+genome's target mean. With only two independent genomes, confidence intervals are
+wide; the near-identical results across checkpoint seeds and layers are therefore
+more informative than the nominal two-fold interval.
+
+The centered 7-mer reaches only R² `0.025` in genome transfer, despite its strong
+gene-grouped result. This likely reflects sparse 7-mer feature coverage across two
+genomes rather than evidence that five bases are universally more informative than
+seven.
+
+## Gene-Grouped Sensitivity
+
+| Representation | Mean R² |
+| --- | ---: |
+| Centered local 5-mer | **0.930** |
+| Centered local 7-mer | 0.844 |
+| One-hot codon | 0.654 |
+| Random Transformer, layer 2 | 0.608 |
+| Random Transformer, final | 0.600 |
+| CodonLM seed 2027, layer 2 | 0.024 |
+| CodonLM seed 1337, layer 2 | 0.017 |
+| CodonLM seed 1337, final | 0.010 |
+| CodonLM seed 2027, final | 0.001 |
+
+Gene grouping prevents positions from the same gene entering both folds, but genes
+from the same genome can appear on both sides. It therefore provides tighter
+uncertainty while testing a weaker generalization boundary.
+
+## Conclusion
+
+The corrected basic CodonLM does not linearly expose the computed local DNA-shape
+targets. This failure is consistent across two checkpoints, final and early
+layers, genome transfer, and gene-grouped sensitivity analysis. Random Transformer
+features retain far more locally decodable sequence information.
+
+This does not invalidate the PPL result. It shows that learning longer-range
+next-codon dependencies did not organize these local physical proxies in a
+linearly accessible form.
+
+A capacity-matched nonlinear probe is still useful as a sensitivity analysis. If
+it succeeds, the defensible conclusion would be that shape information is present
+but nonlinearly encoded. It would not establish that CodonLM improves on random or
+local-sequence controls unless those controls receive the same nonlinear probe and
+grouped folds.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -911,6 +911,16 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     macro-AUPRC from 0.312/0.331 to 0.447/0.451. This confirms final-layer pooling
     was a major failure mode, but the selected pretrained representations still do
     not consistently exceed both random-Transformer controls.
+*   **Corrected DNA-Shape Linear Controls (2026-07-29):** Added deterministic
+    group-balanced window sampling and explicit random-model/layer provenance.
+    The primary two-genome transfer uses 100 windows balanced 50/50 across the
+    held-out genomes (38,068 positions). Final-layer CodonLM R² was -0.677/-0.660
+    for seeds 1337/2027, versus random 0.334, one-hot 0.445, and centered 5-mer
+    0.767. The independently motivated layer-2 hypothesis also failed
+    (-0.670/-0.640 versus matched random 0.344). Five-fold gene-grouped sensitivity
+    reproduced the gap: pretrained R² 0.001-0.024 versus random 0.600-0.608,
+    one-hot 0.654, and local 5-mer 0.930. These computed targets do not support a
+    claim of linearly organized DNA-shape representations.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_dna_shape_evaluation.json
+++ b/docs/benchmarks/corrected_dna_shape_evaluation.json
@@ -1,0 +1,57 @@
+{
+  "benchmark": "corrected_dna_shape_controls",
+  "date": "2026-07-29",
+  "targets": {
+    "source": "computed local-sequence DNA-shape proxy",
+    "properties": 14,
+    "warning": "These are deterministic computational targets, not independent experimental measurements."
+  },
+  "sampling": {
+    "available_test_windows": 5712,
+    "selected_windows": 100,
+    "seed": 42,
+    "genome_counts": {
+      "GCF_000008525.1": 50,
+      "GCF_000009125.1": 50
+    }
+  },
+  "primary_genome_grouped": {
+    "folds": 2,
+    "positions": 38068,
+    "final_layer": {
+      "one_hot": 0.444837,
+      "local_5mer": 0.766993,
+      "local_7mer": 0.025073,
+      "random_seed19": 0.334176,
+      "codonlm_seed1337": -0.677084,
+      "codonlm_seed2027": -0.659900
+    },
+    "layer_2_cross_task_hypothesis": {
+      "random_seed19": 0.344100,
+      "codonlm_seed1337": -0.669800,
+      "codonlm_seed2027": -0.639600
+    }
+  },
+  "gene_grouped_sensitivity": {
+    "folds": 5,
+    "positions": 37182,
+    "final_layer": {
+      "one_hot": 0.653828,
+      "local_5mer": 0.929831,
+      "local_7mer": 0.844424,
+      "random_seed19": 0.600241,
+      "codonlm_seed1337": 0.009727,
+      "codonlm_seed2027": 0.001300
+    },
+    "layer_2_cross_task_hypothesis": {
+      "random_seed19": 0.608000,
+      "codonlm_seed1337": 0.016800,
+      "codonlm_seed2027": 0.024200
+    }
+  },
+  "decision": {
+    "linear_shape_representation_gate": "failed",
+    "reason": "Both trained checkpoints and both tested layers are substantially worse than matched random-Transformer, one-hot, and local-sequence controls.",
+    "next_step": "Run a capacity-matched nonlinear sensitivity analysis without treating it as evidence of linearly organized shape representations."
+  }
+}

--- a/scripts/eval_shape_baselines.py
+++ b/scripts/eval_shape_baselines.py
@@ -32,14 +32,29 @@ PROPERTIES = (
 METHODS = ("one_hot", "local_5mer", "local_7mer", "random", "pretrained")
 
 
-def extract_hidden_states(model, input_ids):
+def extract_hidden_states(model, input_ids, hidden_layer: int | str = "final"):
     forward_hidden = getattr(model, "forward_hidden", None)
     if not callable(forward_hidden):
         raise TypeError(f"{type(model).__name__} lacks the verified forward_hidden API")
     if getattr(model, "use_shape_guidance", False):
         raise RuntimeError("shape-guided models require the dedicated artifact-aware extractor")
     with torch.no_grad():
-        return forward_hidden(input_ids).squeeze(0).cpu().numpy()
+        if hidden_layer == "final":
+            hidden = forward_hidden(input_ids)
+        else:
+            iterator = getattr(model, "iter_hidden_states", None)
+            if not callable(iterator):
+                raise TypeError(
+                    f"{type(model).__name__} lacks the verified iter_hidden_states API"
+                )
+            hidden = None
+            for layer, state in iterator(input_ids):
+                if layer == hidden_layer:
+                    hidden = state
+                    break
+            if hidden is None:
+                raise ValueError(f"hidden layer {hidden_layer} is unavailable")
+        return hidden.squeeze(0).cpu().numpy()
 
 
 def make_group_folds(groups: np.ndarray, n_splits: int, seed: int):
@@ -101,16 +116,79 @@ def _read_genomes(path: Path | None):
         }
 
 
+def select_window_indices(
+    spans,
+    genomes,
+    group_by: str,
+    max_windows: int,
+    seed: int,
+):
+    """Select windows deterministically while balancing declared biological groups."""
+    available = sorted(spans)
+    if max_windows <= 0 or max_windows >= len(available):
+        selected = available
+    elif group_by == "window":
+        rng = np.random.default_rng(seed)
+        selected = sorted(rng.choice(available, size=max_windows, replace=False).tolist())
+    else:
+        by_group = defaultdict(list)
+        for window_index in available:
+            for span in spans[window_index]:
+                source = span["source_id"]
+                group = genomes[source] if group_by == "genome" else source
+                by_group[group].append(window_index)
+        rng = np.random.default_rng(seed)
+        queues = {}
+        for group, indices in sorted(by_group.items()):
+            unique = np.asarray(sorted(set(indices)), dtype=np.int64)
+            queues[group] = list(rng.permutation(unique))
+        selected_order, selected_set = [], set()
+        while len(selected_order) < max_windows:
+            progressed = False
+            for group in sorted(queues):
+                while queues[group] and queues[group][-1] in selected_set:
+                    queues[group].pop()
+                if not queues[group]:
+                    continue
+                window_index = int(queues[group].pop())
+                selected_order.append(window_index)
+                selected_set.add(window_index)
+                progressed = True
+                if len(selected_order) == max_windows:
+                    break
+            if not progressed:
+                break
+        selected = sorted(selected_order)
+    selected_group_counts = defaultdict(int)
+    for window_index in selected:
+        window_groups = set()
+        for span in spans[window_index]:
+            source = span["source_id"]
+            if group_by == "genome":
+                if source not in genomes:
+                    raise ValueError(f"missing genome for source_id={source}")
+                window_groups.add(genomes[source])
+            elif group_by == "gene":
+                window_groups.add(source)
+            else:
+                window_groups.add(f"window:{window_index}")
+        for group in window_groups:
+            selected_group_counts[group] += 1
+    return selected, dict(sorted(selected_group_counts.items()))
+
+
 def collect_features(
-    windows, spans, genomes, tokens, pretrained, random_model, group_by, max_windows
+    windows, spans, genomes, tokens, pretrained, random_model, group_by,
+    window_indices, hidden_layer,
 ):
     pretrained_rows, random_rows, token_rows = [], [], []
     mer5_rows, mer7_rows, groups, sample_ids = [], [], [], []
     targets = {name: [] for name in PROPERTIES}
-    for window_index, sequence in enumerate(windows[:max_windows]):
+    for window_index in window_indices:
+        sequence = windows[window_index]
         input_ids = torch.as_tensor(sequence, dtype=torch.long).unsqueeze(0)
-        hidden_pre = extract_hidden_states(pretrained, input_ids)
-        hidden_random = extract_hidden_states(random_model, input_ids)
+        hidden_pre = extract_hidden_states(pretrained, input_ids, hidden_layer)
+        hidden_random = extract_hidden_states(random_model, input_ids, hidden_layer)
         for span_index, span in enumerate(spans.get(window_index, [])):
             start, end = int(span["window_token_start"]), int(span["window_token_end"])
             positions = [pos for pos in range(start, min(end, len(sequence))) if int(sequence[pos]) >= 4]
@@ -211,9 +289,21 @@ def main():
     parser.add_argument("--group-by", choices=("window", "gene", "genome"), default="gene")
     parser.add_argument("--n-splits", type=int, default=5)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--max-seqs", "--max_seqs", dest="max_seqs", type=int, default=50)
+    parser.add_argument("--random-model-seed", type=int, default=19)
+    parser.add_argument(
+        "--hidden-layer",
+        default="final",
+        help="Representation stage: final or an integer block index.",
+    )
+    parser.add_argument(
+        "--max-windows", "--max-seqs", "--max_seqs",
+        dest="max_windows", type=int, default=50,
+    )
     parser.add_argument("--output-prefix", required=True, type=Path)
     args = parser.parse_args()
+    hidden_layer = (
+        "final" if args.hidden_layer == "final" else int(args.hidden_layer)
+    )
     if args.group_by == "genome" and args.cds_metadata is None:
         parser.error("--cds-metadata is required for --group-by genome")
     run_id, run_dir = resolve_run(args.run_id, args.run_dir)
@@ -235,16 +325,22 @@ def main():
     )
     tokens = load_token_list(run_dir)
     pretrained, spec = load_model(run_dir, ckpt_name=args.ckpt)
+    torch.manual_seed(args.random_model_seed)
     random_model = build_model(spec).eval()
     checkpoint_path = run_dir / "checkpoints" / args.ckpt
     if not checkpoint_path.exists():
         checkpoint_path = run_dir / args.ckpt
     vocabulary_path = run_dir / "itos.txt"
     test_path = Path(args.test_npz)
+    windows = _load_windows(test_path)
+    spans = _read_spans(args.packing_metadata)
+    genomes = _read_genomes(args.cds_metadata)
+    selected_windows, selected_window_group_counts = select_window_indices(
+        spans, genomes, args.group_by, args.max_windows, args.seed
+    )
     features, targets, groups, sample_ids = collect_features(
-        _load_windows(test_path), _read_spans(args.packing_metadata),
-        _read_genomes(args.cds_metadata), tokens, pretrained, random_model,
-        args.group_by, args.max_seqs,
+        windows, spans, genomes, tokens, pretrained, random_model,
+        args.group_by, selected_windows, hidden_layer,
     )
     folds, assignments = make_group_folds(groups, args.n_splits, args.seed)
     results, aggregate, paired = evaluate(features, targets, folds)
@@ -253,6 +349,15 @@ def main():
         "dataset_manifest": manifest_provenance,
         "checkpoint_dataset": checkpoint_dataset,
         "group_by": args.group_by, "n_splits": args.n_splits,
+        "sampling": {
+            "seed": args.seed,
+            "max_windows": args.max_windows,
+            "available_windows": len(spans),
+            "selected_windows": selected_windows,
+            "selected_window_group_counts": selected_window_group_counts,
+        },
+        "random_model_seed": args.random_model_seed,
+        "hidden_layer": hidden_layer,
         "dataset": {"path": str(test_path.resolve()), "sha256": _sha256(test_path)},
         "checkpoint": {"path": str(checkpoint_path.resolve()), "sha256": _sha256(checkpoint_path)},
         "vocabulary": {"path": str(vocabulary_path.resolve()), "sha256": _sha256(vocabulary_path), "size": len(tokens)},

--- a/tests/test_shape_grouped_controls.py
+++ b/tests/test_shape_grouped_controls.py
@@ -1,7 +1,11 @@
 import numpy as np
 import pytest
 
-from scripts.eval_shape_baselines import _local_mer, make_group_folds
+from scripts.eval_shape_baselines import (
+    _local_mer,
+    make_group_folds,
+    select_window_indices,
+)
 
 
 def test_group_folds_are_disjoint_and_deterministic():
@@ -25,3 +29,22 @@ def test_local_mers_pad_sequence_boundaries():
     assert _local_mer("ATGCCC", 1, 5) == "GCCCN"
     assert _local_mer("ATGCCC", 0, 7) == "NNATGCC"
     assert _local_mer("ATGCCC", 1, 7) == "TGCCCNN"
+
+
+def test_window_sampling_balances_genomes_and_is_deterministic():
+    spans = {
+        index: [{"source_id": f"gene-{index}"}]
+        for index in range(10)
+    }
+    genomes = {
+        f"gene-{index}": "genome-a" if index < 8 else "genome-b"
+        for index in range(10)
+    }
+    first, counts = select_window_indices(
+        spans, genomes, "genome", max_windows=4, seed=17
+    )
+    repeated, repeated_counts = select_window_indices(
+        spans, genomes, "genome", max_windows=4, seed=17
+    )
+    assert first == repeated
+    assert counts == repeated_counts == {"genome-a": 2, "genome-b": 2}


### PR DESCRIPTION
## Summary
- make DNA-shape window selection deterministic and balanced across held-out genome groups
- record the random-model seed and support canonical intermediate-layer evaluation
- run the corrected linear DNA-shape controls on both trained seeds, a random transformer, one-hot codons, and local sequence baselines
- document the primary genome-grouped result and gene-grouped sensitivity analysis

## Result
The linear DNA-shape representation gate fails. Across both trained checkpoints, final and layer-2 hidden states underperform the matched random transformer under both grouping protocols. The computed shape targets remain strongly predictable from local sequence controls, as expected for deterministic sequence-derived proxies.

This does not invalidate the improved language-model perplexity. It means the current evidence does not support a claim that corrected pretraining linearly organizes these DNA-shape proxies. A nonlinear, capacity-matched sensitivity analysis remains a separate follow-up.

## Validation
- ruff check scripts/eval_shape_baselines.py tests/test_shape_grouped_controls.py
- pytest -q (324 passed, 1 skipped, 1 xpassed)
- benchmark JSON validated with jq
- git diff --check