### PR TITLE
Evaluate corrected base-model generation

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -137,6 +137,12 @@ an architectural intervention.
   five-fold gene-grouped sensitivity protocols.
 - [ ] Run raw and syntax-constrained generation with memorization and nucleotide/
   protein nearest-neighbor audits; do not use critic scores for promotion yet.
+  The replicated 50-prompt generation gate is complete for both corrected seeds:
+  raw sampling has 0% natural stops and 100% hard-cap failures, while the
+  target-length CDS constraint also has 0% natural stops. Generated GC rises to
+  74-76% versus 52.9% in held-out sources. Exact indexed 10/20-codon coverage is
+  zero. The item remains open only because exhaustive nucleotide/protein nearest
+  neighbors are blocked by MMseqs2 memory on the 8 GB host.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and
   limitations, then record a go/no-go decision for extensions.
 

--- a/docs/CORRECTED_GENERATION_EVALUATION.md
+++ b/docs/CORRECTED_GENERATION_EVALUATION.md
@@ -1,0 +1,67 @@
+# Corrected Base-Model Generation Evaluation
+
+## Question
+
+Can the corrected basic CodonLM continue a start-codon prefix into a plausible CDS
+without termination guidance, critic guidance, replay, or forced terminal tokens?
+
+This is a generation diagnostic, not evidence of protein function or fitness.
+
+## Protocol
+
+- Frozen genome-held-out test source records only.
+- 50 prompts, balanced 25/25 across the two held-out genomes.
+- One codon of natural prefix and one sample per held-out CDS.
+- Paired raw-vocabulary and CDS-token-constrained sampling.
+- Temperature `0.8`, top-k `5`, maximum 300 new tokens.
+- The CDS-constrained decoder stops at its declared 256-codon target if no natural
+  stop occurs. That length is imposed by the evaluator and is not learned.
+- Corrected checkpoints seeds 1337 and 2027.
+- Exact 10- and 20-codon training-match coverage indexed from ten million packed
+  training tokens.
+
+## Results
+
+| Seed | Protocol | Natural stop | Hard cap | Mean total codons | Unique | Mean GC | Codon JS vs held-out sources |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1337 | Raw vocabulary | 0/50 | 50/50 | 301 | 100% | 74.4% | 0.294 |
+| 1337 | CDS constrained | 0/50 | 0/50 | 257 | 100% | 74.3% | 0.292 |
+| 2027 | Raw vocabulary | 0/50 | 50/50 | 301 | 100% | 76.2% | 0.305 |
+| 2027 | CDS constrained | 0/50 | 0/50 | 257 | 100% | 76.3% | 0.303 |
+
+The selected held-out source CDSs have mean GC `52.9%`. No generated sequence
+contains an internal or terminal biological stop. Indexed exact training-match
+coverage is zero at both 10 and 20 codons for every generated sequence.
+
+The CDS-constrained hard-cap rate is zero only because that protocol deliberately
+returns at its 256-codon target. It does not represent natural completion.
+
+## Interpretation
+
+The corrected base model passes the intrinsic PPL gate but fails the natural
+generation gate. Teacher-forced next-token prediction and free-running generation
+are different regimes: small distributional errors compound after the model begins
+conditioning on its own samples.
+
+The replicated failure has two components:
+
+1. Neither checkpoint places a biological stop or EOS in 50 near-de-novo samples.
+2. Both checkpoints drift toward an unusually high-GC codon distribution.
+
+The samples are diverse and show no indexed long exact matches, so the observed
+failure is not simple sequence duplication or sample collapse.
+
+## Remaining Audit
+
+The exhaustive nucleotide/protein nearest-neighbor alignment against all 74,600
+training CDSs remains blocked on the 8 GB host. MMseqs2 could not allocate the
+nucleotide target database even with 512 MB split limits. This must be completed
+with explicit training-database chunking or on a higher-memory host before the
+memorization audit is considered complete.
+
+## Decision
+
+Do not promote the basic model for unguided gene generation. The result motivates
+the predeclared termination/replay phase and a separate decoding/composition
+diagnostic. Syntax constraints may be reported as an inference intervention, but
+they do not repair the model's missing length prior or GC drift.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -921,6 +921,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     reproduced the gap: pretrained R² 0.001-0.024 versus random 0.600-0.608,
     one-hot 0.654, and local 5-mer 0.930. These computed targets do not support a
     claim of linearly organized DNA-shape representations.
+*   **Corrected Base-Model Generation Gate (2026-07-29):** Evaluated both promoted
+    basic-model seeds on 50 start-codon prompts balanced across the two frozen
+    held-out genomes. Raw full-vocabulary sampling produced zero natural stops and
+    hit the 300-token cap in all 100 samples across seeds. CDS-token-constrained
+    sampling also produced zero natural stops and returned at its imposed
+    256-codon target. Samples were unique with zero indexed exact 10/20-codon
+    training-match coverage, but drifted to 74-76% GC versus 52.9% in the held-out
+    sources. The natural-generation gate therefore fails. Exhaustive
+    nearest-neighbor alignment remains blocked by MMseqs2 memory on the 8 GB host.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_generation_evaluation.json
+++ b/docs/benchmarks/corrected_generation_evaluation.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "protocol": {
+    "source_split": "test",
+    "held_out_genomes": 2,
+    "prompts": 50,
+    "prompts_per_genome": 25,
+    "prefix_codons": 1,
+    "samples_per_prompt": 1,
+    "temperature": 0.8,
+    "topk": 5,
+    "max_new_tokens": 300,
+    "constrained_target_codons": 256
+  },
+  "held_out_source_mean_gc": 0.5290762430320225,
+  "runs": [
+    {
+      "seed": 1337,
+      "raw_model": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 1.0,
+        "mean_total_codons": 301.0,
+        "unique_fraction": 1.0,
+        "mean_gc": 0.7435658914728684,
+        "codon_js_vs_held_out_sources": 0.2940788899659267
+      },
+      "cds_constrained": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 0.0,
+        "mean_total_codons": 257.0,
+        "unique_fraction": 1.0,
+        "mean_gc": 0.7429053177691309,
+        "codon_js_vs_held_out_sources": 0.2923885084440104
+      }
+    },
+    {
+      "seed": 2027,
+      "raw_model": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 1.0,
+        "mean_total_codons": 301.0,
+        "unique_fraction": 1.0,
+        "mean_gc": 0.7617940199335547,
+        "codon_js_vs_held_out_sources": 0.3052989229936909
+      },
+      "cds_constrained": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 0.0,
+        "mean_total_codons": 257.0,
+        "unique_fraction": 1.0,
+        "mean_gc": 0.7626459143968873,
+        "codon_js_vs_held_out_sources": 0.30306335024378706
+      }
+    }
+  ],
+  "memorization": {
+    "indexed_training_tokens": 10000384,
+    "exact_10_codon_match_coverage": 0.0,
+    "exact_20_codon_match_coverage": 0.0,
+    "exhaustive_nearest_neighbor_status": "blocked_mmseqs2_memory"
+  },
+  "decision": "failed_natural_generation_gate"
+}

--- a/scripts/audit_generated_sequences.py
+++ b/scripts/audit_generated_sequences.py
@@ -74,6 +74,11 @@ def main() -> None:
     parser.add_argument("--protein-window", type=int, default=10)
     parser.add_argument("--threads", type=int, default=1)
     parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument(
+        "--split-memory-limit",
+        default=None,
+        help="MMseqs2 memory per target-database split, for example 3G.",
+    )
     args = parser.parse_args()
 
     if args.manifest is not None:
@@ -89,6 +94,7 @@ def main() -> None:
         protein_window=args.protein_window,
         threads=args.threads,
         executable=args.mmseqs_executable,
+        split_memory_limit=args.split_memory_limit,
     )
     report["dataset_manifest"] = manifest_provenance
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")

--- a/scripts/eval_generation_prefix.py
+++ b/scripts/eval_generation_prefix.py
@@ -35,6 +35,7 @@ import torch
 import matplotlib.pyplot as plt
 
 from . import query_model as Q
+from src.codonlm.dataset_manifest import manifest_artifact_path
 from src.codonlm.generate import (
     generate_cds_constrained,
     generate_cds_critic_guided,
@@ -110,9 +111,15 @@ def _load_run_meta(run_dir: Path) -> dict:
     raise FileNotFoundError(f"meta.json missing under {run_dir}")
 
 
-def _resolve_repo_path(repo: Path, raw_path: str | Path | None) -> Path | None:
+def _resolve_repo_path(
+    repo: Path, raw_path: str | Path | dict | None
+) -> Path | None:
     if not raw_path:
         return None
+    if isinstance(raw_path, dict):
+        raw_path = raw_path.get("path")
+        if not raw_path:
+            return None
     path = Path(raw_path)
     return path if path.is_absolute() else repo / path
 
@@ -199,7 +206,91 @@ def _build_train_ngram_set(repo: Path, cfg: dict, n: int, max_tokens: int) -> se
     return ngram_set
 
 
-def _resolve_cds_dna_path(repo: Path, run_dir: Path, cfg: dict, max_genes: int) -> Path | None:
+def _extract_frozen_split_cds(
+    run_dir: Path,
+    manifest_path: Path,
+    split: str,
+    max_genes: int,
+    seed: int,
+) -> tuple[Path, dict]:
+    manifest = json.loads(manifest_path.read_text())
+    resolved_manifest = manifest_path.expanduser().resolve()
+    metadata_path = manifest_artifact_path(
+        manifest, resolved_manifest, "source_metadata"
+    )
+    dna_path = manifest_artifact_path(manifest, resolved_manifest, "source_dna")
+    grouped: dict[str, list[tuple[str, str]]] = {}
+    with metadata_path.open(newline="") as metadata_handle, dna_path.open() as dna_handle:
+        metadata_rows = csv.DictReader(metadata_handle, delimiter="\t")
+        for index, (row, sequence) in enumerate(zip(metadata_rows, dna_handle)):
+            if int(row["line_idx"]) != index:
+                raise ValueError(
+                    f"source metadata line_idx mismatch at row {index}: {row['line_idx']}"
+                )
+            if row["split"] != split:
+                continue
+            group = row.get("genome") or row.get("source_id") or "unknown"
+            grouped.setdefault(group, []).append(
+                (row.get("source_id") or f"record-{index}", sequence.strip())
+            )
+    if not grouped:
+        raise ValueError(f"frozen manifest contains no records for split {split!r}")
+
+    rng = random.Random(seed)
+    for records in grouped.values():
+        rng.shuffle(records)
+    group_names = sorted(grouped)
+    selected: list[tuple[str, str, str]] = []
+    cursor = 0
+    while len(selected) < max_genes:
+        made_progress = False
+        for group in group_names:
+            records = grouped[group]
+            if cursor < len(records):
+                source_id, sequence = records[cursor]
+                selected.append((source_id, group, sequence))
+                made_progress = True
+                if len(selected) >= max_genes:
+                    break
+        if not made_progress:
+            break
+        cursor += 1
+
+    out_path = run_dir / "scores" / f"_eval_{split}_cds_dna.txt"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("".join(f"{sequence}\n" for _, _, sequence in selected))
+    return out_path, {
+        "manifest": str(resolved_manifest),
+        "manifest_sha256": hashlib.sha256(resolved_manifest.read_bytes()).hexdigest(),
+        "split": split,
+        "selection": "seeded_shuffle_then_round_robin_by_genome",
+        "seed": seed,
+        "available_groups": group_names,
+        "selected_group_counts": {
+            group: sum(1 for _, selected_group, _ in selected if selected_group == group)
+            for group in group_names
+        },
+        "selected_source_ids": [source_id for source_id, _, _ in selected],
+    }
+
+
+def _resolve_cds_dna_path(
+    repo: Path,
+    run_dir: Path,
+    cfg: dict,
+    max_genes: int,
+    seed: int,
+    dataset_manifest: Path | None,
+    source_split: str,
+) -> tuple[Path | None, dict]:
+    configured_manifest = dataset_manifest or _resolve_repo_path(
+        repo, cfg.get("dataset_manifest")
+    )
+    if configured_manifest is not None and configured_manifest.exists():
+        return _extract_frozen_split_cds(
+            run_dir, configured_manifest, source_split, max_genes, seed
+        )
+
     # Legacy/main.sh manifest layout.
     manifest = run_dir / "combined_manifest.json"
     if manifest.exists():
@@ -207,13 +298,13 @@ def _resolve_cds_dna_path(repo: Path, run_dir: Path, cfg: dict, max_genes: int) 
         if data.get("datasets"):
             dna_path = _resolve_repo_path(repo, data["datasets"][0].get("dna"))
             if dna_path is not None and dna_path.exists():
-                return dna_path
+                return dna_path, {"status": "legacy_unverified"}
 
     # Direct config override for future runs.
     for key in ("dna_path", "cds_dna", "primary_dna"):
         dna_path = _resolve_repo_path(repo, cfg.get(key))
         if dna_path is not None and dna_path.exists():
-            return dna_path
+            return dna_path, {"status": "legacy_unverified"}
 
     manifest_candidates = [cfg.get("hybrid_manifest"), cfg.get("combined_manifest")]
     train_npz = cfg.get("train_npz")
@@ -229,8 +320,8 @@ def _resolve_cds_dna_path(repo: Path, run_dir: Path, cfg: dict, max_genes: int) 
         if manifest_path is not None and manifest_path.exists():
             dna_path = _extract_hybrid_cds_file(repo, run_dir, manifest_path, max_genes=max(10000, max_genes))
             if dna_path is not None and dna_path.exists():
-                return dna_path
-    return None
+                return dna_path, {"status": "legacy_unverified"}
+    return None, {"status": "unresolved"}
 
 
 def _model_spec_from(meta: dict, ckpt: object) -> dict:
@@ -493,6 +584,18 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--run_id", required=True)
     ap.add_argument(
+        "--dataset_manifest",
+        type=Path,
+        default=None,
+        help="Frozen dataset manifest. Defaults to the checkpoint configuration.",
+    )
+    ap.add_argument(
+        "--source_split",
+        choices=("train", "val", "test"),
+        default="test",
+        help="Frozen source-record split from which generation prefixes are sampled.",
+    )
+    ap.add_argument(
         "--preset",
         choices=sorted(PRESETS),
         default=None,
@@ -739,7 +842,15 @@ def main() -> None:
         raise SystemExit("require 0 < min_aa_len ≤ target_aa_len ≤ max_aa_len")
 
     # Choose CDS corpus from legacy combined manifest, config, or hybrid manifest.
-    dna_path = _resolve_cds_dna_path(repo, run_dir, cfg, max_genes=args.max_genes)
+    dna_path, source_provenance = _resolve_cds_dna_path(
+        repo,
+        run_dir,
+        cfg,
+        max_genes=args.max_genes,
+        seed=args.seed,
+        dataset_manifest=args.dataset_manifest,
+        source_split=args.source_split,
+    )
     if dna_path is None or not dna_path.exists():
         raise SystemExit(
             "[gen-prefix] could not locate a CDS dna file via combined or hybrid manifest"
@@ -947,6 +1058,7 @@ def main() -> None:
 
     rows: List[SampleResult] = []
     protocol_rows: List[ProtocolResult] = []
+    protocol_sequences: list[tuple[str, str]] = []
     k_list = [int(x) for x in args.k_list.split(",") if x]
     total_expected = len(cds) * len(k_list) * int(args.samples)
     done = 0
@@ -1073,7 +1185,7 @@ def main() -> None:
                     temperature=float(args.temperature),
                     topk=int(args.topk) if args.topk > 0 else 0,
                 )
-                raw_result, _ = score_protocol(
+                raw_result, raw_metrics = score_protocol(
                     generated_ids=raw_gen_ids,
                     generation_info=raw_info,
                     protocol="raw_model",
@@ -1106,7 +1218,7 @@ def main() -> None:
                         multi_offset_prior_enabled=False,
                         cds_only=True,
                     )
-                    constrained_result, _ = score_protocol(
+                    constrained_result, constrained_metrics = score_protocol(
                         generated_ids=constrained_ids,
                         generation_info=constrained_info,
                         protocol="cds_constrained",
@@ -1123,9 +1235,26 @@ def main() -> None:
                     )
                 else:
                     constrained_result = selected_result
+                    constrained_metrics = selected_metrics
                 protocol_rows.extend([raw_result, constrained_result])
+                record_key = f"gene{gene_idx}_k{k}_sample{sidx}_seed{paired_seed}"
+                protocol_sequences.extend(
+                    [
+                        (
+                            f"raw_model_{record_key}",
+                            "".join(raw_metrics["codons"]),
+                        ),
+                        (
+                            f"cds_constrained_{record_key}",
+                            "".join(constrained_metrics["codons"]),
+                        ),
+                    ]
+                )
                 if is_guided:
                     protocol_rows.append(selected_result)
+                    protocol_sequences.append(
+                        (f"guided_{record_key}", "".join(selected_metrics["codons"]))
+                    )
 
                 codons = selected_metrics["codons"]
                 aaid = selected_metrics["aa_identity"]
@@ -1229,6 +1358,13 @@ def main() -> None:
             )
     print(f"[gen-prefix] wrote {protocol_samples_csv}")
 
+    generated_fasta = out_dir / "generated_protocols.fasta"
+    with generated_fasta.open("w") as handle:
+        for record_id, sequence in protocol_sequences:
+            if sequence:
+                handle.write(f">{record_id}\n{sequence}\n")
+    print(f"[gen-prefix] wrote {generated_fasta}")
+
     protocol_summary = []
     protocols = ("raw_model", "cds_constrained", "guided")
     for k in k_list:
@@ -1294,6 +1430,7 @@ def main() -> None:
         "schema_version": 1,
         "run_id": args.run_id,
         "checkpoint": str(weights_path),
+        "source_data": source_provenance,
         "base_seed": int(args.seed),
         "sample_seed_derivation": "sha256(base_seed:gene_idx:k:sample_id)[0:4]",
         "confidence_interval": {

--- a/src/codonlm/leakage_audit.py
+++ b/src/codonlm/leakage_audit.py
@@ -577,6 +577,7 @@ def audit_generated_sequences(
     protein_window: int = 10,
     threads: int = 1,
     executable: str = "mmseqs",
+    split_memory_limit: str | None = None,
 ) -> dict[str, Any]:
     """Report nearest training identities and matching-substring coverage."""
     resolved = shutil.which(executable)
@@ -602,8 +603,7 @@ def audit_generated_sequences(
             ((str(record["source_id"]), convert(record["sequence"])) for record in generated),
         )
         output = work_dir / f"nearest_{sequence_type}.tsv"
-        _run(
-            [
+        command = [
                 resolved,
                 "easy-search",
                 str(generated_fasta),
@@ -618,9 +618,10 @@ def audit_generated_sequences(
                 "1" if sequence_type == "protein" else "3",
                 "--threads",
                 str(threads),
-            ],
-            commands,
-        )
+            ]
+        if split_memory_limit:
+            command.extend(["--split-memory-limit", split_memory_limit])
+        _run(command, commands)
         nearest_by_type[sequence_type] = {
             row["query_id"]: row for row in _parse_nearest(output)
         }
@@ -663,6 +664,7 @@ def audit_generated_sequences(
             "nucleotide_window": nucleotide_window,
             "protein_window": protein_window,
             "threads": threads,
+            "split_memory_limit": split_memory_limit,
         },
         "commands": commands,
         "training_record_count": len(training),

--- a/tests/test_eval_generation_prefix.py
+++ b/tests/test_eval_generation_prefix.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from scripts import query_model as Q
 from scripts.eval_generation_prefix import (
+    _extract_frozen_split_cds,
     _bootstrap_interval,
     _codon_to_aa,
     _load_vocab_for_run,
@@ -13,6 +14,47 @@ from scripts.eval_generation_prefix import (
     _sample_seed,
     _training_match_coverage,
 )
+
+
+def test_extract_frozen_split_cds_balances_genomes(tmp_path):
+    import json
+
+    metadata = tmp_path / "cds_meta.tsv"
+    dna = tmp_path / "cds_dna.txt"
+    metadata.write_text(
+        "line_idx\tsplit\tsource_id\tgenome\n"
+        "0\ttest\ta1\tgenome-a\n"
+        "1\ttest\ta2\tgenome-a\n"
+        "2\ttest\tb1\tgenome-b\n"
+        "3\ttest\tb2\tgenome-b\n"
+        "4\ttrain\tt1\tgenome-train\n"
+    )
+    dna.write_text(
+        "ATGAAATAA\nATGCCCTAA\nATGGGGTAA\nATGTTTTAA\nATGACGTAA\n"
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "artifacts": {
+                    "source_metadata": {"path": "cds_meta.tsv"},
+                    "source_dna": {"path": "cds_dna.txt"},
+                }
+            }
+        )
+    )
+    run_dir = tmp_path / "run"
+
+    selected_path, provenance = _extract_frozen_split_cds(
+        run_dir, manifest, "test", max_genes=4, seed=17
+    )
+
+    assert len(selected_path.read_text().splitlines()) == 4
+    assert provenance["split"] == "test"
+    assert provenance["selected_group_counts"] == {
+        "genome-a": 2,
+        "genome-b": 2,
+    }
 
 
 def test_ngram_repeat_ratio_simple():
@@ -204,12 +246,14 @@ def test_eval_generation_prefix_end_to_end(tmp_path):
         protocol_samples_csv = test_run_dir / "scores" / "gen_prefix" / "protocol_samples.csv"
         protocol_summary_csv = test_run_dir / "scores" / "gen_prefix" / "protocol_summary.csv"
         protocol_manifest = test_run_dir / "scores" / "gen_prefix" / "protocol_manifest.json"
+        generated_fasta = test_run_dir / "scores" / "gen_prefix" / "generated_protocols.fasta"
         
         assert samples_csv.exists()
         assert summary_csv.exists()
         assert protocol_samples_csv.exists()
         assert protocol_summary_csv.exists()
         assert protocol_manifest.exists()
+        assert generated_fasta.exists()
 
         with protocol_samples_csv.open() as f:
             protocol_rows = list(csv.DictReader(f))


### PR DESCRIPTION
## Summary
- bind generation prefixes to the frozen manifest and select them evenly across held-out genomes
- emit per-protocol FASTA artifacts and complete paired raw/CDS-constrained generation for both corrected checkpoints
- expose the MMseqs2 split-memory option for generated-sequence audits
- document the replicated natural-generation failure and update the training track

## Result
Across 50 balanced held-out prompts per checkpoint, raw generation produced 0 natural stops and hit the 300-token cap in all 100 samples. CDS-constrained generation also produced 0 natural stops and returned at its imposed 256-codon target. Samples were unique and had zero indexed exact 10/20-codon training coverage, but GC drifted to 74-76% versus 52.9% in held-out sources.

The base model passes its intrinsic PPL gate but fails the unguided generation gate. Exhaustive nucleotide/protein nearest-neighbor alignment remains open because MMseqs2 cannot fit the nucleotide database on the 8 GB host, even with 512 MB split limits.

## Validation
- pytest -q: 325 passed, 1 skipped, 1 xpassed
- targeted ruff check passes
- benchmark JSON and git diff validation pass
- repository-wide Ruff still reports 137 pre-existing legacy errors outside this change