### PR TITLE
Diagnose generation termination failures

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -141,8 +141,12 @@ an architectural intervention.
   raw sampling has 0% natural stops and 100% hard-cap failures, while the
   target-length CDS constraint also has 0% natural stops. Generated GC rises to
   74-76% versus 52.9% in held-out sources. Exact indexed 10/20-codon coverage is
-  zero. The item remains open only because exhaustive nucleotide/protein nearest
-  neighbors are blocked by MMseqs2 memory on the 8 GB host.
+  zero. The exhaustive nucleotide/protein audit now completes with minimap2 plus
+  bounded MMseqs2 target batches. Stop-probability diagnostics show termination
+  ranks near 61 at natural gene ends; top-k 5/20 removes termination from the
+  sampling support. A 10-prompt pilot restores 90% natural stopping for both seeds
+  at temperature 1.0 without top-k truncation. Run the larger corrected decoder
+  baseline before promoting termination/replay training.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and
   limitations, then record a go/no-go decision for extensions.
 

--- a/docs/CORRECTED_GENERATION_EVALUATION.md
+++ b/docs/CORRECTED_GENERATION_EVALUATION.md
@@ -53,15 +53,13 @@ failure is not simple sequence duplication or sample collapse.
 
 ## Remaining Audit
 
-The exhaustive nucleotide/protein nearest-neighbor alignment against all 74,600
-training CDSs remains blocked on the 8 GB host. MMseqs2 could not allocate the
-nucleotide target database even with 512 MB split limits. This must be completed
-with explicit training-database chunking or on a higher-memory host before the
-memorization audit is considered complete.
+The exhaustive nucleotide/protein audit now completes on the 8 GB host using
+minimap2 for nucleotide alignments and explicit 5,000-record MMseqs2 protein
+batches. See `GENERATION_TERMINATION_DIAGNOSTICS.md` for results.
 
 ## Decision
 
-Do not promote the basic model for unguided gene generation. The result motivates
-the predeclared termination/replay phase and a separate decoding/composition
-diagnostic. Syntax constraints may be reported as an inference intervention, but
-they do not repair the model's missing length prior or GC drift.
+Do not promote the top-k 5 decoder for unguided gene generation. A subsequent
+pilot found that unrestricted temperature `1.0` sampling restores natural stopping
+in 9/10 samples for both seeds. That decoder requires a larger controlled
+evaluation before termination/replay training is promoted.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -930,6 +930,16 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     training-match coverage, but drifted to 74-76% GC versus 52.9% in the held-out
     sources. The natural-generation gate therefore fails. Exhaustive
     nearest-neighbor alignment remains blocked by MMseqs2 memory on the 8 GB host.
+*   **Generation Termination Diagnosis (2026-07-29):** Replaced the generated
+    novelty audit's monolithic nucleotide MMseqs2 search and materialized training
+    substring index with minimap2, bounded MMseqs2 protein target batches, and a
+    query-window streaming scan. Exhaustive auditing now completes against all
+    74,600 training CDSs. At true terminal contexts, termination probability is
+    only 0.32-0.45% and median rank is about 61, so top-k 5/20 makes stopping
+    impossible. In a 10-prompt pilot per seed, unrestricted temperature-1.0
+    sampling restored 90% natural stops and substantially reduced GC drift. The
+    next gate is a larger unrestricted-decoder evaluation before termination/replay
+    training.
 
 ---
 *End of Log*

--- a/docs/GENERATION_TERMINATION_DIAGNOSTICS.md
+++ b/docs/GENERATION_TERMINATION_DIAGNOSTICS.md
@@ -1,0 +1,70 @@
+# Generation Termination Diagnostics
+
+## Purpose
+
+The corrected base model beat the trigram PPL baseline but produced no natural
+stops under temperature `0.8`, top-k `5` sampling. These diagnostics separate a
+missing termination signal from a decoding policy that removes low-ranked stop
+tokens.
+
+## Stop Probability
+
+Immediately before the true terminal codon in 50 held-out CDSs:
+
+| Checkpoint seed | Mean stop + EOS probability | Median termination rank | Top-20 inclusion |
+| --- | ---: | ---: | ---: |
+| 1337 | 0.447% | 61 | 0% |
+| 2027 | 0.317% | 61.5 | 0% |
+
+The probability does not rise sharply from 32 codons before the terminal position
+to the position immediately before it. EOS probability alone is approximately
+`0.007-0.011%`.
+
+On generated contexts, median termination rank improves with length but remains
+outside the top 20. Therefore top-k 5 and top-k 20 assign exactly zero sampling
+probability to all termination tokens in these samples.
+
+## Decoding Pilot
+
+Ten balanced held-out prompts were sampled per variant and checkpoint:
+
+| Seed | Decoder | Natural stop | Hard cap | Mean generated codons | Mean GC |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 1337 | T=0.8, unrestricted | 1/10 | 9/10 | 299.3 | 55.3% |
+| 1337 | T=1.0, unrestricted | 9/10 | 1/10 | 176.9 | 54.1% |
+| 1337 | T=1.0, top-k 20 | 0/10 | 10/10 | 300.0 | 70.9% |
+| 2027 | T=0.8, unrestricted | 0/10 | 9/10 | 275.3 | 64.2% |
+| 2027 | T=1.0, unrestricted | 9/10 | 1/10 | 191.6 | 61.2% |
+| 2027 | T=1.0, top-k 20 | 0/10 | 10/10 | 300.0 | 60.9% |
+
+The held-out prompt sources have mean GC `52.9%`. The pilot is too small to select
+a final decoder, but it demonstrates that temperature `1.0` without top-k
+truncation substantially restores natural stopping and reduces the extreme GC
+drift seen under top-k 5.
+
+## Exhaustive Novelty Audit
+
+The memory-bounded audit now completes against all 74,600 training CDSs:
+
+- Minimap2 performs the nucleotide search against the complete training FASTA.
+- MMseqs2 searches translated proteins in 5,000-record target batches and retains
+  the best hit over every batch.
+- Exact substring coverage scans the training corpus once against only generated
+  query windows, avoiding a materialized training-window index.
+
+Neither alignment tool reported a qualifying nearest hit for these highly
+divergent generated sequences under its default sensitivity. This means no
+alignment was reported, not that identity is zero. Exact 30-nt coverage is at most
+`3.32%`; mean exact 10-aa coverage ranges from `5.0%` to `10.2%` across checkpoint
+and protocol, with a maximum of `28.8%`.
+
+## Decision
+
+The base model contains a weak termination signal, but truncating the distribution
+at top-k 5 or 20 removes it. The next controlled generation run should use
+unrestricted temperature `1.0` as the decoder baseline. Termination-head and replay
+training remain justified only if a larger unrestricted evaluation still shows
+unacceptable length calibration, early stops, or hard caps.
+
+Decoder correction does not prove protein quality. ORF, composition, diversity,
+and novelty controls remain required for the larger run.

--- a/docs/benchmarks/generation_termination_diagnostics.json
+++ b/docs/benchmarks/generation_termination_diagnostics.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "teacher_forced_terminal_context": {
+    "seed_1337": {
+      "n": 50,
+      "mean_termination_probability": 0.004472234185395791,
+      "median_best_termination_rank": 61.0,
+      "top20_inclusion_rate": 0.0
+    },
+    "seed_2027": {
+      "n": 50,
+      "mean_termination_probability": 0.0031698699489061256,
+      "median_best_termination_rank": 61.5,
+      "top20_inclusion_rate": 0.0
+    }
+  },
+  "decoding_pilot": {
+    "n_per_seed_variant": 10,
+    "seed_1337": {
+      "temperature_0.8_unrestricted": {
+        "natural_stop_rate": 0.1,
+        "hard_cap_rate": 0.9,
+        "mean_generated_codons": 299.3,
+        "mean_gc": 0.5528713811105839
+      },
+      "temperature_1.0_unrestricted": {
+        "natural_stop_rate": 0.9,
+        "hard_cap_rate": 0.1,
+        "mean_generated_codons": 176.9,
+        "mean_gc": 0.5412664539115105
+      },
+      "temperature_1.0_topk20": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 1.0,
+        "mean_generated_codons": 300.0,
+        "mean_gc": 0.7085271317829458
+      }
+    },
+    "seed_2027": {
+      "temperature_0.8_unrestricted": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 0.9,
+        "mean_generated_codons": 275.3,
+        "mean_gc": 0.6424654444034289
+      },
+      "temperature_1.0_unrestricted": {
+        "natural_stop_rate": 0.9,
+        "hard_cap_rate": 0.1,
+        "mean_generated_codons": 191.6,
+        "mean_gc": 0.6119756521475056
+      },
+      "temperature_1.0_topk20": {
+        "natural_stop_rate": 0.0,
+        "hard_cap_rate": 1.0,
+        "mean_generated_codons": 300.0,
+        "mean_gc": 0.6085271317829457
+      }
+    }
+  },
+  "nearest_neighbor_audit": {
+    "training_records": 74600,
+    "nucleotide_tool": "minimap2",
+    "protein_tool": "MMseqs2",
+    "protein_training_batch_size": 5000,
+    "reported_alignment_hits": 0,
+    "interpretation": "no qualifying hit reported at default tool sensitivity"
+  },
+  "decision": "use_temperature_1.0_unrestricted_for_larger_decoder_baseline"
+}

--- a/scripts/audit_generated_sequences.py
+++ b/scripts/audit_generated_sequences.py
@@ -74,10 +74,18 @@ def main() -> None:
     parser.add_argument("--protein-window", type=int, default=10)
     parser.add_argument("--threads", type=int, default=1)
     parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument("--minimap2-executable", default="minimap2")
+    parser.add_argument("--nucleotide-preset", default="asm20")
     parser.add_argument(
         "--split-memory-limit",
         default=None,
         help="MMseqs2 memory per target-database split, for example 3G.",
+    )
+    parser.add_argument(
+        "--training-batch-size",
+        type=int,
+        default=5000,
+        help="Maximum training records in each explicit MMseqs2 target batch.",
     )
     args = parser.parse_args()
 
@@ -94,7 +102,10 @@ def main() -> None:
         protein_window=args.protein_window,
         threads=args.threads,
         executable=args.mmseqs_executable,
+        nucleotide_executable=args.minimap2_executable,
+        nucleotide_preset=args.nucleotide_preset,
         split_memory_limit=args.split_memory_limit,
+        training_batch_size=args.training_batch_size,
     )
     report["dataset_manifest"] = manifest_provenance
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")

--- a/scripts/diagnose_termination_probabilities.py
+++ b/scripts/diagnose_termination_probabilities.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Compare stop-token probabilities on natural and generated CDS contexts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import torch
+from Bio import SeqIO
+
+from scripts import query_model as Q
+from scripts.eval_generation_prefix import (
+    _cfg_from,
+    _load_run_meta,
+    _load_vocab_for_run,
+    _model_spec_from,
+    _resolve_cds_dna_path,
+    _select_device,
+)
+from src.codonlm.generate import STOP_CODONS
+from src.codonlm.codon_tokenize import tokenize_cds_fragments
+
+
+def _token_probabilities(
+    model,
+    token_ids: list[int],
+    positions: list[tuple[str, int]],
+    stop_ids: list[int],
+    eos_id: int | None,
+    device: torch.device,
+) -> list[dict]:
+    if len(token_ids) < 1:
+        return []
+    max_length = int(getattr(model, "block_size", len(token_ids)))
+    offset = max(0, len(token_ids) - max_length)
+    context = token_ids[offset:]
+    with torch.no_grad():
+        logits, _ = model(torch.tensor([context], dtype=torch.long, device=device))
+        probabilities = torch.softmax(logits[0].float(), dim=-1)
+    rows = []
+    for label, original_index in positions:
+        local_index = original_index - offset
+        if not 0 <= local_index < probabilities.shape[0]:
+            continue
+        probs = probabilities[local_index]
+        order = torch.argsort(probs, descending=True)
+        stop_probability = float(probs[stop_ids].sum().item())
+        eos_probability = float(probs[eos_id].item()) if eos_id is not None else 0.0
+        ranks = [
+            int((order == token_id).nonzero(as_tuple=False)[0].item()) + 1
+            for token_id in stop_ids + ([eos_id] if eos_id is not None else [])
+        ]
+        rows.append(
+            {
+                "position": label,
+                "stop_probability": stop_probability,
+                "eos_probability": eos_probability,
+                "termination_probability": stop_probability + eos_probability,
+                "best_termination_rank": min(ranks),
+                "termination_in_top5": min(ranks) <= 5,
+                "termination_in_top20": min(ranks) <= 20,
+            }
+        )
+    return rows
+
+
+def _summarize(rows: list[dict]) -> dict[str, dict]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        grouped[row["position"]].append(row)
+    result = {}
+    for position, selected in sorted(grouped.items()):
+        probabilities = [row["termination_probability"] for row in selected]
+        result[position] = {
+            "n": len(selected),
+            "mean_termination_probability": float(np.mean(probabilities)),
+            "median_termination_probability": float(np.median(probabilities)),
+            "mean_stop_probability": float(
+                np.mean([row["stop_probability"] for row in selected])
+            ),
+            "mean_eos_probability": float(
+                np.mean([row["eos_probability"] for row in selected])
+            ),
+            "top5_inclusion_rate": float(
+                np.mean([row["termination_in_top5"] for row in selected])
+            ),
+            "top20_inclusion_rate": float(
+                np.mean([row["termination_in_top20"] for row in selected])
+            ),
+            "median_best_termination_rank": float(
+                np.median([row["best_termination_rank"] for row in selected])
+            ),
+        }
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--generation-label", default="corrected_generation_primary")
+    parser.add_argument("--checkpoint", default="best.pt")
+    parser.add_argument("--device", choices=("auto", "cpu", "mps", "cuda"), default="auto")
+    parser.add_argument("--max-genes", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    run_dir = repo / "runs" / args.run_id
+    checkpoint_path = run_dir / "checkpoints" / args.checkpoint
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    state_dict = checkpoint["model"] if "model" in checkpoint else checkpoint
+    meta = _load_run_meta(run_dir)
+    cfg = _cfg_from(meta, checkpoint)
+    model = Q.build_model_from_state(
+        state_dict, _model_spec_from(meta, checkpoint), checkpoint=checkpoint
+    )
+    device = _select_device(args.device)
+    model.to(device).eval()
+    itos, stoi = _load_vocab_for_run(run_dir, repo, cfg)
+    stop_ids = [stoi[token] for token in sorted(STOP_CODONS)]
+    eos_id = stoi.get("<EOS_CDS>")
+
+    dna_path, source_provenance = _resolve_cds_dna_path(
+        repo,
+        run_dir,
+        cfg,
+        max_genes=args.max_genes,
+        seed=args.seed,
+        dataset_manifest=None,
+        source_split="test",
+    )
+    if dna_path is None:
+        raise SystemExit("could not resolve frozen test CDS records")
+
+    natural_rows = []
+    for sequence_index, dna in enumerate(dna_path.read_text().splitlines()):
+        tokenized = tokenize_cds_fragments(dna, termination="none")
+        if not tokenized.fragments:
+            continue
+        ids = max(tokenized.fragments, key=lambda fragment: fragment.codon_end).ids
+        if len(ids) < 2:
+            continue
+        target_index = len(ids) - 1
+        positions = [
+            (f"distance_{distance}", target_index - distance)
+            for distance in (1, 2, 4, 8, 16, 32)
+            if target_index - distance >= 0
+        ]
+        for row in _token_probabilities(
+            model, ids[:-1], positions, stop_ids, eos_id, device
+        ):
+            row["sequence_index"] = sequence_index
+            natural_rows.append(row)
+
+    generated_rows = []
+    generated_fasta = (
+        run_dir / "scores" / args.generation_label / "generated_protocols.fasta"
+    )
+    for record in SeqIO.parse(generated_fasta, "fasta"):
+        ids = Q.dna_prefix_to_ids(str(record.seq), stoi)
+        positions = [
+            (f"length_{length}", length)
+            for length in (32, 64, 128, 256)
+            if length < len(ids)
+        ]
+        positions.append(("final", len(ids) - 1))
+        for row in _token_probabilities(
+            model, ids, positions, stop_ids, eos_id, device
+        ):
+            row["record_id"] = record.id
+            row["protocol"] = (
+                "raw_model"
+                if record.id.startswith("raw_model_")
+                else "cds_constrained"
+            )
+            generated_rows.append(row)
+
+    generated_summary = {}
+    for protocol in ("raw_model", "cds_constrained"):
+        generated_summary[protocol] = _summarize(
+            [row for row in generated_rows if row["protocol"] == protocol]
+        )
+    report = {
+        "schema_version": 1,
+        "run_id": args.run_id,
+        "checkpoint": str(checkpoint_path.resolve()),
+        "source_data": source_provenance,
+        "tokens": {
+            "stop": {token: stoi[token] for token in sorted(STOP_CODONS)},
+            "eos": eos_id,
+        },
+        "natural_teacher_forced": _summarize(natural_rows),
+        "generated": generated_summary,
+        "rows": {"natural": natural_rows, "generated": generated_rows},
+    }
+    output = args.output or (
+        run_dir / "scores" / args.generation_label / "termination_diagnostic.json"
+    )
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"[termination-diagnostic] wrote {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_decoding_termination_ablation.py
+++ b/scripts/run_decoding_termination_ablation.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Run a small raw-decoding ablation for natural CodonLM termination."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from scripts import query_model as Q
+from scripts.eval_generation_prefix import (
+    _cfg_from,
+    _load_run_meta,
+    _load_vocab_for_run,
+    _model_spec_from,
+    _resolve_cds_dna_path,
+    _select_device,
+    _set_seed,
+)
+from src.codonlm.generate import generate_model_raw
+
+
+VARIANTS = {
+    "temperature_0.8_unrestricted": {"temperature": 0.8, "topk": 0},
+    "temperature_1.0_unrestricted": {"temperature": 1.0, "topk": 0},
+    "temperature_1.0_topk20": {"temperature": 1.0, "topk": 20},
+}
+
+
+def _sample_seed(base_seed: int, sequence_index: int, variant: str) -> int:
+    payload = f"{base_seed}:{sequence_index}:{variant}".encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:4], "big")
+
+
+def _summary(rows: list[dict]) -> dict:
+    return {
+        "n": len(rows),
+        "natural_stop_rate": float(
+            np.mean([row["had_terminal_stop"] for row in rows])
+        ),
+        "eos_rate": float(np.mean([row["stop_reason"] == "eos" for row in rows])),
+        "hard_cap_rate": float(np.mean([row["hit_hard_cap"] for row in rows])),
+        "mean_generated_tokens": float(
+            np.mean([row["generated_tokens"] for row in rows])
+        ),
+        "mean_generated_codons": float(
+            np.mean([row["generated_codons"] for row in rows])
+        ),
+        "mean_gc_fraction": float(np.mean([row["gc_fraction"] for row in rows])),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--checkpoint", default="best.pt")
+    parser.add_argument("--device", choices=("auto", "cpu", "mps", "cuda"), default="auto")
+    parser.add_argument("--max-genes", type=int, default=10)
+    parser.add_argument("--max-new", type=int, default=300)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    run_dir = repo / "runs" / args.run_id
+    checkpoint_path = run_dir / "checkpoints" / args.checkpoint
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    state_dict = checkpoint["model"] if "model" in checkpoint else checkpoint
+    meta = _load_run_meta(run_dir)
+    cfg = _cfg_from(meta, checkpoint)
+    model = Q.build_model_from_state(
+        state_dict, _model_spec_from(meta, checkpoint), checkpoint=checkpoint
+    )
+    device = _select_device(args.device)
+    model.to(device).eval()
+    itos, stoi = _load_vocab_for_run(run_dir, repo, cfg)
+    dna_path, source_provenance = _resolve_cds_dna_path(
+        repo,
+        run_dir,
+        cfg,
+        max_genes=args.max_genes,
+        seed=args.seed,
+        dataset_manifest=None,
+        source_split="test",
+    )
+    if dna_path is None:
+        raise SystemExit("could not resolve frozen test CDS records")
+
+    rows = []
+    sequences = []
+    for sequence_index, dna in enumerate(dna_path.read_text().splitlines()):
+        prefix_ids = Q.dna_prefix_to_ids(dna[:3], stoi)
+        for variant, parameters in VARIANTS.items():
+            sample_seed = _sample_seed(args.seed, sequence_index, variant)
+            _set_seed(sample_seed)
+            generated_ids, info = generate_model_raw(
+                model,
+                device,
+                prefix_ids,
+                stoi,
+                itos,
+                max_new_tokens=args.max_new,
+                **parameters,
+            )
+            tokens = Q.ids_to_codons(generated_ids, itos)
+            codons = [
+                token
+                for token in tokens
+                if len(token) == 3 and set(token) <= set("ACGT")
+            ]
+            rows.append(
+                {
+                    "variant": variant,
+                    "sequence_index": sequence_index,
+                    "sample_seed": sample_seed,
+                    **parameters,
+                    **info,
+                    "gc_fraction": (
+                        sum(base in "GC" for base in "".join(codons))
+                        / max(1, len("".join(codons)))
+                    ),
+                }
+            )
+            sequences.append(
+                (f"{variant}_sequence{sequence_index}_seed{sample_seed}", "".join(codons))
+            )
+
+    report = {
+        "schema_version": 1,
+        "run_id": args.run_id,
+        "checkpoint": str(checkpoint_path.resolve()),
+        "source_data": source_provenance,
+        "max_new_tokens": args.max_new,
+        "summary": {
+            variant: _summary([row for row in rows if row["variant"] == variant])
+            for variant in VARIANTS
+        },
+        "rows": rows,
+    }
+    output = args.output or (
+        run_dir
+        / "scores"
+        / "corrected_generation_primary"
+        / "decoding_termination_ablation.json"
+    )
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    fasta_path = output.with_suffix(".fasta")
+    fasta_path.write_text(
+        "".join(f">{record_id}\n{sequence}\n" for record_id, sequence in sequences)
+    )
+    print(f"[decoding-ablation] wrote {output} and {fasta_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codonlm/leakage_audit.py
+++ b/src/codonlm/leakage_audit.py
@@ -170,7 +170,8 @@ def _parse_nearest(path: Path) -> list[dict[str, Any]]:
         return rows
     with path.open() as handle:
         for line in handle:
-            query, target, pident, alnlen, qlen, tlen = line.rstrip("\n").split("\t")
+            fields = line.rstrip("\n").split("\t")
+            query, target, pident, alnlen, qlen, tlen = fields[:6]
             rows.append(
                 {
                     "query_id": query,
@@ -180,9 +181,40 @@ def _parse_nearest(path: Path) -> list[dict[str, Any]]:
                     "query_length": int(qlen),
                     "target_length": int(tlen),
                     "query_coverage": int(alnlen) / max(1, int(qlen)),
+                    "bits": float(fields[6]) if len(fields) > 6 else None,
                 }
             )
     return rows
+
+
+def _nearest_rank(row: Mapping[str, Any]) -> tuple[float, float, int]:
+    bits = row.get("bits")
+    return (
+        float(bits) if bits is not None else -1.0,
+        float(row["identity"]),
+        int(row["alignment_length"]),
+    )
+
+
+def _matched_query_windows(
+    queries: Sequence[str], training: Sequence[str], window: int
+) -> set[str]:
+    query_windows = {
+        sequence[start : start + window]
+        for sequence in queries
+        for start in range(max(0, len(sequence) - window + 1))
+    }
+    if not query_windows:
+        return set()
+    matched: set[str] = set()
+    for sequence in training:
+        for start in range(max(0, len(sequence) - window + 1)):
+            candidate = sequence[start : start + window]
+            if candidate in query_windows:
+                matched.add(candidate)
+        if len(matched) == len(query_windows):
+            break
+    return matched
 
 
 def _parse_minimap_paf(path: Path) -> list[dict[str, Any]]:
@@ -577,7 +609,10 @@ def audit_generated_sequences(
     protein_window: int = 10,
     threads: int = 1,
     executable: str = "mmseqs",
+    nucleotide_executable: str = "minimap2",
+    nucleotide_preset: str = "asm20",
     split_memory_limit: str | None = None,
+    training_batch_size: int = 5000,
 ) -> dict[str, Any]:
     """Report nearest training identities and matching-substring coverage."""
     resolved = shutil.which(executable)
@@ -588,30 +623,88 @@ def audit_generated_sequences(
     commands: list[list[str]] = []
     version_result = _run([resolved, "version"], commands)
     version = (version_result.stdout or version_result.stderr).strip()
+    resolved_nucleotide = shutil.which(nucleotide_executable)
+    if resolved_nucleotide is None:
+        raise LeakageAuditError(
+            f"nucleotide aligner {nucleotide_executable!r} was not found"
+        )
+    nucleotide_version_result = _run([resolved_nucleotide, "--version"], commands)
+    nucleotide_version = (
+        nucleotide_version_result.stdout or nucleotide_version_result.stderr
+    ).strip()
     nearest_by_type: dict[str, dict[str, dict[str, Any]]] = {}
 
+    if training_batch_size <= 0:
+        raise ValueError("training_batch_size must be positive")
     converters = {"nucleotide": normalize_cds, "protein": translate_cds}
+    converted_training: dict[str, list[str]] = {}
+    converted_generated: dict[str, list[str]] = {}
     for sequence_type, convert in converters.items():
-        train_fasta = work_dir / f"train_{sequence_type}.fasta"
         generated_fasta = work_dir / f"generated_{sequence_type}.fasta"
-        _write_fasta(
-            train_fasta,
-            ((str(record["source_id"]), convert(record["sequence"])) for record in training),
-        )
+        training_sequences = [convert(record["sequence"]) for record in training]
+        generated_sequences = [convert(record["sequence"]) for record in generated]
+        converted_training[sequence_type] = training_sequences
+        converted_generated[sequence_type] = generated_sequences
         _write_fasta(
             generated_fasta,
-            ((str(record["source_id"]), convert(record["sequence"])) for record in generated),
+            (
+                (str(record["source_id"]), sequence)
+                for record, sequence in zip(generated, generated_sequences)
+            ),
         )
-        output = work_dir / f"nearest_{sequence_type}.tsv"
-        command = [
+        if sequence_type == "nucleotide":
+            train_fasta = work_dir / "train_nucleotide.fasta"
+            _write_fasta(
+                train_fasta,
+                (
+                    (str(record["source_id"]), sequence)
+                    for record, sequence in zip(training, training_sequences)
+                ),
+            )
+            result = _run(
+                [
+                    resolved_nucleotide,
+                    "-x",
+                    nucleotide_preset,
+                    "--secondary=no",
+                    "-t",
+                    str(threads),
+                    str(train_fasta),
+                    str(generated_fasta),
+                ],
+                commands,
+            )
+            output = work_dir / "nearest_nucleotide.paf"
+            output.write_text(result.stdout)
+            nearest_by_type[sequence_type] = {
+                row["query_id"]: row for row in _parse_minimap_paf(output)
+            }
+            continue
+        best_by_query: dict[str, dict[str, Any]] = {}
+        for batch_index, batch_start in enumerate(
+            range(0, len(training), training_batch_size)
+        ):
+            batch_end = min(len(training), batch_start + training_batch_size)
+            train_fasta = work_dir / (
+                f"train_{sequence_type}_{batch_index:04d}.fasta"
+            )
+            _write_fasta(
+                train_fasta,
+                (
+                    (str(training[index]["source_id"]), training_sequences[index])
+                    for index in range(batch_start, batch_end)
+                ),
+            )
+            output = work_dir / f"nearest_{sequence_type}_{batch_index:04d}.tsv"
+            command = [
                 resolved,
                 "easy-search",
                 str(generated_fasta),
                 str(train_fasta),
                 str(output),
-                str(work_dir / f"search_{sequence_type}_tmp"),
+                str(work_dir / f"search_{sequence_type}_{batch_index:04d}_tmp"),
                 "--format-output",
-                "query,target,pident,alnlen,qlen,tlen",
+                "query,target,pident,alnlen,qlen,tlen,bits",
                 "--max-seqs",
                 "1",
                 "--search-type",
@@ -619,25 +712,25 @@ def audit_generated_sequences(
                 "--threads",
                 str(threads),
             ]
-        if split_memory_limit:
-            command.extend(["--split-memory-limit", split_memory_limit])
-        _run(command, commands)
-        nearest_by_type[sequence_type] = {
-            row["query_id"]: row for row in _parse_nearest(output)
-        }
+            if split_memory_limit:
+                command.extend(["--split-memory-limit", split_memory_limit])
+            _run(command, commands)
+            for row in _parse_nearest(output):
+                previous = best_by_query.get(row["query_id"])
+                if previous is None or _nearest_rank(row) > _nearest_rank(previous):
+                    best_by_query[row["query_id"]] = row
+        nearest_by_type[sequence_type] = best_by_query
 
-    training_dna = [normalize_cds(record["sequence"]) for record in training]
-    training_proteins = [translate_cds(record["sequence"]) for record in training]
-    nucleotide_windows = {
-        sequence[start : start + nucleotide_window]
-        for sequence in training_dna
-        for start in range(max(0, len(sequence) - nucleotide_window + 1))
-    }
-    protein_windows = {
-        sequence[start : start + protein_window]
-        for sequence in training_proteins
-        for start in range(max(0, len(sequence) - protein_window + 1))
-    }
+    nucleotide_windows = _matched_query_windows(
+        converted_generated["nucleotide"],
+        converted_training["nucleotide"],
+        nucleotide_window,
+    )
+    protein_windows = _matched_query_windows(
+        converted_generated["protein"],
+        converted_training["protein"],
+        protein_window,
+    )
     rows = []
     for record in generated:
         source_id = str(record["source_id"])
@@ -660,11 +753,26 @@ def audit_generated_sequences(
     report = {
         "schema_version": 1,
         "tool": {"name": "MMseqs2", "executable": resolved, "version": version},
+        "tools": {
+            "protein": {
+                "name": "MMseqs2",
+                "executable": resolved,
+                "version": version,
+            },
+            "nucleotide": {
+                "name": "Minimap2",
+                "executable": resolved_nucleotide,
+                "version": nucleotide_version,
+                "preset": nucleotide_preset,
+            },
+        },
         "parameters": {
             "nucleotide_window": nucleotide_window,
             "protein_window": protein_window,
             "threads": threads,
             "split_memory_limit": split_memory_limit,
+            "training_batch_size": training_batch_size,
+            "nucleotide_preset": nucleotide_preset,
         },
         "commands": commands,
         "training_record_count": len(training),

--- a/tests/test_decoding_termination_ablation.py
+++ b/tests/test_decoding_termination_ablation.py
@@ -1,0 +1,29 @@
+from scripts.run_decoding_termination_ablation import _sample_seed, _summary
+
+
+def test_decoding_ablation_summary_and_seeds_are_deterministic():
+    rows = [
+        {
+            "had_terminal_stop": True,
+            "stop_reason": "biological_stop",
+            "hit_hard_cap": False,
+            "generated_tokens": 10,
+            "generated_codons": 10,
+            "gc_fraction": 0.4,
+        },
+        {
+            "had_terminal_stop": False,
+            "stop_reason": "max_new_tokens",
+            "hit_hard_cap": True,
+            "generated_tokens": 20,
+            "generated_codons": 20,
+            "gc_fraction": 0.6,
+        },
+    ]
+
+    summary = _summary(rows)
+    assert summary["natural_stop_rate"] == 0.5
+    assert summary["hard_cap_rate"] == 0.5
+    assert summary["mean_generated_tokens"] == 15.0
+    assert summary["mean_gc_fraction"] == 0.5
+    assert _sample_seed(3, 2, "x") == _sample_seed(3, 2, "x")

--- a/tests/test_leakage_audit.py
+++ b/tests/test_leakage_audit.py
@@ -277,7 +277,9 @@ def test_mmseqs_protein_cluster_report_policy_is_nonblocking(tmp_path):
 
 def test_generated_audit_reports_nearest_identity_and_match_coverage(tmp_path):
     executable = tmp_path / "mmseqs"
+    nucleotide_executable = tmp_path / "minimap2"
     _write_fake_mmseqs(executable)
+    _write_fake_minimap2(nucleotide_executable)
     output = tmp_path / "generated_audit.json"
 
     report = audit_generated_sequences(
@@ -287,6 +289,7 @@ def test_generated_audit_reports_nearest_identity_and_match_coverage(tmp_path):
         nucleotide_window=6,
         protein_window=2,
         executable=str(executable),
+        nucleotide_executable=str(nucleotide_executable),
     )
 
     record = report["records"][0]
@@ -296,3 +299,31 @@ def test_generated_audit_reports_nearest_identity_and_match_coverage(tmp_path):
     assert record["protein_nearest"]["target_id"] == "train-a"
     assert 0.0 < record["nucleotide_training_match_coverage"] <= 1.0
     assert 0.0 < record["protein_training_match_coverage"] <= 1.0
+
+
+def test_generated_audit_batches_training_and_keeps_global_best(tmp_path):
+    executable = tmp_path / "mmseqs"
+    nucleotide_executable = tmp_path / "minimap2"
+    _write_fake_mmseqs(executable)
+    _write_fake_minimap2(nucleotide_executable)
+    output = tmp_path / "generated_audit.json"
+
+    report = audit_generated_sequences(
+        [
+            _record("train-poor", "train", "ATGTTTTTTTTTTAA"),
+            _record("train-best", "train", "ATGGCTGCTAAATAA"),
+        ],
+        [_record("generated-a", "generated", "ATGGCTGCTAAATAA")],
+        output,
+        nucleotide_window=6,
+        protein_window=2,
+        executable=str(executable),
+        nucleotide_executable=str(nucleotide_executable),
+        training_batch_size=1,
+    )
+
+    record = report["records"][0]
+    assert record["nucleotide_nearest"] is not None
+    assert record["protein_nearest"]["target_id"] == "train-best"
+    assert report["parameters"]["training_batch_size"] == 1
+    assert sum(command[1] == "easy-search" for command in report["commands"]) == 2

--- a/tests/test_termination_diagnostic.py
+++ b/tests/test_termination_diagnostic.py
@@ -1,0 +1,36 @@
+import torch
+
+from scripts.diagnose_termination_probabilities import (
+    _summarize,
+    _token_probabilities,
+)
+
+
+class FixedLogitModel(torch.nn.Module):
+    block_size = 8
+
+    def forward(self, token_ids):
+        logits = torch.zeros(
+            token_ids.shape[0], token_ids.shape[1], 6, device=token_ids.device
+        )
+        logits[..., 4] = 2.0
+        logits[..., 5] = 1.0
+        return logits, None
+
+
+def test_token_probability_diagnostic_reports_ranks_and_summary():
+    rows = _token_probabilities(
+        FixedLogitModel(),
+        [1, 2, 3],
+        [("final", 2)],
+        stop_ids=[4],
+        eos_id=5,
+        device=torch.device("cpu"),
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["best_termination_rank"] == 1
+    assert rows[0]["termination_in_top5"] is True
+    summary = _summarize(rows)
+    assert summary["final"]["n"] == 1
+    assert summary["final"]["mean_termination_probability"] > 0.5


### PR DESCRIPTION
## Summary
- make generated-sequence novelty auditing memory bounded with minimap2 nucleotide search, batched MMseqs2 protein targets, and streaming exact-window coverage
- add teacher-forced versus generated-context stop/EOS probability and rank diagnostics
- add a matched unrestricted decoding pilot for both corrected checkpoints
- document the corrected interpretation and update the training track

## Results
At natural terminal contexts, stop+EOS probability is only 0.32-0.45% and median termination rank is about 61, so top-k 5 and top-k 20 remove termination tokens from the sampling support.

In a 10-prompt pilot per checkpoint, unrestricted temperature-1.0 sampling produced natural biological stops in 9/10 samples for both seeds. Top-k 20 produced 0/10 stops and 100% hard-cap failures. Unrestricted sampling also reduced the severe GC drift.

The exhaustive novelty audit now completes against all 74,600 training CDSs on the 8 GB host. No qualifying nearest alignment was reported at default tool sensitivity; exact 30-nt and 10-aa match coverage remains low and is reported separately.

## Decision
Run a larger unrestricted temperature-1.0 decoder baseline before promoting termination-head or replay training. The base model learned a weak termination signal, but the previous decoder made it unsampleable.

## Validation
- pytest -q: 328 passed, 1 skipped, 1 xpassed
- targeted Ruff checks pass
- benchmark JSON and git diff validation pass