### PR TITLE
Confirm unrestricted generation baseline

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -147,6 +147,10 @@ an architectural intervention.
   sampling support. A 10-prompt pilot restores 90% natural stopping for both seeds
   at temperature 1.0 without top-k truncation. Run the larger corrected decoder
   baseline before promoting termination/replay training.
+  The 50-prompt confirmation reached only 70% and 56% natural stops across seeds,
+  with 30% and 42% hard-cap rates. Completed samples were generally shorter than
+  held-out CDSs. The unrestricted decoder is retained as the base comparison, but
+  the confirmation now authorizes the Phase 6 termination-head ablation.
 - [ ] Publish per-seed and aggregate primary results with confidence intervals and
   limitations, then record a go/no-go decision for extensions.
 

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -940,6 +940,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     sampling restored 90% natural stops and substantially reduced GC drift. The
     next gate is a larger unrestricted-decoder evaluation before termination/replay
     training.
+*   **Unrestricted Decoder Confirmation (2026-07-30):** Expanded the
+    temperature-1.0 unrestricted pilot to 50 balanced held-out prompts per
+    checkpoint. Natural-stop rates fell to 70% and 56%, while hard-cap rates were
+    30% and 42%. Mean generated GC was 52.5% and 58.4% versus 52.9% in held-out
+    sources, but naturally stopped samples were typically short. Exhaustive
+    novelty auditing found no reported nucleotide/protein alignment and negligible
+    exact-window coverage. The decoder correction is retained as the baseline, and
+    Phase 6 termination-head training is authorized.
 
 ---
 *End of Log*

--- a/docs/GENERATION_TERMINATION_DIAGNOSTICS.md
+++ b/docs/GENERATION_TERMINATION_DIAGNOSTICS.md
@@ -68,3 +68,10 @@ unacceptable length calibration, early stops, or hard caps.
 
 Decoder correction does not prove protein quality. ORF, composition, diversity,
 and novelty controls remain required for the larger run.
+
+## Confirmatory Result
+
+The subsequent 50-prompt run did not reproduce the pilot's 90% stop rate. Natural
+stop rates were 70% and 56%, with hard-cap rates of 30% and 42%. See
+`UNRESTRICTED_GENERATION_CONFIRMATION.md`. Unrestricted temperature `1.0` remains
+the correct baseline decoder, but termination/replay ablation is now warranted.

--- a/docs/UNRESTRICTED_GENERATION_CONFIRMATION.md
+++ b/docs/UNRESTRICTED_GENERATION_CONFIRMATION.md
@@ -1,0 +1,63 @@
+# Unrestricted Generation Confirmation
+
+## Protocol
+
+The exploratory decoder pilot suggested that temperature `1.0` without top-k
+truncation might restore natural termination. The confirmatory evaluation used:
+
+- both corrected base-model checkpoints;
+- 50 held-out CDS prompts per checkpoint, balanced 25/25 across two genomes;
+- the first natural codon as context;
+- one deterministic sample per prompt;
+- unrestricted vocabulary sampling at temperature `1.0`;
+- a maximum of 300 generated tokens;
+- exhaustive train-only nucleotide, protein, and exact-window novelty auditing.
+
+No forced stop, CDS mask, critic, termination bias, or replay intervention was used.
+
+## Results
+
+| Seed | Natural stop | 95% Wilson CI | EOS | Hard cap | Mean codons | Median codons | Mean GC |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1337 | 35/50 (70%) | 56.2-80.9% | 0/50 | 15/50 (30%) | 175.6 | 162.0 | 52.5% |
+| 2027 | 28/50 (56%) | 42.3-68.8% | 1/50 | 21/50 (42%) | 205.5 | 248.5 | 58.4% |
+
+The selected held-out source CDSs have mean length 350.1 codons, median length
+294 codons, and mean GC 52.9%. Among naturally stopped generations, median lengths
+are 119 codons for seed 1337 and 152 codons for seed 2027. Because the prompt
+contains only the first codon, paired generated and source lengths are not expected
+to match exactly; nevertheless, the combination of short completed sequences and
+30-42% hard caps shows poor length calibration.
+
+The earlier 10-prompt pilot reported 9/10 natural stops for each seed. The larger
+result demonstrates why that pilot was insufficient for promotion.
+
+## Novelty
+
+The exhaustive bounded audit searched all 74,600 pretraining CDSs:
+
+- no qualifying nucleotide or protein alignment was reported at default tool
+  sensitivity;
+- seed 1337 has zero exact 30-nt and 10-aa match coverage;
+- seed 2027 has zero exact 30-nt coverage and mean 10-aa coverage `0.19%`, with a
+  maximum of `9.71%`.
+
+No reported alignment is not equivalent to zero biological similarity, but these
+results do not suggest direct memorization.
+
+## Decision
+
+Unrestricted temperature-1.0 decoding is the correct base decoder for subsequent
+comparisons, and it is substantially better than top-k 5/20. It is not reliable
+enough for promotion: natural completion is inconsistent across seeds, hard-cap
+rates remain high, and completed sequences tend to be short.
+
+Proceed to the predeclared Phase 6 ablation:
+
+1. termination head without replay;
+2. termination head plus generated-prefix replay only if the head-only condition
+   remains inadequate;
+3. compare both against this unrestricted base decoder with matched prompts and
+   seeds;
+4. report natural-stop, early-stop, hard-cap, length-distribution, GC, PPL,
+   runtime, and novelty effects.

--- a/docs/benchmarks/unrestricted_generation_confirmation.json
+++ b/docs/benchmarks/unrestricted_generation_confirmation.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "protocol": {
+    "prompts_per_checkpoint": 50,
+    "held_out_genomes": 2,
+    "prefix_codons": 1,
+    "temperature": 1.0,
+    "topk": 0,
+    "max_new_tokens": 300,
+    "forced_stop": false,
+    "cds_mask": false
+  },
+  "held_out_sources": {
+    "mean_length_codons": 350.08,
+    "median_length_codons": 294.0,
+    "mean_gc": 0.5290762430320225
+  },
+  "runs": [
+    {
+      "seed": 1337,
+      "natural_stop_rate": 0.7,
+      "natural_stop_wilson_95": [0.562496495355466, 0.8089644649911906],
+      "eos_rate": 0.0,
+      "hard_cap_rate": 0.3,
+      "mean_generated_codons": 175.58,
+      "median_generated_codons": 162.0,
+      "median_naturally_stopped_codons": 119.0,
+      "mean_gc": 0.5246116711343984,
+      "novelty": {
+        "reported_nucleotide_hits": 0,
+        "reported_protein_hits": 0,
+        "mean_exact_30nt_coverage": 0.0,
+        "mean_exact_10aa_coverage": 0.0
+      }
+    },
+    {
+      "seed": 2027,
+      "natural_stop_rate": 0.56,
+      "natural_stop_wilson_95": [0.4230602802165686, 0.6883780078874284],
+      "eos_rate": 0.02,
+      "hard_cap_rate": 0.42,
+      "mean_generated_codons": 205.54,
+      "median_generated_codons": 248.5,
+      "median_naturally_stopped_codons": 152.0,
+      "mean_gc": 0.5841003745757023,
+      "novelty": {
+        "reported_nucleotide_hits": 0,
+        "reported_protein_hits": 0,
+        "mean_exact_30nt_coverage": 0.0,
+        "mean_exact_10aa_coverage": 0.001941747572815534,
+        "max_exact_10aa_coverage": 0.0970873786407767
+      }
+    }
+  ],
+  "decision": "proceed_to_termination_head_ablation"
+}

--- a/scripts/run_decoding_termination_ablation.py
+++ b/scripts/run_decoding_termination_ablation.py
@@ -62,8 +62,19 @@ def main() -> None:
     parser.add_argument("--max-genes", type=int, default=10)
     parser.add_argument("--max-new", type=int, default=300)
     parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument(
+        "--variants",
+        default=",".join(VARIANTS),
+        help="Comma-separated decoding variants to run.",
+    )
     parser.add_argument("--output", type=Path, default=None)
     args = parser.parse_args()
+    selected_variants = [name.strip() for name in args.variants.split(",") if name.strip()]
+    unknown_variants = sorted(set(selected_variants) - set(VARIANTS))
+    if unknown_variants:
+        parser.error(f"unknown variants: {', '.join(unknown_variants)}")
+    if not selected_variants:
+        parser.error("--variants must select at least one variant")
 
     repo = Path(__file__).resolve().parents[1]
     run_dir = repo / "runs" / args.run_id
@@ -94,7 +105,8 @@ def main() -> None:
     sequences = []
     for sequence_index, dna in enumerate(dna_path.read_text().splitlines()):
         prefix_ids = Q.dna_prefix_to_ids(dna[:3], stoi)
-        for variant, parameters in VARIANTS.items():
+        for variant in selected_variants:
+            parameters = VARIANTS[variant]
             sample_seed = _sample_seed(args.seed, sequence_index, variant)
             _set_seed(sample_seed)
             generated_ids, info = generate_model_raw(
@@ -137,7 +149,7 @@ def main() -> None:
         "max_new_tokens": args.max_new,
         "summary": {
             variant: _summary([row for row in rows if row["variant"] == variant])
-            for variant in VARIANTS
+            for variant in selected_variants
         },
         "rows": rows,
     }


### PR DESCRIPTION
## Summary
- allow selecting explicit decoder variants in the termination ablation runner
- run the predeclared unrestricted temperature-1.0 decoder on 50 balanced held-out prompts for each corrected checkpoint
- complete exhaustive nucleotide, protein, and exact-window novelty audits
- record the confirmatory decision and authorize the Phase 6 termination-head ablation

## Results
Seed 1337 produced 35/50 natural stops (70%, Wilson 95% CI 56.2-80.9%) with 30% hard caps. Seed 2027 produced 28/50 natural stops (56%, CI 42.3-68.8%), one EOS, and 42% hard caps. Completed generations were generally shorter than held-out CDSs.

GC improved substantially relative to top-k sampling: 52.5% and 58.4% versus 52.9% in held-out sources. Exhaustive novelty auditing reported no qualifying nucleotide/protein alignments and negligible exact-window coverage.

## Decision
Keep unrestricted temperature 1.0 as the base decoder, but proceed to the termination-head ablation. The larger run does not support the pilot's apparent 90% reliability.

## Validation
- pytest -q: 328 passed, 1 skipped, 1 xpassed
- targeted Ruff checks pass
- benchmark JSON and git diff validation pass