### PR TITLE
Prepare corrected termination-head ablation

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -194,8 +194,15 @@ next-token quality, termination, memory, or runtime reliability.
 
 ## Phase 6: Termination and Replay Ablation
 
-- [ ] Predeclare distance buckets, replay construction, matched prompts/seeds,
+- [x] Predeclare distance buckets, replay construction, matched prompts/seeds,
   decoding conditions, token budget, and acceptance thresholds.
+  The head-only condition uses EOS-distance buckets `[0,3,10,30]`, square-root
+  inverse-frequency weights measured on 25,238,438 frozen training positions, one
+  epoch from the promoted seed-1337 checkpoint, joint LR `5e-6`/head LR `1e-4`,
+  and no replay. Raw unrestricted temperature-1.0 decoding is primary;
+  head-biased decoding is a separately labelled intervention. Promotion permits
+  at most 2% test-NLL regression and requires fewer hard caps without short-length
+  collapse.
 - [ ] Train the termination-head condition without replay from the corrected primary
   checkpoint.
 - [ ] Add generated-prefix replay only if the head-only condition is insufficient.

--- a/configs/corrected_termination_head_seed1337.yaml
+++ b/configs/corrected_termination_head_seed1337.yaml
@@ -1,0 +1,89 @@
+# Phase 6 head-only termination ablation from the promoted corrected base model.
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+run_id: corrected-termination-head-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 1
+max_time_minutes: null
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.05
+label_smoothing: 0.0
+tie_embeddings: false
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+multi_offset_loss_enabled: false
+multi_offset_targets: []
+
+termination_loss_enabled: true
+termination_loss_weight: 0.1
+termination_stop_ids: [2]
+termination_bucket_edges: [0, 3, 10, 30]
+termination_n_classes: 5
+# Square-root inverse-frequency weights, normalized to E[w] = 1 on frozen train.
+termination_class_weights: [12.364329, 7.145187, 4.686482, 2.785020, 0.705228]
+replay_loss_enabled: false
+freeze_backbone: false
+eos_loss_weight: 1.0
+
+transfer_from: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/checkpoints/best.pt
+
+batch_size: 4
+grad_accum_steps: 16
+lr: 0.000005
+lr_embedding: 0.0001
+min_lr: 0.0000005
+weight_decay: 0.05
+warmup_fraction: 0.1
+optimizer: adamw
+scheduler: cosine
+scheduler_total_steps: 1000
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores
+
+extension_experiment_contract:
+  schema_version: 1
+  phase: termination_head_without_replay
+  anchor_run_id: corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4
+  dataset_protocol: frozen_genome_holdout
+  token_exposure_epochs: 1
+  primary_decoder:
+    temperature: 1.0
+    topk: 0
+    forced_stop: false
+    cds_mask: false
+  replay_enabled: false
+  promotion:
+    max_relative_test_nll_regression: 0.02
+    require_reduced_hard_cap_rate: true
+    require_no_short_length_collapse: true

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -948,6 +948,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     novelty auditing found no reported nucleotide/protein alignment and negligible
     exact-window coverage. The decoder correction is retained as the baseline, and
     Phase 6 termination-head training is authorized.
+*   **Termination-Head Protocol Freeze (2026-07-30):** Predeclared the Phase 6
+    head-only condition from corrected seed 1337. The historical distance buckets
+    were retained, but their frozen-corpus imbalance was measured explicitly:
+    90.9% of positions are in the farthest class and only 0.30% are at the exact
+    boundary. Added square-root inverse-frequency loss weights, conservative joint
+    backbone/head learning rates, a one-epoch token budget, and gates for PPL,
+    hard caps, and short-length collapse. Replay remains disabled pending the
+    head-only result.
 
 ---
 *End of Log*

--- a/docs/TERMINATION_HEAD_ABLATION_PROTOCOL.md
+++ b/docs/TERMINATION_HEAD_ABLATION_PROTOCOL.md
@@ -1,0 +1,73 @@
+# Termination-Head Ablation Protocol
+
+## Hypothesis
+
+The corrected base model assigns termination tokens low but nonzero probability.
+Unrestricted decoding recovers some natural stops, but 30-42% of samples still hit
+the hard cap. A distance-to-boundary auxiliary task may organize causal hidden
+states around CDS endings and improve raw next-token termination after conservative
+joint fine-tuning.
+
+The auxiliary head does not directly modify next-token logits. Consequently:
+
+- raw unrestricted generation tests an intrinsic training effect;
+- termination-head logit bias is a separate decoder intervention;
+- a frozen-backbone head can only help the decoder intervention and is not the
+  primary condition.
+
+## Locked Training Condition
+
+- Anchor: corrected seed-1337 promoted checkpoint.
+- Frozen genome split and unchanged 68-token vocabulary.
+- One epoch, approximately one frozen-corpus exposure.
+- Main next-token loss retained.
+- Termination loss weight `0.1`.
+- EOS (`token 2`) defines the future CDS boundary.
+- Distance buckets: exact boundary, 1-3, 4-10, 11-30, and greater than 30/no future
+  boundary in the packed segment.
+- No replay, multi-offset heads, shape encoder, critic, termination bias, or forced
+  stop during training.
+- Joint update: backbone learning rate `5e-6`; new termination head learning rate
+  `1e-4`.
+
+## Class Balance
+
+The frozen training labels contain 25,238,438 valid positions:
+
+| Class | Count | Fraction | Weight |
+| --- | ---: | ---: | ---: |
+| exact boundary | 74,659 | 0.296% | 12.364329 |
+| 1-3 | 223,561 | 0.886% | 7.145187 |
+| 4-10 | 519,672 | 2.059% | 4.686482 |
+| 11-30 | 1,471,522 | 5.830% | 2.785020 |
+| far/no future boundary | 22,949,024 | 90.929% | 0.705228 |
+
+Weights are square-root inverse frequency normalized to unit expected weight.
+This prevents the auxiliary head from learning only the majority class without
+using the extreme weights produced by full inverse frequency.
+
+## Evaluation
+
+Compare the anchor and head-only checkpoint with identical held-out prompts and
+sample seeds:
+
+1. raw unrestricted sampling, temperature `1.0`;
+2. syntax-constrained sampling, reported separately;
+3. termination-head-biased decoding, reported only as an inference intervention.
+
+Report:
+
+- frozen validation and test next-token NLL/PPL;
+- termination loss and per-class accuracy/confusion;
+- natural-stop, EOS, early-stop, and hard-cap rates;
+- generated and held-out length distributions;
+- GC and codon-distribution divergence;
+- diversity, exact coverage, and nucleotide/protein nearest neighbors;
+- runtime, memory, and nonfinite-update counts.
+
+## Promotion Gate
+
+- Test next-token NLL may regress by no more than 2% relative to the anchor.
+- Raw unrestricted hard-cap rate must decrease with no short-sequence collapse.
+- Any decoder-biased gain must remain labelled as an inference intervention.
+- Replay is authorized only if the head-only condition remains inadequate.

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -341,6 +341,18 @@ def run_training(cfg: dict, args) -> None:
     termination_n_classes = int(cfg.get("termination_n_classes", len(termination_bucket_edges) + 1))
     if termination_n_classes != len(termination_bucket_edges) + 1:
         raise ValueError("termination_n_classes must equal len(termination_bucket_edges) + 1")
+    termination_class_weights_raw = cfg.get("termination_class_weights")
+    termination_class_weight_values = None
+    if termination_class_weights_raw is not None:
+        if len(termination_class_weights_raw) != termination_n_classes:
+            raise ValueError(
+                "termination_class_weights must contain termination_n_classes values"
+            )
+        termination_class_weight_values = [
+            float(value) for value in termination_class_weights_raw
+        ]
+        if any(value <= 0 for value in termination_class_weight_values):
+            raise ValueError("termination_class_weights values must be positive")
     replay_loss_enabled = bool(cfg.get("replay_loss_enabled", False))
     replay_loss_weight = float(cfg.get("replay_loss_weight", 0.1))
     replay_data = cfg.get("replay_data")
@@ -349,7 +361,8 @@ def run_training(cfg: dict, args) -> None:
     if termination_loss_enabled:
         print(
             f"[loss] termination_aux weight={termination_loss_weight} "
-            f"stop_ids={termination_stop_ids} bucket_edges={termination_bucket_edges}"
+            f"stop_ids={termination_stop_ids} bucket_edges={termination_bucket_edges} "
+            f"class_weights={termination_class_weights_raw}"
         )
     if replay_loss_enabled:
         if not replay_data:
@@ -451,6 +464,15 @@ def run_training(cfg: dict, args) -> None:
     print(f"[device] using {device}")
     torch.manual_seed(base_seed)
     amp = bool(cfg.get("amp", True)) and (device.type == "mps")
+    termination_class_weights = (
+        torch.tensor(
+            termination_class_weight_values,
+            dtype=torch.float32,
+            device=device,
+        )
+        if termination_class_weight_values is not None
+        else None
+    )
 
     use_shape_guidance = bool(cfg.get("use_shape_guidance", False))
     encoder = None
@@ -1026,7 +1048,11 @@ def run_training(cfg: dict, args) -> None:
                             stop_ids=termination_stop_ids,
                             bucket_edges=termination_bucket_edges,
                         )
-                        term_loss_ = termination_aux_loss(term_logits, term_labels)
+                        term_loss_ = termination_aux_loss(
+                            term_logits,
+                            term_labels,
+                            class_weights=termination_class_weights,
+                        )
                         total_loss_ = total_loss_ + (termination_loss_weight * term_loss_)
                     replay_loss_ = None
                     if split == "train" and replay_loader is not None:

--- a/src/codonlm/training/objectives.py
+++ b/src/codonlm/training/objectives.py
@@ -97,10 +97,12 @@ def termination_distance_bucket_labels(
 def termination_aux_loss(
     termination_logits: torch.Tensor,
     labels: torch.Tensor,
+    class_weights: torch.Tensor | None = None,
     ignore_index: int = -100,
 ) -> torch.Tensor:
     return torch.nn.functional.cross_entropy(
         termination_logits.float().view(-1, termination_logits.size(-1)),
         labels.contiguous().view(-1),
+        weight=class_weights,
         ignore_index=ignore_index,
     )

--- a/tests/test_long_range_codon_objectives.py
+++ b/tests/test_long_range_codon_objectives.py
@@ -107,6 +107,19 @@ def test_termination_aux_loss_accepts_labels():
     assert torch.isfinite(loss)
 
 
+def test_termination_aux_loss_accepts_class_weights():
+    logits = torch.zeros((1, 2, 2), dtype=torch.float32)
+    labels = torch.tensor([[0, 1]], dtype=torch.long)
+
+    loss = termination_aux_loss(
+        logits,
+        labels,
+        class_weights=torch.tensor([4.0, 1.0]),
+    )
+
+    assert torch.isfinite(loss)
+
+
 def test_multi_offset_projection_heads():
     # Instantiate model with multi-offset targets
     model = TinyGPT(


### PR DESCRIPTION
## Summary
- add class-weighted termination auxiliary loss support for the highly imbalanced distance buckets
- freeze the one-epoch MPS head-only ablation config from the promoted corrected seed-1337 checkpoint
- document the matched decoding evaluation, promotion gates, and Phase 6 conductor progress

## Protocol
- joint fine-tuning: backbone LR 5e-6, new termination head LR 1e-4
- square-root inverse-frequency weights measured on 25,238,438 frozen training targets
- raw unrestricted temperature-1.0 decoding remains the primary intrinsic test
- replay remains disabled unless the head-only condition is insufficient

## Validation
- ruff check src/codonlm/training/loop.py src/codonlm/training/objectives.py tests/test_long_range_codon_objectives.py
- pytest -q tests/test_long_range_codon_objectives.py tests/test_trainer_utils.py tests/test_primary_training_contract.py (41 passed)
- pytest -q (329 passed, 1 skipped, 1 xpassed)