### PR TITLE
Vectorize termination labels on MPS

### DIFF
--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -956,6 +956,13 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     backbone/head learning rates, a one-epoch token budget, and gates for PPL,
     hard caps, and short-length collapse. Replay remains disabled pending the
     head-only result.
+*   **Termination-Label MPS Vectorization (2026-07-31):** Paused the head-only run
+    at committed optimizer step 393 after throughput declined during scalar label
+    construction. Replaced the nested per-token scan and MPS `.item()` calls with
+    a reverse cumulative-minimum tensor pass. Randomized parity tests preserve the
+    original labels, while the measured `4 x 512` MPS workload improved from about
+    1,615 ms to 0.78 ms per microbatch. The run resumes from the unchanged
+    checkpoint after review.
 
 ---
 *End of Log*

--- a/src/codonlm/training/objectives.py
+++ b/src/codonlm/training/objectives.py
@@ -66,32 +66,29 @@ def termination_distance_bucket_labels(
     bucket_edges: tuple[int, ...] = (0, 3, 10, 30),
     ignore_index: int = -100,
 ) -> torch.Tensor:
-    """Bucket distance from each target position to the next stop token."""
+    """Bucket each valid position's distance to the next stop token."""
     if not stop_ids:
         raise ValueError("stop_ids must not be empty")
     if tuple(bucket_edges) != tuple(sorted(bucket_edges)):
         raise ValueError("bucket_edges must be sorted")
 
-    labels = torch.full_like(yb, fill_value=ignore_index, dtype=torch.long)
-    n_classes = len(bucket_edges) + 1
-    for row_idx in range(yb.shape[0]):
-        row = yb[row_idx]
-        valid_positions = row != PAD_ID
-        stop_positions = torch.nonzero(
-            torch.isin(row, torch.tensor(stop_ids, device=row.device)),
-            as_tuple=False,
-        ).flatten()
-        for pos in torch.nonzero(valid_positions, as_tuple=False).flatten():
-            future_stops = stop_positions[stop_positions >= pos]
-            if len(future_stops) == 0:
-                labels[row_idx, pos] = n_classes - 1
-                continue
-            distance = int(future_stops[0].item() - pos.item())
-            bucket = 0
-            while bucket < len(bucket_edges) and distance > int(bucket_edges[bucket]):
-                bucket += 1
-            labels[row_idx, pos] = bucket
-    return labels
+    sequence_length = yb.shape[1]
+    positions = torch.arange(sequence_length, device=yb.device, dtype=torch.long)
+    positions = positions.unsqueeze(0).expand_as(yb)
+    stop_mask = torch.isin(
+        yb,
+        torch.as_tensor(stop_ids, device=yb.device, dtype=yb.dtype),
+    )
+    stop_positions = torch.where(stop_mask, positions, sequence_length)
+    next_stop = torch.flip(
+        torch.cummin(torch.flip(stop_positions, dims=(1,)), dim=1).values,
+        dims=(1,),
+    )
+    distances = next_stop - positions
+    edges = torch.as_tensor(bucket_edges, device=yb.device, dtype=distances.dtype)
+    labels = (distances.unsqueeze(-1) > edges).sum(dim=-1).to(torch.long)
+    labels = labels.masked_fill(next_stop == sequence_length, len(bucket_edges))
+    return labels.masked_fill(yb == PAD_ID, ignore_index)
 
 
 def termination_aux_loss(

--- a/tests/test_long_range_codon_objectives.py
+++ b/tests/test_long_range_codon_objectives.py
@@ -92,6 +92,46 @@ def test_termination_distance_bucket_labels():
     ]
 
 
+def _reference_termination_labels(yb, stop_ids, bucket_edges, ignore_index=-100):
+    labels = torch.full_like(yb, fill_value=ignore_index, dtype=torch.long)
+    n_classes = len(bucket_edges) + 1
+    for row_idx, row in enumerate(yb):
+        stop_positions = [
+            pos for pos, token in enumerate(row.tolist()) if token in stop_ids
+        ]
+        for pos, token in enumerate(row.tolist()):
+            if token == 0:
+                continue
+            future_stops = [stop for stop in stop_positions if stop >= pos]
+            if not future_stops:
+                labels[row_idx, pos] = n_classes - 1
+                continue
+            distance = future_stops[0] - pos
+            labels[row_idx, pos] = sum(
+                distance > edge for edge in bucket_edges
+            )
+    return labels
+
+
+def test_vectorized_termination_labels_match_reference():
+    generator = torch.Generator().manual_seed(1337)
+    for shape in ((1, 1), (2, 17), (4, 512)):
+        yb = torch.randint(0, 12, shape, generator=generator)
+        for stop_ids in ((2,), (2, 3)):
+            for bucket_edges in ((), (0,), (0, 3, 10, 30)):
+                expected = _reference_termination_labels(
+                    yb,
+                    stop_ids=stop_ids,
+                    bucket_edges=bucket_edges,
+                )
+                actual = termination_distance_bucket_labels(
+                    yb,
+                    stop_ids=stop_ids,
+                    bucket_edges=bucket_edges,
+                )
+                assert torch.equal(actual, expected)
+
+
 def test_termination_aux_loss_accepts_labels():
     logits = torch.randn(2, 4, 5)
     labels = torch.tensor(


### PR DESCRIPTION
## Summary
- replace nested per-token termination-distance scans with a tensorized reverse cumulative-minimum pass
- eliminate thousands of scalar item CPU/MPS synchronization points per microbatch
- add randomized parity coverage against the original algorithm and document the paused resume boundary

## Measured MPS result
On the experiments 4 x 512 workload:
- reference: approximately 1,615 ms per microbatch
- vectorized: approximately 0.78 ms per microbatch
- speedup: approximately 2,073x for label construction

The live head-only run is paused at committed optimizer step 393 / microbatch 6288 with zero active or discarded accumulation work. It will resume from the unchanged checkpoint after merge.

## Validation
- ruff check src/codonlm/training/objectives.py tests/test_long_range_codon_objectives.py
- pytest -q tests/test_long_range_codon_objectives.py (11 passed)
- pytest -q (330 passed, 1 skipped, 1 xpassed)