### PR TITLE
Report corrected termination-head evaluation

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -203,9 +203,13 @@ next-token quality, termination, memory, or runtime reliability.
   head-biased decoding is a separately labelled intervention. Promotion permits
   at most 2% test-NLL regression and requires fewer hard caps without short-length
   collapse.
-- [ ] Train the termination-head condition without replay from the corrected primary
-  checkpoint.
+- [x] Train the termination-head condition without replay from the corrected primary
+  checkpoint. The frozen test NLL regression is 1.10%, within the 2% gate, but
+  raw unrestricted termination remains 63/100, identical to the anchor aggregate.
+  The head predicts only exact-boundary and far classes (balanced accuracy 36.44%;
+  zero recall for all three intermediate buckets), so this condition is not promoted.
 - [ ] Add generated-prefix replay only if the head-only condition is insufficient.
+  Head-only is insufficient; the predeclared replay condition is authorized.
 - [ ] Compare natural, syntax-constrained, replay-trained, and decoder-biased
   behavior without conflating training and inference interventions.
 - [ ] Report length distributions, natural-stop, early-stop, and hard-cap rates plus

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -963,6 +963,13 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     original labels, while the measured `4 x 512` MPS workload improved from about
     1,615 ms to 0.78 ms per microbatch. The run resumes from the unchanged
     checkpoint after review.
+*   **Termination-Head Evaluation (2026-07-31):** Completed the head-only Phase 6
+    condition and frozen evaluation. Test NLL increased 1.10%, within the locked
+    2% gate, but raw unrestricted termination was unchanged at 63/100 across two
+    seeds. The auxiliary head obtained 36.44% balanced accuracy and zero recall
+    for the three intermediate distance buckets, predicting only exact-boundary
+    and far classes. Strict class-0 decoder bias never activated. The checkpoint
+    is not promoted; generated-prefix replay is authorized as the next condition.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_termination_head_evaluation.json
+++ b/docs/benchmarks/corrected_termination_head_evaluation.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "run_id": "corrected-termination-head-seed1337",
+  "anchor_run_id": "corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4",
+  "protocol": {
+    "checkpoint": "best.pt",
+    "frozen_split": "test",
+    "raw_prompts_per_seed": 50,
+    "raw_temperature": 1.0,
+    "raw_topk": 0,
+    "raw_max_new_tokens": 300,
+    "raw_forced_stop": false,
+    "raw_cds_mask": false
+  },
+  "next_token": {
+    "anchor_test_nll": 3.666961473787338,
+    "anchor_test_ppl": 39.13281893145237,
+    "termination_head_test_nll": 3.7071192486363427,
+    "termination_head_test_ppl": 40.736286222787754,
+    "relative_test_nll_regression": 0.010951239912408648,
+    "passes_max_relative_nll_regression_0_02": true
+  },
+  "raw_unrestricted": {
+    "seed_1337": {
+      "natural_stop_rate": 0.62,
+      "hard_cap_rate": 0.38,
+      "mean_generated_codons": 189.82,
+      "median_generated_codons": 197.0,
+      "median_naturally_stopped_codons": 119.0,
+      "mean_gc": 0.5801487906852364
+    },
+    "seed_2027": {
+      "natural_stop_rate": 0.64,
+      "hard_cap_rate": 0.36,
+      "mean_generated_codons": 189.74,
+      "median_generated_codons": 223.0,
+      "median_naturally_stopped_codons": 133.0,
+      "mean_gc": 0.589454660734883
+    },
+    "aggregate": {
+      "natural_stops": 63,
+      "samples": 100,
+      "natural_stop_rate": 0.63,
+      "hard_cap_rate": 0.37,
+      "anchor_natural_stop_rate": 0.63,
+      "anchor_hard_cap_rate": 0.37
+    },
+    "paired_seed_1337": {
+      "paired_samples": 50,
+      "anchor_stops": 35,
+      "termination_head_stops": 31,
+      "anchor_cap_to_head_stop": 2,
+      "anchor_stop_to_head_cap": 6,
+      "mcnemar_exact_p": 0.2890625
+    }
+  },
+  "termination_head": {
+    "weighted_cross_entropy": 0.9887382312905921,
+    "accuracy": 0.9084335565567017,
+    "balanced_accuracy": 0.36442773727250055,
+    "class_recall": [
+      0.824566646742379,
+      0.0,
+      0.0,
+      0.0,
+      0.9975720396201235
+    ],
+    "interpretation": "The head predicts only exact-boundary and far classes; it does not recover the three intermediate distance classes."
+  },
+  "separate_decoder_conditions_seed_1337": {
+    "syntax_constrained": {
+      "terminal_stop_rate": 0.6,
+      "mean_aa_length": 167.08,
+      "median_aa_length": 169.5,
+      "early_stop_rate": 0.0
+    },
+    "strict_class_0_decoder_bias": {
+      "stop_logit_bias": 5.0,
+      "window_codons": 5,
+      "terminal_stop_rate": 0.6,
+      "mean_aa_length": 167.08,
+      "median_aa_length": 169.5,
+      "termination_bias_steps_total": 0,
+      "interpretation": "The head never predicted class 0 inside the target window, so the intervention was identical to syntax-constrained decoding."
+    }
+  },
+  "novelty": {
+    "seed_1337": {
+      "reported_nucleotide_hits": 0,
+      "reported_protein_hits": 0,
+      "mean_exact_30nt_coverage": 0.0,
+      "mean_exact_10aa_coverage": 0.0
+    },
+    "seed_2027": {
+      "reported_nucleotide_hits": 0,
+      "reported_protein_hits": 0,
+      "mean_exact_30nt_coverage": 0.0,
+      "mean_exact_10aa_coverage": 0.000664451827242525,
+      "max_exact_10aa_coverage": 0.03322259136212625
+    }
+  },
+  "decision": {
+    "promote_head_only": false,
+    "reason": "The NLL gate passes, but raw natural-stop and hard-cap rates do not improve and intermediate termination-distance classes collapse.",
+    "next_condition": "generated_prefix_replay"
+  }
+}

--- a/scripts/evaluate_termination_head.py
+++ b/scripts/evaluate_termination_head.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Evaluate a CodonLM termination-distance head on a frozen data split."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from scripts._shared import resolve_run
+from scripts.evaluate_test import _find_test_npz, _find_validation_npz, dev
+from src.codonlm.checkpoints import build_codon_model_from_cfg, load_codon_checkpoint
+from src.codonlm.data_loading import (
+    PackedDataset,
+    dynamic_lm_collate_fn,
+)
+from src.codonlm.training.objectives import termination_distance_bucket_labels
+
+
+def summarize_confusion(
+    confusion: torch.Tensor,
+    true_probability_sums: torch.Tensor,
+) -> dict:
+    counts = confusion.sum(dim=1)
+    predicted = confusion.sum(dim=0)
+    diagonal = confusion.diag().double()
+    recall = diagonal / counts.clamp_min(1)
+    precision = diagonal / predicted.clamp_min(1)
+    total = confusion.sum().clamp_min(1)
+    return {
+        "evaluated_positions": int(confusion.sum()),
+        "accuracy": float(diagonal.sum() / total),
+        "balanced_accuracy": float(recall.mean()),
+        "confusion_matrix": confusion.tolist(),
+        "classes": [
+            {
+                "class": class_index,
+                "count": int(counts[class_index]),
+                "fraction": float(counts[class_index] / total),
+                "recall": float(recall[class_index]),
+                "precision": float(precision[class_index]),
+                "mean_true_probability": float(
+                    true_probability_sums[class_index]
+                    / counts[class_index].clamp_min(1)
+                ),
+            }
+            for class_index in range(confusion.shape[0])
+        ],
+    }
+
+
+@torch.no_grad()
+def evaluate(model, loader, device, cfg: dict) -> dict:
+    bucket_edges = tuple(int(value) for value in cfg["termination_bucket_edges"])
+    stop_ids = tuple(int(value) for value in cfg["termination_stop_ids"])
+    n_classes = int(cfg["termination_n_classes"])
+    class_weights = cfg.get("termination_class_weights")
+    weights = (
+        torch.tensor(class_weights, dtype=torch.float32, device=device)
+        if class_weights is not None
+        else None
+    )
+    confusion = torch.zeros((n_classes, n_classes), dtype=torch.long)
+    true_probability_sums = torch.zeros(n_classes, dtype=torch.float64)
+    loss_sum = 0.0
+    loss_denominator = 0.0
+
+    for xb, yb in loader:
+        xb, yb = xb.to(device), yb.to(device)
+        _, _, aux = model(xb, return_aux=True)
+        logits = aux["termination_logits"].float()
+        labels = termination_distance_bucket_labels(yb, stop_ids, bucket_edges)
+        valid = labels != -100
+        targets = labels[valid]
+        selected = logits[valid]
+        predictions = selected.argmax(dim=-1)
+        batch_confusion = torch.bincount(
+            targets * n_classes + predictions,
+            minlength=n_classes * n_classes,
+        ).reshape(n_classes, n_classes)
+        confusion += batch_confusion.cpu()
+        loss_sum += float(
+            F.cross_entropy(
+                selected,
+                targets,
+                weight=weights,
+                reduction="sum",
+            ).item()
+        )
+        loss_denominator += float(
+            weights[targets].sum().item() if weights is not None else targets.numel()
+        )
+        true_probabilities = (
+            torch.softmax(selected, dim=-1)
+            .gather(1, targets[:, None])
+            .squeeze(1)
+            .cpu()
+            .double()
+        )
+        targets_cpu = targets.cpu()
+        for class_index in range(n_classes):
+            true_probability_sums[class_index] += true_probabilities[
+                targets_cpu == class_index
+            ].sum()
+
+    return {
+        "bucket_edges": list(bucket_edges),
+        "stop_ids": list(stop_ids),
+        "class_weights": class_weights,
+        "weighted_cross_entropy": loss_sum / max(loss_denominator, 1.0),
+        **summarize_confusion(confusion, true_probability_sums),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--checkpoint", default="best.pt")
+    parser.add_argument("--split", choices=("validation", "test"), default="test")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    run_id, run_dir = resolve_run(args.run_id, None)
+    state_dict, cfg, checkpoint_path = load_codon_checkpoint(
+        run_dir, ckpt_name=args.checkpoint
+    )
+    if not cfg.get("termination_loss_enabled"):
+        raise ValueError("checkpoint configuration has no termination head")
+    model = build_codon_model_from_cfg(cfg)
+    model.load_state_dict(state_dict, strict=True)
+    device = dev()
+    model.to(device).eval()
+
+    repo = Path(__file__).resolve().parents[1]
+    if args.split == "validation":
+        data_path = _find_validation_npz(cfg, repo)
+    else:
+        data_path = _find_test_npz(run_id, cfg, repo, None)
+    dataset = PackedDataset(data_path)
+    collate_fn = dynamic_lm_collate_fn if dataset.is_dynamic else None
+    loader = DataLoader(dataset, batch_size=args.batch_size, collate_fn=collate_fn)
+    report = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "checkpoint": str(checkpoint_path.resolve()),
+        "split": args.split,
+        "data": str(data_path.resolve()),
+        "device": str(device),
+        **evaluate(model, loader, device, cfg),
+    }
+    output = args.output or (
+        run_dir / "scores" / "termination_head_evaluation" / f"{args.split}_metrics.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"[termination-head] wrote {output}")
+    print(
+        f"[termination-head] loss={report['weighted_cross_entropy']:.4f} "
+        f"accuracy={report['accuracy']:.4f} "
+        f"balanced_accuracy={report['balanced_accuracy']:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluate_termination_head.py
+++ b/tests/test_evaluate_termination_head.py
@@ -1,0 +1,19 @@
+import pytest
+import torch
+
+from scripts.evaluate_termination_head import summarize_confusion
+
+
+def test_summarize_confusion_reports_class_imbalance():
+    confusion = torch.tensor([[8, 2], [9, 81]], dtype=torch.long)
+    probability_sums = torch.tensor([6.0, 63.0], dtype=torch.float64)
+
+    result = summarize_confusion(confusion, probability_sums)
+
+    assert result["evaluated_positions"] == 100
+    assert result["accuracy"] == pytest.approx(0.89)
+    assert result["balanced_accuracy"] == pytest.approx(0.85)
+    assert result["classes"][0]["recall"] == pytest.approx(0.8)
+    assert result["classes"][1]["recall"] == pytest.approx(0.9)
+    assert result["classes"][0]["mean_true_probability"] == pytest.approx(0.6)
+    assert result["classes"][1]["mean_true_probability"] == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- add a reusable termination-head evaluator with weighted loss, confusion, balanced accuracy, and per-class metrics
- publish the matched head-only test and generation results
- record that the NLL gate passes but raw termination does not improve, so head-only is not promoted and replay is authorized

## Results
- test NLL: 3.7071 vs anchor 3.6670, a 1.10% regression within the 2% gate
- raw unrestricted termination: 63/100 for both head-only and anchor aggregates
- termination-head balanced accuracy: 36.44%, with zero recall for intermediate classes 1-3
- strict class-0 decoder intervention: zero bias activations in 50 prompts
- novelty: no reported nucleotide or protein nearest-neighbor hits

## Validation
- reusable evaluator reproduced the frozen test metrics on MPS
- ruff check scripts/evaluate_termination_head.py tests/test_evaluate_termination_head.py
- pytest -q: 331 passed, 1 skipped, 1 xpassed