### PR TITLE
Prepare leakage-controlled termination replay

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -209,7 +209,10 @@ next-token quality, termination, memory, or runtime reliability.
   The head predicts only exact-boundary and far classes (balanced accuracy 36.44%;
   zero recall for all three intermediate buckets), so this condition is not promoted.
 - [ ] Add generated-prefix replay only if the head-only condition is insufficient.
-  Head-only is insufficient; the predeclared replay condition is authorized.
+  Head-only is insufficient; the replay condition is authorized and frozen. Replay
+  uses 79 unrestricted hard-cap failures generated from 200 training-split prefixes,
+  exact `[0,3,10,30]` tail labels, one replay batch per optimizer group, and no
+  validation/test source records.
 - [ ] Compare natural, syntax-constrained, replay-trained, and decoder-biased
   behavior without conflating training and inference interventions.
 - [ ] Report length distributions, natural-stop, early-stop, and hard-cap rates plus

--- a/configs/corrected_termination_replay_seed1337.yaml
+++ b/configs/corrected_termination_replay_seed1337.yaml
@@ -1,0 +1,99 @@
+# Phase 6 generated-prefix replay condition from the evaluated head-only checkpoint.
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+run_id: corrected-termination-replay-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 1
+max_time_minutes: null
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.05
+label_smoothing: 0.0
+tie_embeddings: false
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+multi_offset_loss_enabled: false
+multi_offset_targets: []
+
+termination_loss_enabled: true
+termination_loss_weight: 0.1
+termination_stop_ids: [2]
+termination_bucket_edges: [0, 3, 10, 30]
+termination_n_classes: 5
+termination_class_weights: [12.364329, 7.145187, 4.686482, 2.785020, 0.705228]
+
+replay_loss_enabled: true
+# Applied once per 16 microbatches: 3.2 / 16 = group-average weight 0.2.
+replay_loss_weight: 3.2
+replay_batch_size: 4
+replay_every_microbatches: 16
+replay_class_weights: [3.147228, 1.817053, 1.189540, 0.703742, 1.0]
+replay_data: runs/corrected-termination-head-seed1337/scores/generated_prefix_replay_corrected_seed1337.jsonl
+freeze_backbone: false
+eos_loss_weight: 1.0
+
+transfer_from: runs/corrected-termination-head-seed1337/checkpoints/best.pt
+
+batch_size: 4
+grad_accum_steps: 16
+lr: 0.000002
+lr_embedding: 0.00005
+min_lr: 0.0000002
+weight_decay: 0.05
+warmup_fraction: 0.1
+optimizer: adamw
+scheduler: cosine
+scheduler_total_steps: 1000
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+use_checkpoint: true
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores
+
+extension_experiment_contract:
+  schema_version: 1
+  phase: generated_prefix_replay
+  anchor_run_id: corrected-termination-head-seed1337
+  primary_anchor_run_id: corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4
+  dataset_protocol: frozen_genome_holdout
+  replay_source_split: train
+  replay_source_records: 200
+  replay_failure_records: 79
+  replay_sha256: adb92c0b940d155d84ea6580c420089c07ad327cec31d28d0852989d757e87d2
+  token_exposure_epochs: 1
+  primary_decoder:
+    temperature: 1.0
+    topk: 0
+    forced_stop: false
+    cds_mask: false
+  promotion:
+    max_relative_test_nll_regression_from_primary: 0.02
+    require_reduced_hard_cap_rate: true
+    require_no_short_length_collapse: true

--- a/docs/CORRECTED_TERMINATION_REPLAY_PROTOCOL.md
+++ b/docs/CORRECTED_TERMINATION_REPLAY_PROTOCOL.md
@@ -1,0 +1,59 @@
+# Corrected Termination Replay Protocol
+
+## Purpose
+
+The head-only condition preserved next-token quality but did not improve raw
+termination. Its auxiliary head also collapsed the three intermediate distance
+classes. Generated-prefix replay tests whether explicit supervision on the states
+immediately preceding real model failures can correct that representation and, via
+joint backbone fine-tuning, improve unrestricted termination.
+
+Replay remains an auxiliary-head intervention. It does not directly add stop-token
+cross-entropy to the language-model logits. Any raw-decoding improvement must arise
+through shared-backbone co-adaptation.
+
+## Replay Construction
+
+- Source checkpoint: `corrected-termination-head-seed1337/best.pt`.
+- Prefix source: frozen **training** split only; test and validation records are not
+  used for replay training.
+- Source selection: 200 records, seed 1337, round-robin across 20 training genomes.
+- Prefix: one codon.
+- Decoder: unrestricted model sampling, temperature 1.0, top-k disabled.
+- Limit: 300 new tokens, with no CDS mask or forced termination.
+- Captured failures: 79 hard-cap prefixes.
+- Replay artifact SHA-256:
+  `adb92c0b940d155d84ea6580c420089c07ad327cec31d28d0852989d757e87d2`.
+
+The final failed-prefix state is assigned class 0 because the desired next token is
+a termination token. The preceding 30 states receive classes from the same locked
+distance edges `[0,3,10,30]` as native training. This produces 2,449 sparse labels:
+
+| Class | Labels |
+| ---: | ---: |
+| 0 | 79 |
+| 1 | 237 |
+| 2 | 553 |
+| 3 | 1,580 |
+| 4 | 0 |
+
+Square-root inverse-frequency weights over replay classes 0-3 are used. Class 4 is
+absent by construction and its configured weight is inert.
+
+## Training Condition
+
+- Initialize from the evaluated head-only checkpoint.
+- One native-corpus epoch; unchanged frozen dataset and vocabulary.
+- Native termination loss remains enabled at weight 0.1.
+- One replay batch of four failures per 16-microbatch optimizer group.
+- Replay loss multiplier 3.2, yielding group-average weight 0.2.
+- Backbone learning rate `2e-6`; termination-head learning rate `5e-5`.
+- No shape encoder, multi-offset prior, critic, decoder bias, or forced stop.
+
+## Evaluation And Decision
+
+Repeat the head-only frozen test and matched raw-generation protocol. Promotion
+requires test NLL regression no greater than 2% relative to the corrected primary,
+fewer raw hard caps across the two locked seeds, and no short-length collapse.
+Syntax-constrained and decoder-biased outputs remain separately labelled inference
+interventions.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -970,6 +970,13 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     for the three intermediate distance buckets, predicting only exact-boundary
     and far classes. Strict class-0 decoder bias never activated. The checkpoint
     is not promoted; generated-prefix replay is authorized as the next condition.
+*   **Corrected Replay Freeze (2026-08-02):** Repaired the legacy replay builder's
+    frozen-source API and corrected two protocol errors: test-derived prefixes are
+    forbidden for training, and replay classes now use exact distance buckets rather
+    than mapping a 12-codon window to class 1. Built 79 unrestricted hard-cap records
+    from 200 training-split prefixes across 20 genomes. Added replay cadence and
+    replay-specific class weighting so the locked group-average replay contribution
+    is 0.2 without replaying a synthetic batch on every native microbatch.
 
 ---
 *End of Log*

--- a/scripts/build_generated_prefix_replay.py
+++ b/scripts/build_generated_prefix_replay.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 import time
 from pathlib import Path
@@ -21,7 +22,7 @@ from scripts.eval_generation_prefix import (
     _select_device,
     _set_seed,
 )
-from src.codonlm.generate import generate_cds_constrained
+from src.codonlm.generate import generate_cds_constrained, generate_model_raw
 
 
 def _is_codon(tok: str) -> bool:
@@ -41,23 +42,25 @@ def _codon_positions(ids: list[int], itos: list[str]) -> list[tuple[int, int, st
 
 def _replay_labels(
     ids: list[int],
-    itos: list[str],
     *,
-    prefix_codons: int,
-    target_codons: int,
+    prefix_tokens: int,
     window: int,
-    near_class: int,
-    immediate_class: int,
+    bucket_edges: tuple[int, ...],
 ) -> list[dict[str, int]]:
-    labels: list[dict[str, int]] = []
-    start_generated = max(0, int(target_codons) - max(0, int(window)))
-    for pos, total_codons, _tok in _codon_positions(ids, itos):
-        generated_codons = int(total_codons) - int(prefix_codons)
-        if generated_codons < start_generated:
-            continue
-        target_class = int(immediate_class) if generated_codons >= int(target_codons) else int(near_class)
-        labels.append({"pos": int(pos), "class": target_class})
-    return labels
+    """Label the tail of a failed prefix relative to a desired next-token stop."""
+    if tuple(bucket_edges) != tuple(sorted(bucket_edges)):
+        raise ValueError("bucket_edges must be sorted")
+    if len(ids) <= int(prefix_tokens):
+        return []
+    boundary_state = len(ids) - 1
+    start = max(int(prefix_tokens), boundary_state - max(0, int(window)))
+    return [
+        {
+            "pos": pos,
+            "class": sum((boundary_state - pos) > edge for edge in bucket_edges),
+        }
+        for pos in range(start, boundary_state + 1)
+    ]
 
 
 def _load_model(repo: Path, run_id: str, ckpt_name: str, device: torch.device):
@@ -84,6 +87,8 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--run_id", required=True)
     ap.add_argument("--ckpt", default="best.pt")
+    ap.add_argument("--dataset_manifest", type=Path, default=None)
+    ap.add_argument("--source_split", choices=("train", "val", "test"), default="train")
     ap.add_argument("--preset", choices=sorted(PRESETS), default="quick")
     ap.add_argument("--k_list", default="1,3,5,10")
     ap.add_argument("--samples", type=int, default=None)
@@ -97,9 +102,14 @@ def main() -> None:
     ap.add_argument("--target_aa_len", type=int, default=256)
     ap.add_argument("--max_aa_len", type=int, default=400)
     ap.add_argument("--special_margin", type=int, default=6)
-    ap.add_argument("--replay_window", type=int, default=12)
-    ap.add_argument("--near_class", type=int, default=1)
-    ap.add_argument("--immediate_class", type=int, default=0)
+    ap.add_argument("--replay_window", type=int, default=30)
+    ap.add_argument("--bucket_edges", default="0,3,10,30")
+    ap.add_argument(
+        "--decoder",
+        choices=("raw", "cds_constrained"),
+        default="cds_constrained",
+        help="Generation distribution used to collect hard-cap failures.",
+    )
     ap.add_argument("--out", default=None)
     ap.add_argument("--progress_every", type=int, default=20)
     ap.add_argument(
@@ -125,7 +135,15 @@ def main() -> None:
     repo = Path(__file__).resolve().parents[1]
     device = _select_device(args.device)
     run_dir, cfg, model, itos, stoi = _load_model(repo, args.run_id, args.ckpt, device)
-    dna_path = _resolve_cds_dna_path(repo, run_dir, cfg, max_genes=args.max_genes)
+    dna_path, source_provenance = _resolve_cds_dna_path(
+        repo,
+        run_dir,
+        cfg,
+        max_genes=args.max_genes,
+        seed=int(args.seed),
+        dataset_manifest=args.dataset_manifest,
+        source_split=args.source_split,
+    )
     if dna_path is None or not dna_path.exists():
         raise SystemExit("[replay] could not locate CDS DNA via run manifests/config")
 
@@ -145,11 +163,15 @@ def main() -> None:
                 break
 
     k_list = [int(x) for x in str(args.k_list).split(",") if x]
+    bucket_edges = tuple(int(x) for x in str(args.bucket_edges).split(",") if x)
+    if tuple(bucket_edges) != tuple(sorted(bucket_edges)):
+        raise SystemExit("--bucket_edges must be sorted")
     total_expected = len(cds) * len(k_list) * int(args.samples)
     done = 0
     written = 0
     hard_caps = 0
     terminal_stops = 0
+    label_class_counts: Counter[int] = Counter()
     wall0 = time.perf_counter()
     block_size = int(cfg.get("block_size", getattr(model, "block_size", 512)))
 
@@ -166,19 +188,31 @@ def main() -> None:
                         raise ValueError("block_size too small for requested replay generation lengths")
                     hard_cap = int(min(max_window_codons, args.max_aa_len, args.max_new))
                     target_codons = int(max(args.min_aa_len, min(args.target_aa_len, hard_cap)))
-                    gen_ids, info = generate_cds_constrained(
-                        model=model,
-                        device=device,
-                        ctx_ids=ctx_ids,
-                        stoi=stoi,
-                        itos=itos,
-                        target_codons=target_codons,
-                        hard_cap=hard_cap,
-                        require_terminal_stop=True,
-                        temperature=float(args.temperature),
-                        topk=int(args.topk) if args.topk > 0 else 0,
-                        cds_only=not bool(args.allow_non_cds_tokens),
-                    )
+                    if args.decoder == "raw":
+                        gen_ids, info = generate_model_raw(
+                            model=model,
+                            device=device,
+                            ctx_ids=ctx_ids,
+                            stoi=stoi,
+                            itos=itos,
+                            max_new_tokens=hard_cap,
+                            temperature=float(args.temperature),
+                            topk=int(args.topk) if args.topk > 0 else 0,
+                        )
+                    else:
+                        gen_ids, info = generate_cds_constrained(
+                            model=model,
+                            device=device,
+                            ctx_ids=ctx_ids,
+                            stoi=stoi,
+                            itos=itos,
+                            target_codons=target_codons,
+                            hard_cap=hard_cap,
+                            require_terminal_stop=True,
+                            temperature=float(args.temperature),
+                            topk=int(args.topk) if args.topk > 0 else 0,
+                            cds_only=not bool(args.allow_non_cds_tokens),
+                        )
                     done += 1
                     if info.get("had_terminal_stop"):
                         terminal_stops += 1
@@ -186,14 +220,12 @@ def main() -> None:
                         hard_caps += 1
                         labels = _replay_labels(
                             gen_ids,
-                            itos,
-                            prefix_codons=prefix_k,
-                            target_codons=target_codons,
+                            prefix_tokens=len(ctx_ids),
                             window=int(args.replay_window),
-                            near_class=int(args.near_class),
-                            immediate_class=int(args.immediate_class),
+                            bucket_edges=bucket_edges,
                         )
                         if labels:
+                            label_class_counts.update(item["class"] for item in labels)
                             record = {
                                 "source_run_id": args.run_id,
                                 "source_ckpt": args.ckpt,
@@ -205,6 +237,8 @@ def main() -> None:
                                 "target_codons": int(target_codons),
                                 "generated_codons": int(info.get("generated_codons", 0)),
                                 "hard_cap": int(hard_cap),
+                                "decoder": args.decoder,
+                                "synthetic_boundary": "next_token_after_failed_prefix",
                                 "last_termination_class": info.get("last_termination_class"),
                             }
                             out_fh.write(json.dumps(record, separators=(",", ":")) + "\n")
@@ -224,6 +258,8 @@ def main() -> None:
         "run_id": args.run_id,
         "ckpt": args.ckpt,
         "device": str(device),
+        "source_split": args.source_split,
+        "source_provenance": source_provenance,
         "preset": args.preset,
         "samples": int(args.samples),
         "max_genes": int(args.max_genes),
@@ -232,10 +268,15 @@ def main() -> None:
         "hard_cap_without_stop": int(hard_caps),
         "terminal_stops": int(terminal_stops),
         "records_written": int(written),
+        "label_class_counts": {
+            str(class_index): int(label_class_counts[class_index])
+            for class_index in range(len(bucket_edges) + 1)
+        },
+        "decoder": args.decoder,
         "replay_window": int(args.replay_window),
-        "near_class": int(args.near_class),
-        "immediate_class": int(args.immediate_class),
-        "cds_only": not bool(args.allow_non_cds_tokens),
+        "bucket_edges": list(bucket_edges),
+        "cds_only": args.decoder == "cds_constrained"
+        and not bool(args.allow_non_cds_tokens),
         "out": str(out_path),
     }
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -357,6 +357,21 @@ def run_training(cfg: dict, args) -> None:
     replay_loss_weight = float(cfg.get("replay_loss_weight", 0.1))
     replay_data = cfg.get("replay_data")
     replay_batch_size = int(cfg.get("replay_batch_size", cfg.get("batch_size", 1)))
+    replay_every_microbatches = int(cfg.get("replay_every_microbatches", 1))
+    if replay_every_microbatches <= 0:
+        raise ValueError("replay_every_microbatches must be positive")
+    replay_class_weights_raw = cfg.get("replay_class_weights")
+    replay_class_weight_values = None
+    if replay_class_weights_raw is not None:
+        if len(replay_class_weights_raw) != termination_n_classes:
+            raise ValueError(
+                "replay_class_weights must contain termination_n_classes values"
+            )
+        replay_class_weight_values = [
+            float(value) for value in replay_class_weights_raw
+        ]
+        if any(value <= 0 for value in replay_class_weight_values):
+            raise ValueError("replay_class_weights values must be positive")
     termination_head_enabled = termination_loss_enabled or replay_loss_enabled
     if termination_loss_enabled:
         print(
@@ -369,7 +384,9 @@ def run_training(cfg: dict, args) -> None:
             raise ValueError("replay_loss_enabled=true requires replay_data")
         print(
             f"[loss] replay_termination weight={replay_loss_weight} "
-            f"data={replay_data} batch_size={replay_batch_size}"
+            f"data={replay_data} batch_size={replay_batch_size} "
+            f"every_microbatches={replay_every_microbatches} "
+            f"class_weights={replay_class_weights_raw}"
         )
 
     eos_loss_weight = cfg.get("eos_loss_weight", None)
@@ -471,6 +488,15 @@ def run_training(cfg: dict, args) -> None:
             device=device,
         )
         if termination_class_weight_values is not None
+        else None
+    )
+    replay_class_weights = (
+        torch.tensor(
+            replay_class_weight_values,
+            dtype=torch.float32,
+            device=device,
+        )
+        if replay_class_weight_values is not None
         else None
     )
 
@@ -1055,7 +1081,11 @@ def run_training(cfg: dict, args) -> None:
                         )
                         total_loss_ = total_loss_ + (termination_loss_weight * term_loss_)
                     replay_loss_ = None
-                    if split == "train" and replay_loader is not None:
+                    if (
+                        split == "train"
+                        and replay_loader is not None
+                        and current_microbatch_idx % replay_every_microbatches == 0
+                    ):
                         if replay_iter is None:
                             replay_iter = iter(replay_loader)
                         try:
@@ -1074,7 +1104,11 @@ def run_training(cfg: dict, args) -> None:
                         replay_logits = replay_aux.get("termination_logits")
                         if replay_logits is None:
                             raise RuntimeError("replay_loss_enabled=true but model returned no termination logits")
-                        replay_loss_ = termination_aux_loss(replay_logits, replay_labels)
+                        replay_loss_ = termination_aux_loss(
+                            replay_logits,
+                            replay_labels,
+                            class_weights=replay_class_weights,
+                        )
                         total_loss_ = total_loss_ + (replay_loss_weight * replay_loss_)
                     return total_loss_, next_loss_, offset_losses_, term_loss_, replay_loss_
 

--- a/tests/test_build_generated_prefix_replay.py
+++ b/tests/test_build_generated_prefix_replay.py
@@ -13,22 +13,30 @@ def test_codon_positions_counts_only_codon_tokens():
 
 
 def test_replay_labels_targets_boundary_window_after_prefix():
-    itos = ["<PAD>", "<BOS_CDS>", "ATG", "AAA", "CCC", "GGG", "TAA"]
     ids = [1, 2, 3, 4, 5, 3, 4, 5]
 
     labels = _replay_labels(
         ids,
-        itos,
-        prefix_codons=2,
-        target_codons=4,
-        window=2,
-        near_class=1,
-        immediate_class=0,
+        prefix_tokens=2,
+        window=4,
+        bucket_edges=(0, 1, 3),
     )
 
     assert labels == [
-        {"pos": 4, "class": 1},
-        {"pos": 5, "class": 1},
-        {"pos": 6, "class": 0},
+        {"pos": 3, "class": 3},
+        {"pos": 4, "class": 2},
+        {"pos": 5, "class": 2},
+        {"pos": 6, "class": 1},
         {"pos": 7, "class": 0},
     ]
+
+
+def test_replay_labels_do_not_supervise_the_original_prefix():
+    labels = _replay_labels(
+        [1, 2, 3],
+        prefix_tokens=2,
+        window=30,
+        bucket_edges=(0, 3, 10, 30),
+    )
+
+    assert labels == [{"pos": 2, "class": 0}]

--- a/tests/test_corrected_termination_replay_contract.py
+++ b/tests/test_corrected_termination_replay_contract.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _config():
+    return yaml.safe_load(
+        (ROOT / "configs" / "corrected_termination_replay_seed1337.yaml").read_text()
+    )
+
+
+def test_corrected_replay_config_preserves_locked_protocol():
+    cfg = _config()
+
+    assert cfg["transfer_from"].endswith(
+        "corrected-termination-head-seed1337/checkpoints/best.pt"
+    )
+    assert cfg["replay_loss_enabled"] is True
+    assert cfg["replay_every_microbatches"] == cfg["grad_accum_steps"] == 16
+    assert cfg["replay_loss_weight"] / cfg["grad_accum_steps"] == pytest.approx(0.2)
+    assert cfg["extension_experiment_contract"]["replay_source_split"] == "train"
+    assert cfg["extension_experiment_contract"]["replay_failure_records"] == 79
+    assert len(cfg["replay_class_weights"]) == cfg["termination_n_classes"]
+
+
+def test_corrected_replay_config_keeps_other_extensions_disabled():
+    cfg = _config()
+
+    assert cfg["multi_offset_loss_enabled"] is False
+    assert cfg["use_shape_guidance"] is False
+    assert cfg["freeze_backbone"] is False


### PR DESCRIPTION
## Summary
- correct replay labels to use the locked termination-distance buckets and next-token boundary alignment
- add unrestricted replay collection from frozen training-split prefixes with explicit provenance
- add replay cadence and replay-specific class weighting
- freeze the one-epoch corrected replay config and protocol

## Frozen replay artifact
- 200 training-split prefixes across 20 genomes
- unrestricted temperature 1.0, top-k disabled, 300-token cap
- 79 hard-cap failure records and 2,449 sparse labels
- SHA-256 adb92c0b940d155d84ea6580c420089c07ad327cec31d28d0852989d757e87d2
- no validation or test records used

## Training contract
- initialize from corrected-termination-head-seed1337/best.pt
- one replay batch per 16-microbatch optimizer group
- group-average replay weight 0.2
- backbone LR 2e-6, head LR 5e-5, one native-corpus epoch

## Validation
- corrected raw MPS builder smoke passed
- focused tests: 33 passed
- pytest -q: 334 passed, 1 skipped, 1 xpassed
- replay artifact hash and all local dependencies verified