### PR TITLE
Report corrected termination replay results

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -208,18 +208,28 @@ next-token quality, termination, memory, or runtime reliability.
   raw unrestricted termination remains 63/100, identical to the anchor aggregate.
   The head predicts only exact-boundary and far classes (balanced accuracy 36.44%;
   zero recall for all three intermediate buckets), so this condition is not promoted.
-- [ ] Add generated-prefix replay only if the head-only condition is insufficient.
+- [x] Add generated-prefix replay only if the head-only condition is insufficient.
   Head-only is insufficient; the replay condition is authorized and frozen. Replay
   uses 79 unrestricted hard-cap failures generated from 200 training-split prefixes,
   exact `[0,3,10,30]` tail labels, one replay batch per optimizer group, and no
-  validation/test source records.
-- [ ] Compare natural, syntax-constrained, replay-trained, and decoder-biased
-  behavior without conflating training and inference interventions.
-- [ ] Report length distributions, natural-stop, early-stop, and hard-cap rates plus
-  primary loss, sequence controls, runtime, and memorization.
+  validation/test source records. The one-epoch condition is complete.
+- [x] Compare natural, syntax-constrained, replay-trained, and decoder-biased
+  behavior without conflating training and inference interventions. Replay changes
+  raw behavior intrinsically; strict class-0 decoder bias applies zero steps and is
+  reported separately.
+- [x] Report length distributions, natural-stop, early-stop, and hard-cap rates plus
+  primary loss, sequence controls, runtime, and memorization. Replay reduces hard
+  caps from 37/100 to 19/100 (`p=7.6e-6`) with a 1.31% primary-test NLL regression
+  and no measured training-sequence overlap. Median generated length falls from 207
+  to 147.5 codons, so the result requires an independent training replicate before
+  promotion over the corrected primary.
 
 Exit gate: natural completion improves without forced-stop dependence,
 short-sequence collapse, or material primary-quality regression.
+
+Screening status: passed, but not promoted. Natural completion improves within the
+NLL gate and without forced stopping; the material length shift and poorly calibrated
+auxiliary classes require independent replay replication.
 
 ## Phase 7: Biophysical Shape-Guidance Ablation
 

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -977,6 +977,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     from 200 training-split prefixes across 20 genomes. Added replay cadence and
     replay-specific class weighting so the locked group-average replay contribution
     is 0.2 without replaying a synthetic batch on every native microbatch.
+*   **Termination Replay Evaluation (2026-08-03):** The one-epoch replay condition
+    passed its screening gate: frozen test NLL regressed 1.31% from the primary,
+    while matched unrestricted hard caps fell from 37/100 to 19/100. In 100 paired
+    samples, replay resolved 18 former hard caps with zero reverse transitions
+    (`p=7.6e-6`). No nucleotide/protein alignment or exact-window overlap was
+    reported. Median generated length fell from 207 to 147.5 codons, and the
+    auxiliary head still ignored classes 1-2 while overpredicting class 3. Retain
+    the corrected primary as canonical and require an independent replay-training
+    replicate before promoting this termination-aware variant.
 
 ---
 *End of Log*

--- a/docs/benchmarks/corrected_termination_replay_evaluation.json
+++ b/docs/benchmarks/corrected_termination_replay_evaluation.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": 1,
+  "run_id": "corrected-termination-replay-seed1337",
+  "primary_anchor_run_id": "corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4",
+  "head_only_anchor_run_id": "corrected-termination-head-seed1337",
+  "protocol": {
+    "checkpoint": "best.pt",
+    "frozen_split": "test",
+    "raw_prompts_per_seed": 50,
+    "raw_temperature": 1.0,
+    "raw_topk": 0,
+    "raw_max_new_tokens": 300,
+    "raw_forced_stop": false,
+    "raw_cds_mask": false
+  },
+  "next_token": {
+    "primary_test_nll": 3.666961473787338,
+    "primary_test_ppl": 39.13281893145237,
+    "head_only_test_nll": 3.7071192486363427,
+    "head_only_test_ppl": 40.736286222787754,
+    "replay_test_nll": 3.7151306077767985,
+    "replay_test_ppl": 41.06395000538229,
+    "relative_nll_regression_from_primary": 0.013135980384247164,
+    "relative_nll_regression_from_head_only": 0.0021610740316494468,
+    "passes_max_relative_nll_regression_0_02": true
+  },
+  "termination_head": {
+    "weighted_cross_entropy": 1.4975594048137015,
+    "accuracy": 0.2418229651138007,
+    "balanced_accuracy": 0.39000008106653417,
+    "class_recall": [
+      0.9577106993424985,
+      0.0,
+      0.0,
+      0.7798308204901946,
+      0.21245888549997752
+    ],
+    "interpretation": "Replay shifts predictions toward classes 0 and 3, but classes 1 and 2 remain unused and far-class recall collapses."
+  },
+  "raw_unrestricted": {
+    "seed_1337": {
+      "natural_stop_rate": 0.74,
+      "eos_rate": 0.06,
+      "hard_cap_rate": 0.2,
+      "mean_generated_codons": 151.7,
+      "median_generated_codons": 146.5,
+      "median_naturally_stopped_codons": 109.0,
+      "early_natural_stops_below_30": 6,
+      "mean_gc": 0.5564793878703561
+    },
+    "seed_2027": {
+      "natural_stop_rate": 0.78,
+      "eos_rate": 0.04,
+      "hard_cap_rate": 0.18,
+      "mean_generated_codons": 150.36,
+      "median_generated_codons": 150.0,
+      "median_naturally_stopped_codons": 93.0,
+      "early_natural_stops_below_30": 7,
+      "mean_gc": 0.5698981519603208
+    },
+    "aggregate": {
+      "samples": 100,
+      "natural_stops": 76,
+      "natural_stop_rate": 0.76,
+      "natural_stop_wilson_95": [0.6676766365018553, 0.8330867444305122],
+      "eos_endings": 5,
+      "eos_rate": 0.05,
+      "hard_caps": 19,
+      "hard_cap_rate": 0.19,
+      "hard_cap_wilson_95": [0.12514751509768735, 0.27778845379064376],
+      "median_generated_codons": 147.5,
+      "mean_generated_codons": 151.03,
+      "median_naturally_stopped_codons": 105.5,
+      "early_natural_stops_below_30": 13,
+      "head_only_natural_stop_rate": 0.63,
+      "head_only_hard_cap_rate": 0.37,
+      "head_only_median_generated_codons": 207.0,
+      "head_only_median_naturally_stopped_codons": 122.0
+    },
+    "paired_against_head_only": {
+      "paired_samples": 100,
+      "former_hard_caps_resolved": 18,
+      "former_completions_became_hard_caps": 0,
+      "mcnemar_exact_p": 0.00000762939453125
+    }
+  },
+  "separate_decoder_conditions_seed_1337": {
+    "syntax_constrained": {
+      "terminal_stop_rate": 0.7,
+      "mean_aa_length": 149.06,
+      "hard_cap_rate": 0.0
+    },
+    "strict_class_0_decoder_bias": {
+      "stop_logit_bias": 5.0,
+      "window_codons": 5,
+      "terminal_stop_rate": 0.7,
+      "mean_aa_length": 149.06,
+      "termination_bias_steps_total": 0,
+      "interpretation": "The auxiliary head never predicted class 0 in the target window; guided output equals syntax-constrained output."
+    }
+  },
+  "novelty": {
+    "samples": 100,
+    "reported_nucleotide_hits": 0,
+    "reported_protein_hits": 0,
+    "mean_exact_30nt_coverage": 0.0,
+    "max_exact_30nt_coverage": 0.0,
+    "mean_exact_10aa_coverage": 0.0,
+    "max_exact_10aa_coverage": 0.0
+  },
+  "decision": {
+    "screening_gate_passed": true,
+    "promote_over_primary": false,
+    "reason": "Replay significantly reduces raw hard caps within the NLL gate, but generated median length decreases 28.7 percent and the auxiliary head remains poorly calibrated.",
+    "next_step": "replicate replay training with an independent seed before promotion"
+  }
+}


### PR DESCRIPTION
## Summary
- publish frozen test, termination-class, matched generation, length, and novelty results
- complete Phase 6 while keeping inference interventions separate
- require an independent replay-training replicate before promotion

## Results
- test NLL 3.7151 and PPL 41.06, a 1.31% NLL regression from primary
- natural stops improve from 63/100 to 76/100
- hard caps fall from 37/100 to 19/100
- 18 paired hard caps resolve with zero reverse transitions, exact McNemar p=7.6e-6
- median generated length falls from 207 to 147.5 codons
- no reported nucleotide or protein hits or exact-window coverage
- strict class-0 decoder bias applies zero steps

## Decision
Replay passes screening but is not promoted over the corrected primary. The length shift and poorly calibrated auxiliary head require an independent replay-training replicate.

## Validation
- JSON report validation passed
- focused evaluation tests: 4 passed