### PR TITLE
Prepare corrected multi-offset prior-head ablation

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -179,10 +179,17 @@ support promotion, stability, family, function, or guidance claims.
 
 ## Phase 5: Multi-Offset `n+x` Ablation
 
-- [ ] Predeclare offsets (including whether `n+2` is used), weights, projection-head
+- [x] Predeclare offsets (including whether `n+2` is used), weights, projection-head
   initialization, backbone-freeze/joint-training policy, token budget, and metrics.
-- [ ] State separately whether offset logits are auxiliary training signals or are
+- [x] State separately whether offset logits are auxiliary training signals or are
   consumed by a merged-prior decoder at inference.
+  The first corrected condition uses independent identity-initialized two-layer
+  projection heads at `+2/+4/+8/+16/+32`, equal weights of `0.1`, three frozen-
+  backbone epochs, effective batch 64, and adaptive 10% warmup. These offsets are
+  future-token distances, not direct labels for helices, sheets, or contacts. The
+  main next-token head remains frozen. Prior merging is disabled during training
+  and is evaluated later as a separately labelled decoder condition against raw
+  next-token sampling.
 - [ ] Train matched multi-offset runs from the corrected primary checkpoint without
   changing data splits or the main next-token head.
 - [ ] Report main next-token loss and every offset loss separately; rerun long-range,

--- a/configs/corrected_multi_offset_heads_seed1337.yaml
+++ b/configs/corrected_multi_offset_heads_seed1337.yaml
@@ -1,0 +1,95 @@
+# Phase 5 frozen-backbone multi-offset representation probe.
+dataset_manifest: data/processed/corrected/corrected-codonlm-v1/genome/manifest.json
+itos_path: data/processed/corrected/corrected-codonlm-v1/genome/itos.txt
+train_npz: data/processed/corrected/corrected-codonlm-v1/genome/train_bs512.npz
+val_npz: data/processed/corrected/corrected-codonlm-v1/genome/val_bs512.npz
+test_npz: data/processed/corrected/corrected-codonlm-v1/genome/test_bs512.npz
+
+run_id: corrected-multi-offset-heads-seed1337
+seed: 1337
+dataloader_seed: 1337
+epochs: 3
+max_time_minutes: null
+
+block_size: 512
+vocab_size: 68
+n_layer: 10
+n_head: 8
+n_embd: 384
+dropout: 0.05
+label_smoothing: 0.0
+tie_embeddings: false
+use_sdpa: true
+sep_mask_enabled: true
+n_kv_head: null
+use_rope: false
+use_swiglu: false
+use_shape_guidance: false
+unfreeze_encoder: false
+
+multi_offset_loss_enabled: true
+multi_offset_targets: [2, 4, 8, 16, 32]
+# Equal weights give the independent heads equal effective learning rates.
+multi_offset_weights:
+  2: 0.1
+  4: 0.1
+  8: 0.1
+  16: 0.1
+  32: 0.1
+termination_loss_enabled: false
+replay_loss_enabled: false
+freeze_backbone: true
+eos_loss_weight: 1.0
+
+transfer_from: runs/corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/checkpoints/best.pt
+
+batch_size: 4
+grad_accum_steps: 16
+lr: 0.0001
+lr_embedding: 0.0001
+min_lr: 0.00001
+weight_decay: 0.0
+warmup_fraction: 0.1
+optimizer: adamw
+scheduler: cosine
+early_stop_patience: 0
+max_nonfinite_accumulation_groups: 0
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+save_epochs: false
+
+device: mps
+force_gpu: true
+amp: true
+# The frozen backbone needs no activation recomputation during backward.
+use_checkpoint: false
+use_mmap: true
+bucket_batching: false
+num_workers: 0
+pin_memory: false
+compile: false
+
+out_dir: outputs/checkpoints
+scores_dir: outputs/scores
+
+extension_experiment_contract:
+  schema_version: 1
+  phase: multi_offset_frozen_backbone
+  anchor_run_id: corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4
+  dataset_protocol: frozen_genome_holdout
+  offsets: [2, 4, 8, 16, 32]
+  offset_semantics: future_token_distances_not_structural_labels
+  projection_initialization: two_layer_identity_mlp
+  backbone_policy: frozen
+  primary_next_token_head_policy: frozen
+  token_exposure_epochs: 3
+  training_prior_merge: false
+  inference_conditions:
+    - raw_next_token
+    - multi_offset_prior_guided
+  promotion:
+    require_each_offset_val_loss_improvement: true
+    max_relative_test_nll_regression: 0.0
+    require_no_generation_length_or_termination_regression: true
+    require_runtime_and_memory_report: true
+    require_independent_seed_replication: true

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -986,6 +986,18 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     auxiliary head still ignored classes 1-2 while overpredicting class 3. Retain
     the corrected primary as canonical and require an independent replay-training
     replicate before promoting this termination-aware variant.
+*   **Corrected Multi-Offset Protocol Freeze (2026-08-03):** Started the Phase 5
+    replay of the legacy `n+x` extension from the promoted corrected seed-1337
+    checkpoint and frozen genome split. The first condition trains only independent
+    identity-initialized projection heads for `+2/+4/+8/+16/+32`; the backbone and
+    ordinary next-token head remain frozen. Equal auxiliary weights avoid confounding
+    offset distance with effective learning rate. The offsets are treated as
+    multi-scale future-token probes, not as direct structural labels. Raw decoding
+    remains the control, and any merged-prior decoding is a separate evaluation.
+    A two-minute real-data MPS smoke loaded all 176 anchor tensors exactly, left
+    only the 20 new projection tensors trainable, processed 400 microbatches at
+    about 19.5 sequences/second, reported no nonfinite or aborted accumulation
+    groups, and saved a resumable wall-time checkpoint.
 
 ---
 *End of Log*

--- a/tests/test_corrected_multi_offset_contract.py
+++ b/tests/test_corrected_multi_offset_contract.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _config():
+    return yaml.safe_load(
+        (ROOT / "configs" / "corrected_multi_offset_heads_seed1337.yaml").read_text()
+    )
+
+
+def test_corrected_multi_offset_probe_preserves_anchor_and_split():
+    cfg = _config()
+    contract = cfg["extension_experiment_contract"]
+
+    assert cfg["transfer_from"].endswith(
+        "corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4/checkpoints/best.pt"
+    )
+    assert "corrected/corrected-codonlm-v1/genome" in cfg["dataset_manifest"]
+    assert contract["anchor_run_id"] == (
+        "corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4"
+    )
+    assert contract["dataset_protocol"] == "frozen_genome_holdout"
+
+
+def test_corrected_multi_offset_probe_is_head_only():
+    cfg = _config()
+    contract = cfg["extension_experiment_contract"]
+
+    assert cfg["multi_offset_loss_enabled"] is True
+    assert cfg["multi_offset_targets"] == [2, 4, 8, 16, 32]
+    assert cfg["freeze_backbone"] is True
+    assert cfg["termination_loss_enabled"] is False
+    assert cfg["replay_loss_enabled"] is False
+    assert cfg["use_shape_guidance"] is False
+    assert contract["backbone_policy"] == "frozen"
+    assert contract["primary_next_token_head_policy"] == "frozen"
+    assert contract["training_prior_merge"] is False
+
+
+def test_corrected_multi_offset_probe_does_not_confound_distance_with_weight():
+    cfg = _config()
+    weights = cfg["multi_offset_weights"]
+
+    assert set(weights) == set(cfg["multi_offset_targets"])
+    assert len(set(weights.values())) == 1
+    assert cfg["batch_size"] * cfg["grad_accum_steps"] == 64
+    assert cfg["warmup_fraction"] == 0.1
+    assert cfg["use_checkpoint"] is False


### PR DESCRIPTION
## Summary
- add the frozen-backbone Phase 5 multi-offset configuration at +2/+4/+8/+16/+32
- lock the corrected checkpoint, genome split, equal head weights, adaptive warmup, and promotion gates
- document that offsets are future-token probes and prior-guided decoding is a separate evaluation condition
- add contract tests and record a successful two-minute real-data MPS smoke

## Verification
- pytest -q (337 passed, 1 skipped, 1 xpassed)
- pytest -q tests/test_corrected_multi_offset_contract.py tests/test_long_range_codon_objectives.py tests/test_primary_training_contract.py (31 passed)
- ruff check tests/test_corrected_multi_offset_contract.py
- two-minute MPS smoke: 400 microbatches, ~19.5 seq/s, zero nonfinite/aborted groups, clean wall-time checkpoint

## After merge
Run the three-epoch head-only condition, then evaluate per-offset validation/test loss before enabling merged-prior decoding.