### PR TITLE
Evaluate corrected multi-offset heads

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -183,21 +183,34 @@ support promotion, stability, family, function, or guidance claims.
   initialization, backbone-freeze/joint-training policy, token budget, and metrics.
 - [x] State separately whether offset logits are auxiliary training signals or are
   consumed by a merged-prior decoder at inference.
-  The first corrected condition uses independent identity-initialized two-layer
+  The first corrected condition uses independent two-layer projection heads whose
+  linear matrices are identity-initialized but whose intervening GELU means the
+  complete projection is not initially an identity function. It evaluates
   projection heads at `+2/+4/+8/+16/+32`, equal weights of `0.1`, three frozen-
   backbone epochs, effective batch 64, and adaptive 10% warmup. These offsets are
   future-token distances, not direct labels for helices, sheets, or contacts. The
   main next-token head remains frozen. Prior merging is disabled during training
   and is evaluated later as a separately labelled decoder condition against raw
   next-token sampling.
-- [ ] Train matched multi-offset runs from the corrected primary checkpoint without
+- [x] Train the predeclared head-only multi-offset condition from the corrected primary checkpoint without
   changing data splits or the main next-token head.
-- [ ] Report main next-token loss and every offset loss separately; rerun long-range,
+- [x] Report main next-token loss and every offset loss separately; rerun long-range,
   downstream, termination, runtime, and memory evaluations.
-- [ ] Promote or reject the extension using replicated predeclared gates.
+- [x] Reject merged-prior decoding at the tested weights using matched seeds.
+  The run completed three epochs cleanly. All 176 shared anchor tensors remained
+  bitwise identical, so ordinary logits, hidden-state probes, and downstream
+  embeddings are unchanged by construction. Frozen-test next-token NLL/PPL remained
+  `3.66696`/`39.13`. Offset heads improved NLL only `0.98-1.12%` over the
+  unprojected next-token head, with no decay from `+2` to `+32`. Across 160 matched
+  generations, equal-weight prior merging reduced natural stops from `30.6%` to
+  `6.25%` and increased hard caps from `69.4%` to `93.8%`; it lost 39 control stops,
+  preserved 10, and rescued none. Retain the heads only as exploratory probes and
+  do not promote this merged-prior decoder. A second training seed is unnecessary
+  for rejection but would be required before making a positive representation claim.
 
-Exit gate: a replicated long-range/downstream gain does not materially degrade
-next-token quality, termination, memory, or runtime reliability.
+Exit gate result: failed. Next-token quality was preserved, but the weak,
+distance-flat probe gain did not establish long-range structure and prior-guided
+decoding materially degraded termination.
 
 ## Phase 6: Termination and Replay Ablation
 

--- a/configs/corrected_multi_offset_heads_seed1337.yaml
+++ b/configs/corrected_multi_offset_heads_seed1337.yaml
@@ -79,7 +79,7 @@ extension_experiment_contract:
   dataset_protocol: frozen_genome_holdout
   offsets: [2, 4, 8, 16, 32]
   offset_semantics: future_token_distances_not_structural_labels
-  projection_initialization: two_layer_identity_mlp
+  projection_initialization: identity_weight_matrices_with_gelu
   backbone_policy: frozen
   primary_next_token_head_policy: frozen
   token_exposure_epochs: 3

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -989,7 +989,9 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
 *   **Corrected Multi-Offset Protocol Freeze (2026-08-03):** Started the Phase 5
     replay of the legacy `n+x` extension from the promoted corrected seed-1337
     checkpoint and frozen genome split. The first condition trains only independent
-    identity-initialized projection heads for `+2/+4/+8/+16/+32`; the backbone and
+    projection heads for `+2/+4/+8/+16/+32`; their linear matrices are initialized
+    to identity, but the intervening GELU makes the full mapping non-identity. The
+    backbone and
     ordinary next-token head remain frozen. Equal auxiliary weights avoid confounding
     offset distance with effective learning rate. The offsets are treated as
     multi-scale future-token probes, not as direct structural labels. Raw decoding
@@ -998,6 +1000,17 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     only the 20 new projection tensors trainable, processed 400 microbatches at
     about 19.5 sequences/second, reported no nonfinite or aborted accumulation
     groups, and saved a resumable wall-time checkpoint.
+*   **Corrected Multi-Offset Evaluation (2026-08-04):** The three-epoch head-only
+    run completed cleanly in 9,523.56 seconds. Bitwise comparison found no changes
+    among the 176 shared anchor tensors; only the 20 new projection tensors differ,
+    so ordinary logits and hidden-state/downstream probes remain identical to the
+    corrected base. Frozen-test next-token NLL/PPL stayed `3.66696`/`39.13`.
+    Per-offset heads improved NLL only `0.98-1.12%` over the unprojected token head,
+    nearly flat from `+2` through `+32`, which does not establish distance-specific
+    structural learning. Across 160 matched generations from two seeds, equal-weight
+    prior merging reduced natural stops from `30.6%` to `6.25%` and raised hard caps
+    from `69.4%` to `93.8%`. The tested merged-prior decoder is rejected; retain the
+    heads only as exploratory probes.
 
 ---
 *End of Log*

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -297,7 +297,9 @@ python -m scripts.infer_score_mutations --run_dir runs/<RUN_ID>/checkpoints --se
   - python -m scripts.eval_generation_prefix --run_id <RUN_ID> --ckpt best.pt \
     --device cpu --preset quick --multi_offset_prior \
     --multi_offset_prior_weights '{"2": 0.05, "4": 0.05, "8": 0.05, "16": 0.03, "32": 0.02}'
-  The look-ahead weights bias decoding logits towards target structural features (e.g. helices at $x=4$ and sheets at $x=2$).
+  The look-ahead weights merge future-token logits into the next-token distribution.
+  Offsets are sequence distances, not direct labels for helices, sheets, or contacts;
+  this decoding mode must be evaluated against matched raw and constrained controls.
 
 ### Benchmarking & Evaluation
 

--- a/docs/benchmarks/corrected_multi_offset_heads_evaluation.json
+++ b/docs/benchmarks/corrected_multi_offset_heads_evaluation.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "run_id": "corrected-multi-offset-heads-seed1337",
+  "anchor_run_id": "corrected-codonlm-v1-batch64-lr-ablation-lr_1_5e4",
+  "checkpoint": "best.pt",
+  "decision": "reject_merged_prior_at_tested_weights",
+  "training": {
+    "status": "completed",
+    "best_epoch": 2,
+    "epochs_run": 3,
+    "wall_seconds": 9523.56,
+    "nonfinite_microbatches": 0,
+    "aborted_accumulation_groups": 0,
+    "mps_peak_allocated_bytes": 339024384,
+    "mps_peak_driver_bytes": 1631682560
+  },
+  "base_parameter_invariance": {
+    "shared_tensors": 176,
+    "changed_shared_tensors": 0,
+    "new_projection_tensors": 20,
+    "interpretation": "Ordinary logits and hidden states are identical to the anchor checkpoint."
+  },
+  "frozen_test": {
+    "evaluated_next_tokens": 2228589,
+    "next_token_nll": 3.666961464585187,
+    "next_token_ppl": 39.13281857134626,
+    "offsets": {
+      "2": {"nll": 3.7064676525594678, "ppl": 40.70975126447475, "unprojected_nll": 3.748618687503719, "relative_nll_improvement": 0.01124441786644358},
+      "4": {"nll": 3.7089875012994624, "ppl": 40.81246303461778, "unprojected_nll": 3.746178874718885, "relative_nll_improvement": 0.009927815692520376},
+      "8": {"nll": 3.7088817517228536, "ppl": 40.808147362125794, "unprojected_nll": 3.745664226072312, "relative_nll_improvement": 0.009820013789123972},
+      "16": {"nll": 3.7081326611077396, "ppl": 40.77758980853386, "unprojected_nll": 3.745110253395528, "relative_nll_improvement": 0.009873565739289634},
+      "32": {"nll": 3.708161010884538, "ppl": 40.77874586049015, "unprojected_nll": 3.7469825661712695, "relative_nll_improvement": 0.010360751511688986}
+    },
+    "interpretation": "The small, distance-flat gain is compatible with broad codon-distribution remapping and is not evidence of offset-specific structural learning."
+  },
+  "matched_generation": {
+    "seeds": [1337, 2027],
+    "samples_per_protocol": 160,
+    "temperature": 1.0,
+    "topk": 0,
+    "prior_weights": {"2": 0.1, "4": 0.1, "8": 0.1, "16": 0.1, "32": 0.1},
+    "cds_constrained": {
+      "terminal_stop_rate": 0.30625,
+      "hard_cap_rate": 0.69375,
+      "median_gqs": 28.179905,
+      "mean_generated_codons": 91.30625,
+      "mean_aa_identity": 0.066166
+    },
+    "multi_offset_prior_guided": {
+      "terminal_stop_rate": 0.0625,
+      "hard_cap_rate": 0.9375,
+      "median_gqs": 27.45,
+      "mean_generated_codons": 102.24375,
+      "mean_aa_identity": 0.069789
+    },
+    "paired_transitions": {
+      "control_stop_preserved_by_prior": 10,
+      "control_stop_lost_by_prior": 39,
+      "control_failure_rescued_by_prior": 0,
+      "both_failed": 111
+    },
+    "memorization_audit_seed1337": {
+      "mean_train_overlap_10": 0.0,
+      "mean_train_overlap_20": 0.0
+    }
+  },
+  "limitations": [
+    "Only one auxiliary-head training seed was run.",
+    "Decoder evaluation used a quick held-out prompt set and one predeclared equal-weight setting.",
+    "No claim is made that codon offsets directly label protein secondary structure or contacts."
+  ]
+}

--- a/scripts/evaluate_test.py
+++ b/scripts/evaluate_test.py
@@ -31,6 +31,7 @@ from src.codonlm.evaluation_provenance import (
 from src.codonlm.dataset_manifest import manifest_artifact_path
 from scripts._shared import resolve_run
 from src.codonlm.metrics_io import write_merge_metrics
+from src.codonlm.training.objectives import offset_target_mask
 
 
 def dev() -> torch.device:
@@ -89,14 +90,23 @@ def evaluate(
     loader: DataLoader,
     *,
     label_smoothing: float = 0.0,
-) -> tuple[float, float, float, int]:
+    offset_targets: tuple[int, ...] = (),
+) -> tuple[float, float, float, int, dict[int, dict[str, float | int]]]:
     total_nll = 0.0
     total_objective = 0.0
     total_tokens = 0
+    offset_sums = {
+        offset: {"trained": 0.0, "unprojected": 0.0, "tokens": 0}
+        for offset in offset_targets
+    }
     for xb, yb in loader:
         xb = xb.to(device)
         yb = yb.to(device)
-        logits, _ = model(xb)
+        if offset_targets:
+            logits, _, aux = model(xb, return_aux=True)
+        else:
+            logits, _ = model(xb)
+            aux = {}
         valid = (yb != 0).sum().item()
         if valid == 0:
             continue
@@ -120,10 +130,45 @@ def evaluate(
             ).item()
         )
         total_tokens += valid
+        offset_logits = aux.get("offset_logits", {})
+        for offset in offset_targets:
+            if offset not in offset_logits:
+                continue
+            target = yb[:, offset - 1 :]
+            valid_mask = offset_target_mask(yb, offset)
+            offset_tokens = int(valid_mask.sum().item())
+            if offset_tokens == 0:
+                continue
+            trained = offset_logits[offset][:, : target.shape[1], :][valid_mask]
+            unprojected = logits[:, : target.shape[1], :][valid_mask]
+            offset_sums[offset]["trained"] += float(
+                F.cross_entropy(trained.float(), target[valid_mask], reduction="sum").item()
+            )
+            offset_sums[offset]["unprojected"] += float(
+                F.cross_entropy(unprojected.float(), target[valid_mask], reduction="sum").item()
+            )
+            offset_sums[offset]["tokens"] += offset_tokens
     mean_nll = total_nll / max(1, total_tokens)
     mean_objective = total_objective / max(1, total_tokens)
     ppl = float(math.exp(min(20.0, mean_nll)))
-    return mean_nll, ppl, mean_objective, total_tokens
+    offset_metrics = {}
+    for offset, sums in offset_sums.items():
+        tokens = int(sums["tokens"])
+        if tokens == 0:
+            continue
+        trained_nll = float(sums["trained"]) / tokens
+        unprojected_nll = float(sums["unprojected"]) / tokens
+        improvement = unprojected_nll - trained_nll
+        offset_metrics[offset] = {
+            "nll": trained_nll,
+            "ppl": float(math.exp(min(20.0, trained_nll))),
+            "unprojected_nll": unprojected_nll,
+            "unprojected_ppl": float(math.exp(min(20.0, unprojected_nll))),
+            "nll_improvement": improvement,
+            "relative_nll_improvement": improvement / unprojected_nll,
+            "evaluated_tokens": tokens,
+        }
+    return mean_nll, ppl, mean_objective, total_tokens, offset_metrics
 
 
 def main() -> None:
@@ -221,20 +266,33 @@ def main() -> None:
         batch_size = int(cfg.get("eval_batch_size", 16 if dev().type == "mps" else 64))
     loader = DataLoader(ds, batch_size=batch_size, collate_fn=collate_fn)
     label_smoothing = float(cfg.get("label_smoothing", 0.0))
-    nll, ppl, objective_loss, evaluated_tokens = evaluate(
+    offset_targets = tuple(int(x) for x in cfg.get("multi_offset_targets", []))
+    nll, ppl, objective_loss, evaluated_tokens, offset_metrics = evaluate(
         model,
         dev(),
         loader,
         label_smoothing=label_smoothing,
+        offset_targets=offset_targets,
     )
     print(
         f"[{args.split}] nll={nll:.4f} ppl={ppl:.2f} "
         f"objective={objective_loss:.4f} label_smoothing={label_smoothing:.4f}"
     )
+    for offset, values in sorted(offset_metrics.items()):
+        print(
+            f"[{args.split}] offset=+{offset} nll={values['nll']:.4f} "
+            f"ppl={values['ppl']:.2f} unprojected_nll={values['unprojected_nll']:.4f} "
+            f"relative_improvement={100.0 * values['relative_nll_improvement']:.2f}%"
+        )
 
     metrics_path = run_dir / "scores" / "metrics.json"
     prefix = metric_prefix
 
+    offset_updates = {
+        f"{prefix}_offset_{offset}_{name}": value
+        for offset, values in offset_metrics.items()
+        for name, value in values.items()
+    }
     write_merge_metrics(
         metrics_path,
         {
@@ -244,6 +302,7 @@ def main() -> None:
             f"{prefix}_objective_loss": float(objective_loss),
             f"{prefix}_label_smoothing": label_smoothing,
             f"{prefix}_evaluated_tokens": int(evaluated_tokens),
+            **offset_updates,
             f"{prefix}_evaluation_provenance": {
                 "schema_version": 2,
                 "loss_definition": {

--- a/tests/test_evaluation_provenance.py
+++ b/tests/test_evaluation_provenance.py
@@ -7,7 +7,9 @@ import numpy as np
 import pytest
 import torch
 import yaml
+from torch.utils.data import DataLoader, TensorDataset
 
+from scripts.evaluate_test import evaluate
 from scripts.training_preflight import _write_fixture
 from scripts.audit_generated_sequences import _read_manifest_training
 from src.codonlm.dataset_manifest import artifact_entry, finalize_manifest
@@ -18,6 +20,35 @@ from src.codonlm.evaluation_provenance import (
     bind_dataset_manifest,
 )
 from src.codonlm.model_tiny_gpt import TinyGPT
+
+
+def test_test_evaluator_reports_multi_offset_unprojected_baseline():
+    model = TinyGPT(
+        vocab_size=8,
+        block_size=6,
+        n_layer=1,
+        n_head=1,
+        n_embd=8,
+        dropout=0.0,
+        multi_offset_targets=[2, 4],
+    ).eval()
+    x = torch.tensor([[1, 4, 5, 6, 7, 2]])
+    y = torch.tensor([[4, 5, 6, 7, 2, 0]])
+
+    _, _, _, _, offsets = evaluate(
+        model,
+        torch.device("cpu"),
+        DataLoader(TensorDataset(x, y), batch_size=1),
+        offset_targets=(2, 4),
+    )
+
+    assert set(offsets) == {2, 4}
+    assert offsets[2]["evaluated_tokens"] > offsets[4]["evaluated_tokens"]
+    assert offsets[2]["unprojected_nll"] > 0.0
+    assert offsets[4]["unprojected_ppl"] > 0.0
+    assert offsets[2]["relative_nll_improvement"] == pytest.approx(
+        offsets[2]["nll_improvement"] / offsets[2]["unprojected_nll"]
+    )
 
 
 def _corrected_run(tmp_path: Path):


### PR DESCRIPTION
## Summary
- extend frozen-test evaluation with per-offset NLL/PPL and an unprojected-head comparator
- correct the legacy claim that identity-initialized matrices make the GELU MLP an identity mapping
- report the completed three-epoch corrected head-only run and two-seed matched decoder evaluation
- reject equal-weight merged-prior decoding because it materially worsens natural termination

## Results
- ordinary test NLL/PPL unchanged at 3.66696 / 39.13
- all 176 shared anchor tensors are bitwise unchanged; only 20 offset-head tensors are new
- offset heads improve NLL only 0.98-1.12% over unprojected logits, nearly flat from +2 to +32
- across 160 paired generations, natural stops fall 30.6% -> 6.25% and hard caps rise 69.4% -> 93.8%

## Verification
- pytest -q: 338 passed, 1 skipped, 1 xpassed
- ruff check scripts/evaluate_test.py tests/test_evaluation_provenance.py
- full manifest-bound MPS test evaluation
- matched quick generation at seeds 1337 and 2027