### PR TITLE
Build corrected ProteinCritic dataset

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -159,12 +159,19 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
 
 ## Phase 4: Revalidate the External ProteinCritic
 
-- [ ] Select and freeze one critic architecture rather than mixing historical
+- [x] Select and freeze one critic architecture rather than mixing historical
   average-pooled, structural-transfer, and bidirectional variants.
-- [ ] Freeze protein sources, label definitions, task vocabularies, preprocessing,
+- [x] Freeze protein sources, label definitions, task vocabularies, preprocessing,
   and train/validation/test artifacts with exact provenance.
-- [ ] Split translated proteins by sequence-homology clusters and report label/class
+- [x] Split translated proteins by sequence-homology clusters and report label/class
   balance, missing classes, cluster thresholds, and cross-split nearest neighbors.
+  Corrected critic v1 uses a from-scratch bidirectional 8L8H-d256 backbone with
+  attention pooling and no motif-saliency regularizer or legacy checkpoint transfer.
+  MMseqs2 clustering at 30% identity and 80% coverage produced 14,689 disjoint
+  clusters over 34,705 records. Supported targets are 43 first-domain Pfam classes,
+  seven top-level EC classes, and continuous MegaScale `deltaG`. Stability has eight
+  train, one validation, and one test scaffold cluster, so it is a limited
+  scaffold-held-out regression rather than a universal stability probability.
 - [ ] Retrain Pfam-family, EC-function, stability, and declared structural/protein-
   type heads under the corrected split; do not initialize from a holdout-exposed
   critic unless the transfer protocol proves compatibility and isolation.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1011,6 +1011,17 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     prior merging reduced natural stops from `30.6%` to `6.25%` and raised hard caps
     from `69.4%` to `93.8%`. The tested merged-prior decoder is rejected; retain the
     heads only as exploratory probes.
+*   **Corrected ProteinCritic Dataset Freeze (2026-08-04):** Replaced the legacy
+    random 90/10 critic split and sparse 2,000-Pfam/1,000-EC targets with a
+    provenance-bound MMseqs2 cluster split. At 30% identity and 80% coverage, the
+    local build contains 34,705 records in 14,689 clusters with zero cross-split
+    clusters. Post-split support gates retain 43 first-domain Pfam classes and all
+    seven top-level EC classes. MegaScale stability remains continuous `deltaG`
+    rather than an arbitrary binary threshold, with eight training, one validation,
+    and one test scaffold cluster. Frozen architecture: from-scratch bidirectional
+    8L8H-d256, attention pooling, no legacy transfer, and no hand-selected motif
+    saliency regularizer. Trainer regression/calibration support is still required
+    before training this critic.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -125,6 +125,27 @@ python -m scripts.evaluate_test \
 
 ---
 
+## Corrected ProteinCritic Dataset
+
+Build the homology-cluster-held-out critic artifacts before critic training:
+
+```bash
+caffeinate -i python -m scripts.build_corrected_protein_critic_dataset \
+  --protein-records data/processed/protein_pfam_labels.json \
+  --annotation-metadata data/processed/uniprot_metadata_full.csv \
+  --stability-csv data/raw/stability/dG_extdG_data_Fig1.csv \
+  --out-dir data/processed/protein_lm/corrected-v1-task-balanced \
+  --threads 2
+```
+
+The builder requires MMseqs2, clusters all sources together, assigns whole clusters
+to one split, reserves stability clusters in every split, filters Pfam/EC labels by
+post-split support, and writes `manifest.json` with input, tool, threshold, split,
+and artifact hashes. Do not train the legacy critic configuration on these files:
+continuous `stability_score` requires the corrected regression-aware trainer.
+
+---
+
 ## 3. Synonymous and Shuffling Controls
 
 ### The Golden Rule

--- a/docs/benchmarks/corrected_protein_critic_dataset_v1.json
+++ b/docs/benchmarks/corrected_protein_critic_dataset_v1.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "dataset_id": "corrected-protein-critic-v1",
+  "status": "built_locally_reproducible_not_yet_trained",
+  "protocol": "mmseqs_cluster_held_out_multitask_protein_critic",
+  "clustering": {
+    "tool": "MMseqs2 18-8cc5c",
+    "minimum_sequence_identity": 0.3,
+    "minimum_coverage": 0.8,
+    "coverage_mode": 0,
+    "clusters": 14689,
+    "cross_split_clusters": 0
+  },
+  "records": {
+    "total": 34705,
+    "train": 27764,
+    "validation": 3471,
+    "test": 3470,
+    "exact_label_conflicts_quarantined": 0
+  },
+  "tasks": {
+    "pfam_first_domain": {
+      "eligible_classes": 43,
+      "labeled_train": 4204,
+      "labeled_validation": 447,
+      "labeled_test": 473
+    },
+    "ec_top_level": {
+      "eligible_classes": 7,
+      "labeled_train": 8551,
+      "labeled_validation": 523,
+      "labeled_test": 517
+    },
+    "megascale_delta_g": {
+      "target_type": "continuous_regression",
+      "units": "kcal/mol",
+      "train_records": 1122,
+      "validation_records": 80,
+      "test_records": 62,
+      "train_clusters": 8,
+      "validation_clusters": 1,
+      "test_clusters": 1
+    }
+  },
+  "artifact_sha256": {
+    "train": "f872a520d3a87e12c9fe5fd56c6ebcc39f95eef60dcda3135bb1837315b03184",
+    "validation": "6af25dbb095c611e5d2183a24a3e06509fd70cc69f33b92abedcdbf43d9507b4",
+    "test": "1aa2f09321cfae6dcdea3988258e6fd1f5ba9730136d2e2373207e9064e88e51",
+    "task_vocabs": "f167bd57a0a7265ffd737a7efe7fd4a4b68ba9c49351b6456fd9e4958c09c0ae"
+  },
+  "architecture_freeze": {
+    "backbone": "bidirectional_transformer",
+    "layers": 8,
+    "heads": 8,
+    "embedding_dimension": 256,
+    "pooling": "attention",
+    "initialization": "from_scratch",
+    "legacy_checkpoint_transfer": false,
+    "saliency_motif_regularizer": false
+  },
+  "limitations": [
+    "Pfam is represented by the first annotated domain and is a closed-set classification task.",
+    "EC uses only the top-level catalytic class and does not establish exact enzyme function.",
+    "Stability contains ten scaffold groups, so held-out regression uncertainty will be large.",
+    "The dataset has been built locally but no corrected critic checkpoint exists yet."
+  ]
+}

--- a/scripts/build_corrected_protein_critic_dataset.py
+++ b/scripts/build_corrected_protein_critic_dataset.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Build a provenance-bound, protein-cluster-held-out ProteinCritic dataset."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from src.protein_lm.corrected_dataset import (
+    assign_clusters,
+    eligible_labels,
+    group_by_sequence,
+    normalize_protein,
+    split_report,
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_annotation_records(proteins_path: Path, metadata_path: Path) -> list[dict]:
+    proteins = json.loads(proteins_path.read_text())
+    metadata = {}
+    with metadata_path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            metadata.setdefault(str(row.get("ncbi_id", "")).strip(), row)
+
+    records = []
+    for protein_id, payload in proteins.items():
+        row = metadata.get(protein_id)
+        if row is None:
+            continue
+        try:
+            sequence = normalize_protein(payload.get("sequence", ""))
+        except ValueError:
+            continue
+        pfam_values = [value.strip() for value in str(row.get("pfam", "")).split(";") if value.strip()]
+        ec = str(row.get("ec", "")).strip()
+        ec_label = int(ec[0]) if ec and ec[0].isdigit() and 1 <= int(ec[0]) <= 7 else None
+        pfam_label = pfam_values[0] if pfam_values else None
+        if pfam_label is None and ec_label is None:
+            continue
+        records.append(
+            {
+                "sequence": sequence,
+                "source": "genome_uniprot_annotation",
+                "source_ids": [protein_id],
+                "pfam_label": pfam_label,
+                "ec_label": ec_label,
+                "stability_score": None,
+            }
+        )
+    return records
+
+
+def load_stability_records(path: Path) -> list[dict]:
+    records = []
+    with path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            try:
+                sequence = normalize_protein(row.get("aa_seq", ""))
+                score = float(row["deltaG"])
+            except (ValueError, KeyError):
+                continue
+            records.append(
+                {
+                    "sequence": sequence,
+                    "source": "megascale_delta_g",
+                    "source_ids": [str(row.get("name", ""))],
+                    "pfam_label": None,
+                    "ec_label": None,
+                    "stability_score": score,
+                }
+            )
+    return records
+
+
+def cluster_records(records: list[dict], work_dir: Path, args) -> dict:
+    executable = shutil.which(args.mmseqs_executable)
+    if executable is None:
+        raise RuntimeError(f"MMseqs2 executable not found: {args.mmseqs_executable}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    fasta = work_dir / "proteins.fasta"
+    with fasta.open("w") as handle:
+        for index, record in enumerate(records):
+            key = f"record-{index}"
+            record["cluster_key"] = key
+            handle.write(f">{key}\n{record['sequence']}\n")
+    prefix = work_dir / "clusters"
+    command = [
+        executable,
+        "easy-cluster",
+        str(fasta),
+        str(prefix),
+        str(work_dir / "tmp"),
+        "--min-seq-id", str(args.min_sequence_identity),
+        "-c", str(args.min_coverage),
+        "--cov-mode", "0",
+        "--cluster-mode", "0",
+        "--threads", str(args.threads),
+    ]
+    version = subprocess.run([executable, "version"], check=True, capture_output=True, text=True)
+    subprocess.run(command, check=True, capture_output=True, text=True)
+    assignments = {}
+    cluster_path = Path(f"{prefix}_cluster.tsv")
+    with cluster_path.open() as handle:
+        for line in handle:
+            representative, member = line.rstrip("\n").split("\t")[:2]
+            assignments[member] = representative
+    missing = [record["cluster_key"] for record in records if record["cluster_key"] not in assignments]
+    if missing:
+        raise RuntimeError(f"MMseqs2 omitted {len(missing)} records")
+    for record in records:
+        record["protein_cluster"] = assignments[record["cluster_key"]]
+    return {
+        "tool": {"executable": executable, "version": (version.stdout or version.stderr).strip()},
+        "command": command,
+        "thresholds": {
+            "minimum_sequence_identity": args.min_sequence_identity,
+            "minimum_coverage": args.min_coverage,
+            "coverage_mode": 0,
+        },
+        "protein_fasta_sha256": sha256(fasta),
+        "cluster_assignments_sha256": sha256(cluster_path),
+        "cluster_count": len(set(assignments.values())),
+    }
+
+
+def write_jsonl(path: Path, records: list[dict], pfam_vocab: dict, ec_vocab: dict) -> None:
+    with path.open("w") as handle:
+        for record in records:
+            output = {
+                "record_id": record["record_id"],
+                "sequence": record["sequence"],
+                "source": record["source"],
+                "source_ids": record["source_ids"],
+                "protein_cluster": record["protein_cluster"],
+                "pfam_id": pfam_vocab.get(record.get("pfam_label"), -1),
+                "ec_id": ec_vocab.get(record.get("ec_label"), -1),
+                "stability_score": record.get("stability_score"),
+            }
+            handle.write(json.dumps(output, sort_keys=True) + "\n")
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protein-records", type=Path, required=True)
+    parser.add_argument("--annotation-metadata", type=Path, required=True)
+    parser.add_argument("--stability-csv", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--mmseqs-executable", default="mmseqs")
+    parser.add_argument("--min-sequence-identity", type=float, default=0.3)
+    parser.add_argument("--min-coverage", type=float, default=0.8)
+    parser.add_argument("--threads", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--min-train-per-class", type=int, default=20)
+    parser.add_argument("--min-validation-per-class", type=int, default=5)
+    parser.add_argument("--min-test-per-class", type=int, default=5)
+    args = parser.parse_args(argv)
+
+    raw_records = load_annotation_records(args.protein_records, args.annotation_metadata)
+    raw_records.extend(load_stability_records(args.stability_csv))
+    records, quarantined = group_by_sequence(raw_records)
+    if not records:
+        raise ValueError("no valid ProteinCritic records")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    clustering = cluster_records(records, args.out_dir / "clustering", args)
+    assignments = assign_clusters(
+        records,
+        seed=args.seed,
+        required_task_keys=("stability_score",),
+    )
+    for record in records:
+        record["split"] = assignments[record["protein_cluster"]]
+
+    minimums = {
+        "train": args.min_train_per_class,
+        "validation": args.min_validation_per_class,
+        "test": args.min_test_per_class,
+    }
+    pfam_labels = sorted(eligible_labels(records, "pfam_label", minimums))
+    ec_labels = sorted(eligible_labels(records, "ec_label", minimums))
+    pfam_vocab = {label: index for index, label in enumerate(pfam_labels)}
+    ec_vocab = {str(label): index for index, label in enumerate(ec_labels)}
+    ec_lookup = {label: index for index, label in enumerate(ec_labels)}
+    if len(pfam_vocab) < 2 or len(ec_vocab) < 2:
+        raise ValueError("fewer than two supported Pfam or EC classes survive the held-out split")
+
+    report = split_report(records, ("pfam_label", "ec_label"))
+    if report["cross_split_clusters"]:
+        raise AssertionError("protein clusters cross train/validation/test splits")
+    artifacts = {}
+    for split in ("train", "validation", "test"):
+        path = args.out_dir / f"{split}.jsonl"
+        write_jsonl(path, [record for record in records if record["split"] == split], pfam_vocab, ec_lookup)
+        artifacts[split] = {"path": str(path.resolve()), "sha256": sha256(path)}
+    vocab_path = args.out_dir / "task_vocabs.json"
+    vocab_path.write_text(json.dumps({
+        "pfam": pfam_vocab,
+        "ec": ec_vocab,
+        "stability": {"type": "regression", "target": "deltaG", "units": "kcal/mol"},
+    }, indent=2, sort_keys=True) + "\n")
+    artifacts["task_vocabs"] = {"path": str(vocab_path.resolve()), "sha256": sha256(vocab_path)}
+    manifest = {
+        "schema_version": 1,
+        "protocol": "mmseqs_cluster_held_out_multitask_protein_critic",
+        "seed": args.seed,
+        "inputs": {
+            "protein_records": {"path": str(args.protein_records.resolve()), "sha256": sha256(args.protein_records)},
+            "annotation_metadata": {"path": str(args.annotation_metadata.resolve()), "sha256": sha256(args.annotation_metadata)},
+            "stability_csv": {"path": str(args.stability_csv.resolve()), "sha256": sha256(args.stability_csv)},
+        },
+        "clustering": clustering,
+        "exact_sequence_conflicts_quarantined": len(quarantined),
+        "eligible_classes": {"pfam": pfam_labels, "ec_top_level": ec_labels},
+        "minimum_class_support": minimums,
+        "splits": report,
+        "artifacts": artifacts,
+    }
+    manifest_path = args.out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(
+        f"[critic-data] records={len(records)} clusters={clustering['cluster_count']} "
+        f"pfam_classes={len(pfam_vocab)} ec_classes={len(ec_vocab)} out={args.out_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/protein_lm/corrected_dataset.py
+++ b/src/protein_lm/corrected_dataset.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import hashlib
+import random
+from collections import Counter, defaultdict
+
+
+SPLIT_FRACTIONS = {"train": 0.8, "validation": 0.1, "test": 0.1}
+
+
+def sequence_sha256(sequence: str) -> str:
+    return hashlib.sha256(sequence.encode("ascii")).hexdigest()
+
+
+def normalize_protein(sequence: str) -> str:
+    normalized = "".join(str(sequence).upper().split()).rstrip("*")
+    if not normalized or any(residue not in "ACDEFGHIKLMNPQRSTVWY" for residue in normalized):
+        raise ValueError("protein sequence contains empty, ambiguous, or non-amino-acid symbols")
+    return normalized
+
+
+def assign_clusters(
+    records: list[dict],
+    *,
+    seed: int,
+    fractions: dict[str, float] | None = None,
+    required_task_keys: tuple[str, ...] = (),
+) -> dict[str, str]:
+    fractions = fractions or SPLIT_FRACTIONS
+    if set(fractions) != {"train", "validation", "test"}:
+        raise ValueError("fractions must define train, validation, and test")
+    if abs(sum(fractions.values()) - 1.0) > 1e-9:
+        raise ValueError("split fractions must sum to one")
+
+    cluster_sizes = Counter(record["protein_cluster"] for record in records)
+    rng = random.Random(seed)
+    tie_breakers = {cluster: rng.random() for cluster in cluster_sizes}
+    # Place large homology groups first so one large family cannot accidentally
+    # consume an entire validation or test split late in the assignment.
+    clusters = sorted(
+        cluster_sizes,
+        key=lambda cluster: (-cluster_sizes[cluster], tie_breakers[cluster], cluster),
+    )
+    targets = {split: len(records) * fraction for split, fraction in fractions.items()}
+    assigned_counts = {split: 0 for split in fractions}
+    assignments = {}
+    for key in required_task_keys:
+        task_cluster_set = {
+            record["protein_cluster"]
+            for record in records
+            if record.get(key) is not None
+        }
+        task_clusters = [
+            cluster
+            for cluster in clusters
+            if cluster in task_cluster_set
+        ]
+        if len(task_clusters) < 3:
+            raise ValueError(f"task {key} has fewer than three protein clusters")
+        for cluster, split in zip(task_clusters[:3], ("train", "validation", "test")):
+            existing = assignments.get(cluster)
+            if existing is not None and existing != split:
+                raise ValueError(f"task coverage constraints conflict for cluster {cluster}")
+            assignments[cluster] = split
+            assigned_counts[split] += cluster_sizes[cluster]
+    for cluster in clusters:
+        if cluster in assignments:
+            continue
+        split = max(
+            fractions,
+            key=lambda name: (
+                targets[name] - assigned_counts[name],
+                fractions[name],
+                name,
+            ),
+        )
+        assignments[cluster] = split
+        assigned_counts[split] += cluster_sizes[cluster]
+    return assignments
+
+
+def eligible_labels(
+    records: list[dict],
+    label_key: str,
+    minimums: dict[str, int],
+) -> set[str | int]:
+    counts = {
+        split: Counter(
+            record.get(label_key)
+            for record in records
+            if record["split"] == split and record.get(label_key) is not None
+        )
+        for split in minimums
+    }
+    labels = set.intersection(*(set(counter) for counter in counts.values()))
+    return {
+        label
+        for label in labels
+        if all(counts[split][label] >= minimums[split] for split in minimums)
+    }
+
+
+def split_report(records: list[dict], label_keys: tuple[str, ...]) -> dict:
+    report = {}
+    for split in ("train", "validation", "test"):
+        members = [record for record in records if record["split"] == split]
+        report[split] = {
+            "records": len(members),
+            "clusters": len({record["protein_cluster"] for record in members}),
+            "sources": dict(sorted(Counter(record["source"] for record in members).items())),
+            "labels": {
+                key: dict(
+                    sorted(
+                        Counter(
+                            str(record[key])
+                            for record in members
+                            if record.get(key) is not None
+                        ).items()
+                    )
+                )
+                for key in label_keys
+            },
+        }
+    split_clusters = {
+        split: {
+            record["protein_cluster"]
+            for record in records
+            if record["split"] == split
+        }
+        for split in report
+    }
+    crossing = set()
+    for left, right in (("train", "validation"), ("train", "test"), ("validation", "test")):
+        crossing.update(split_clusters[left] & split_clusters[right])
+    report["cross_split_clusters"] = sorted(crossing)
+    return report
+
+
+def group_by_sequence(records: list[dict]) -> tuple[list[dict], list[dict]]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for record in records:
+        grouped[record["sequence"]].append(record)
+
+    merged, quarantined = [], []
+    for sequence, members in grouped.items():
+        combined = {
+            "record_id": sequence_sha256(sequence),
+            "sequence": sequence,
+            "source": "+".join(sorted({member["source"] for member in members})),
+            "source_ids": sorted({source_id for member in members for source_id in member["source_ids"]}),
+        }
+        conflict = False
+        for key in ("pfam_label", "ec_label"):
+            values = {member.get(key) for member in members if member.get(key) is not None}
+            if len(values) > 1:
+                conflict = True
+            combined[key] = next(iter(values)) if len(values) == 1 else None
+        stability = [float(member["stability_score"]) for member in members if member.get("stability_score") is not None]
+        if stability and max(stability) - min(stability) > 1e-6:
+            conflict = True
+        combined["stability_score"] = stability[0] if stability else None
+        if conflict:
+            quarantined.append({"sequence_sha256": combined["record_id"], "source_ids": combined["source_ids"]})
+        else:
+            merged.append(combined)
+    return merged, quarantined

--- a/tests/test_corrected_protein_critic_dataset.py
+++ b/tests/test_corrected_protein_critic_dataset.py
@@ -1,0 +1,94 @@
+import pytest
+
+from src.protein_lm.corrected_dataset import (
+    assign_clusters,
+    eligible_labels,
+    group_by_sequence,
+    normalize_protein,
+    split_report,
+)
+
+
+def test_normalize_protein_rejects_ambiguous_residues():
+    assert normalize_protein(" acd ef* ") == "ACDEF"
+    with pytest.raises(ValueError):
+        normalize_protein("ACDX")
+
+
+def test_cluster_assignment_is_deterministic_and_disjoint():
+    records = [
+        {"protein_cluster": f"c{index // 2}", "source": "fixture"}
+        for index in range(60)
+    ]
+    first = assign_clusters(records, seed=1337)
+    second = assign_clusters(records, seed=1337)
+    assert first == second
+    for record in records:
+        record["split"] = first[record["protein_cluster"]]
+    report = split_report(records, ())
+    assert report["cross_split_clusters"] == []
+    assert all(report[split]["records"] > 0 for split in ("train", "validation", "test"))
+
+
+def test_large_cluster_is_assigned_before_small_split_can_be_consumed():
+    records = [
+        *({"protein_cluster": "large", "source": "fixture"} for _ in range(60)),
+        *(
+            {"protein_cluster": f"small-{index}", "source": "fixture"}
+            for index in range(40)
+        ),
+    ]
+    assignments = assign_clusters(records, seed=1337)
+    assert assignments["large"] == "train"
+
+
+def test_required_task_clusters_seed_all_three_splits():
+    records = [
+        *(
+            {"protein_cluster": "stability-large", "source": "fixture", "score": 1.0}
+            for _ in range(20)
+        ),
+        {"protein_cluster": "stability-medium", "source": "fixture", "score": 2.0},
+        {"protein_cluster": "stability-small", "source": "fixture", "score": 3.0},
+        *(
+            {"protein_cluster": f"other-{index}", "source": "fixture", "score": None}
+            for index in range(30)
+        ),
+    ]
+    assignments = assign_clusters(records, seed=1337, required_task_keys=("score",))
+    task_splits = {
+        assignments[record["protein_cluster"]]
+        for record in records
+        if record["score"] is not None
+    }
+    assert task_splits == {"train", "validation", "test"}
+
+
+def test_eligible_labels_requires_support_in_every_split():
+    records = []
+    for split, count in (("train", 4), ("validation", 2), ("test", 2)):
+        records.extend({"split": split, "label": "kept"} for _ in range(count))
+    records.extend({"split": "train", "label": "train-only"} for _ in range(10))
+    assert eligible_labels(
+        records,
+        "label",
+        {"train": 4, "validation": 2, "test": 2},
+    ) == {"kept"}
+
+
+def test_exact_sequence_label_conflicts_are_quarantined():
+    base = {
+        "sequence": "ACDE",
+        "source": "fixture",
+        "source_ids": ["a"],
+        "ec_label": 1,
+        "stability_score": None,
+    }
+    merged, quarantined = group_by_sequence(
+        [
+            {**base, "pfam_label": "PF1"},
+            {**base, "source_ids": ["b"], "pfam_label": "PF2"},
+        ]
+    )
+    assert merged == []
+    assert quarantined[0]["source_ids"] == ["a", "b"]


### PR DESCRIPTION
## Summary
- add a reproducible MMseqs2 cluster-held-out ProteinCritic dataset builder
- quarantine exact-sequence label conflicts and enforce task coverage across train/validation/test
- replace sparse exact EC targets with seven top-level EC classes and retain only post-split-supported Pfam classes
- preserve MegaScale deltaG as a continuous regression target instead of an arbitrary binary label
- freeze one from-scratch 8L8H-d256 bidirectional attention-pooled architecture and document artifact hashes

## Local build
- 34,705 records in 14,689 protein clusters
- zero cross-split clusters
- 43 supported Pfam classes and 7 EC classes
- stability: 1,122/80/62 records across 8/1/1 train/validation/test clusters

## Verification
- pytest -q: 344 passed, 1 skipped, 1 xpassed
- ruff check on new builder/helpers/tests
- real MMseqs2 18-8cc5c build at 30% identity and 80% coverage
- recorded artifact SHA-256 values verified with shasum

## Follow-up
The next PR will add continuous-regression/task-balanced training, corrected accumulation, calibration hooks, and manifest-bound critic checkpoints. No corrected critic has been trained yet.