### PR TITLE
Prepare corrected ProteinCritic training

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -167,14 +167,17 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
   balance, missing classes, cluster thresholds, and cross-split nearest neighbors.
   Corrected critic v1 uses a from-scratch bidirectional 8L8H-d256 backbone with
   attention pooling and no motif-saliency regularizer or legacy checkpoint transfer.
-  MMseqs2 clustering at 30% identity and 80% coverage produced 14,689 disjoint
-  clusters over 34,705 records. Supported targets are 43 first-domain Pfam classes,
+  MMseqs2 clustering at 30% identity and 80% coverage produced 14,689 source
+  clusters. After removing records without a retained target, v2 contains 15,054
+  records in 5,149 disjoint retained clusters. Supported targets are 43 first-domain Pfam classes,
   seven top-level EC classes, and continuous MegaScale `deltaG`. Stability has eight
   train, one validation, and one test scaffold cluster, so it is a limited
   scaffold-held-out regression rather than a universal stability probability.
 - [ ] Retrain Pfam-family, EC-function, stability, and declared structural/protein-
   type heads under the corrected split; do not initialize from a holdout-exposed
   critic unless the transfer protocol proves compatibility and isolation.
+  The regression-aware, manifest-bound trainer and evaluator are implemented. The
+  remaining task is the full corrected training and held-out evaluation run.
 - [ ] Calibrate every probability-producing head and report class-aware metrics,
   confidence intervals, reliability, and generated-protein OOD behavior.
 - [ ] Version the passing critic checkpoint and bind it to its dataset, labels,

--- a/configs/corrected_protein_critic_v1.yaml
+++ b/configs/corrected_protein_critic_v1.yaml
@@ -1,0 +1,39 @@
+critic_training_contract:
+  schema_version: 1
+  dataset_id: corrected-protein-critic-v2
+  role: corrected_external_critic
+
+dataset_manifest: data/processed/protein_lm/corrected-v2/manifest.json
+train_data: data/processed/protein_lm/corrected-v2/train.jsonl
+val_data: data/processed/protein_lm/corrected-v2/validation.jsonl
+test_data: data/processed/protein_lm/corrected-v2/test.jsonl
+task_vocabs: data/processed/protein_lm/corrected-v2/task_vocabs.json
+
+run_id: corrected-protein-critic-v1-seed1337
+seed: 1337
+device: mps
+
+block_size: 512
+n_layer: 8
+n_head: 8
+n_embd: 256
+dropout: 0.1
+bidirectional: true
+pooling: attention
+use_checkpoint: false
+transfer_from: null
+saliency_regularizer_weight: 0.0
+
+regression_tasks:
+  - stability
+multi_label_tasks: []
+
+batch_size: 8
+grad_accum_steps: 8
+epochs: 10
+lr: 0.0001
+dynamic_padding: true
+log_every_steps: 100
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+max_time_minutes: null

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1022,6 +1022,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     8L8H-d256, attention pooling, no legacy transfer, and no hand-selected motif
     saliency regularizer. Trainer regression/calibration support is still required
     before training this critic.
+*   **Corrected ProteinCritic Trainer (2026-08-04):** Prepared the frozen critic
+    for training with manifest and SHA-256 verification, checkpoint-bound dataset/
+    architecture provenance, deterministic epoch-varying bucket order, correctly
+    scaled partial gradient accumulation, resumable mid-epoch wall-time checkpoints,
+    task-balanced supervised losses, and continuous MegaScale `deltaG` Smooth-L1
+    regression. The evaluator now reports stability MAE/RMSE/Pearson/Spearman and
+    a held-out median baseline. Dataset v2 removes targetless records after class
+    gates, reducing the trainable corpus from 34,705 to 15,054 records without
+    changing the frozen source clustering or retained labels.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -134,15 +134,24 @@ caffeinate -i python -m scripts.build_corrected_protein_critic_dataset \
   --protein-records data/processed/protein_pfam_labels.json \
   --annotation-metadata data/processed/uniprot_metadata_full.csv \
   --stability-csv data/raw/stability/dG_extdG_data_Fig1.csv \
-  --out-dir data/processed/protein_lm/corrected-v1-task-balanced \
+  --out-dir data/processed/protein_lm/corrected-v2 \
   --threads 2
 ```
 
 The builder requires MMseqs2, clusters all sources together, assigns whole clusters
 to one split, reserves stability clusters in every split, filters Pfam/EC labels by
 post-split support, and writes `manifest.json` with input, tool, threshold, split,
-and artifact hashes. Do not train the legacy critic configuration on these files:
-continuous `stability_score` requires the corrected regression-aware trainer.
+and artifact hashes. Records without any retained Pfam, EC, or stability target are
+discarded after the support gates. Train the corrected critic with:
+
+```bash
+caffeinate -i python -m src.protein_lm.train_multi_task \
+  --config configs/corrected_protein_critic_v1.yaml
+```
+
+The trainer verifies every dataset artifact against the manifest before training,
+treats `stability_score` as continuous regression, and stores the dataset provenance
+and model specification in each checkpoint.
 
 ---
 

--- a/docs/benchmarks/corrected_protein_critic_dataset_v2.json
+++ b/docs/benchmarks/corrected_protein_critic_dataset_v2.json
@@ -1,36 +1,31 @@
 {
   "schema_version": 1,
-  "dataset_id": "corrected-protein-critic-v1",
+  "dataset_id": "corrected-protein-critic-v2",
   "status": "built_locally_reproducible_not_yet_trained",
-  "superseded_by": "corrected-protein-critic-v2",
   "protocol": "mmseqs_cluster_held_out_multitask_protein_critic",
+  "change_from_v1": "Records without a retained Pfam, EC, or stability target are excluded after class-support gates.",
   "clustering": {
     "tool": "MMseqs2 18-8cc5c",
     "minimum_sequence_identity": 0.3,
     "minimum_coverage": 0.8,
     "coverage_mode": 0,
-    "clusters": 14689,
+    "source_clusters": 14689,
+    "retained_clusters": 5149,
     "cross_split_clusters": 0
   },
   "records": {
-    "total": 34705,
-    "train": 27764,
-    "validation": 3471,
-    "test": 3470,
+    "total": 15054,
+    "train": 13071,
+    "validation": 992,
+    "test": 991,
     "exact_label_conflicts_quarantined": 0
   },
   "tasks": {
     "pfam_first_domain": {
-      "eligible_classes": 43,
-      "labeled_train": 4204,
-      "labeled_validation": 447,
-      "labeled_test": 473
+      "eligible_classes": 43
     },
     "ec_top_level": {
-      "eligible_classes": 7,
-      "labeled_train": 8551,
-      "labeled_validation": 523,
-      "labeled_test": 517
+      "eligible_classes": 7
     },
     "megascale_delta_g": {
       "target_type": "continuous_regression",
@@ -44,9 +39,9 @@
     }
   },
   "artifact_sha256": {
-    "train": "f872a520d3a87e12c9fe5fd56c6ebcc39f95eef60dcda3135bb1837315b03184",
-    "validation": "6af25dbb095c611e5d2183a24a3e06509fd70cc69f33b92abedcdbf43d9507b4",
-    "test": "1aa2f09321cfae6dcdea3988258e6fd1f5ba9730136d2e2373207e9064e88e51",
+    "train": "aa822464f8120a38b6b4db2e42dad7dc80685f082d4a1b88b08919d68fc9d1a5",
+    "validation": "5e0c19092fef982ecad8e10776c9c15c5a4d79d1a3316e6561998fb7a743db47",
+    "test": "4f5afe6cad055f478946842ec002f499bb2faa77f128811d6fd3071a33745ae4",
     "task_vocabs": "f167bd57a0a7265ffd737a7efe7fd4a4b68ba9c49351b6456fd9e4958c09c0ae"
   },
   "architecture_freeze": {

--- a/scripts/build_corrected_protein_critic_dataset.py
+++ b/scripts/build_corrected_protein_critic_dataset.py
@@ -44,9 +44,15 @@ def load_annotation_records(proteins_path: Path, metadata_path: Path) -> list[di
             sequence = normalize_protein(payload.get("sequence", ""))
         except ValueError:
             continue
-        pfam_values = [value.strip() for value in str(row.get("pfam", "")).split(";") if value.strip()]
+        pfam_values = [
+            value.strip()
+            for value in str(row.get("pfam", "")).split(";")
+            if value.strip()
+        ]
         ec = str(row.get("ec", "")).strip()
-        ec_label = int(ec[0]) if ec and ec[0].isdigit() and 1 <= int(ec[0]) <= 7 else None
+        ec_label = (
+            int(ec[0]) if ec and ec[0].isdigit() and 1 <= int(ec[0]) <= 7 else None
+        )
         pfam_label = pfam_values[0] if pfam_values else None
         if pfam_label is None and ec_label is None:
             continue
@@ -103,13 +109,20 @@ def cluster_records(records: list[dict], work_dir: Path, args) -> dict:
         str(fasta),
         str(prefix),
         str(work_dir / "tmp"),
-        "--min-seq-id", str(args.min_sequence_identity),
-        "-c", str(args.min_coverage),
-        "--cov-mode", "0",
-        "--cluster-mode", "0",
-        "--threads", str(args.threads),
+        "--min-seq-id",
+        str(args.min_sequence_identity),
+        "-c",
+        str(args.min_coverage),
+        "--cov-mode",
+        "0",
+        "--cluster-mode",
+        "0",
+        "--threads",
+        str(args.threads),
     ]
-    version = subprocess.run([executable, "version"], check=True, capture_output=True, text=True)
+    version = subprocess.run(
+        [executable, "version"], check=True, capture_output=True, text=True
+    )
     subprocess.run(command, check=True, capture_output=True, text=True)
     assignments = {}
     cluster_path = Path(f"{prefix}_cluster.tsv")
@@ -117,13 +130,20 @@ def cluster_records(records: list[dict], work_dir: Path, args) -> dict:
         for line in handle:
             representative, member = line.rstrip("\n").split("\t")[:2]
             assignments[member] = representative
-    missing = [record["cluster_key"] for record in records if record["cluster_key"] not in assignments]
+    missing = [
+        record["cluster_key"]
+        for record in records
+        if record["cluster_key"] not in assignments
+    ]
     if missing:
         raise RuntimeError(f"MMseqs2 omitted {len(missing)} records")
     for record in records:
         record["protein_cluster"] = assignments[record["cluster_key"]]
     return {
-        "tool": {"executable": executable, "version": (version.stdout or version.stderr).strip()},
+        "tool": {
+            "executable": executable,
+            "version": (version.stdout or version.stderr).strip(),
+        },
         "command": command,
         "thresholds": {
             "minimum_sequence_identity": args.min_sequence_identity,
@@ -136,7 +156,9 @@ def cluster_records(records: list[dict], work_dir: Path, args) -> dict:
     }
 
 
-def write_jsonl(path: Path, records: list[dict], pfam_vocab: dict, ec_vocab: dict) -> None:
+def write_jsonl(
+    path: Path, records: list[dict], pfam_vocab: dict, ec_vocab: dict
+) -> None:
     with path.open("w") as handle:
         for record in records:
             output = {
@@ -168,7 +190,9 @@ def main(argv=None) -> None:
     parser.add_argument("--min-test-per-class", type=int, default=5)
     args = parser.parse_args(argv)
 
-    raw_records = load_annotation_records(args.protein_records, args.annotation_metadata)
+    raw_records = load_annotation_records(
+        args.protein_records, args.annotation_metadata
+    )
     raw_records.extend(load_stability_records(args.stability_csv))
     records, quarantined = group_by_sequence(raw_records)
     if not records:
@@ -194,7 +218,19 @@ def main(argv=None) -> None:
     ec_vocab = {str(label): index for index, label in enumerate(ec_labels)}
     ec_lookup = {label: index for index, label in enumerate(ec_labels)}
     if len(pfam_vocab) < 2 or len(ec_vocab) < 2:
-        raise ValueError("fewer than two supported Pfam or EC classes survive the held-out split")
+        raise ValueError(
+            "fewer than two supported Pfam or EC classes survive the held-out split"
+        )
+
+    records = [
+        record
+        for record in records
+        if record.get("pfam_label") in pfam_vocab
+        or record.get("ec_label") in ec_lookup
+        or record.get("stability_score") is not None
+    ]
+    if not records:
+        raise ValueError("no records retain a supported task target")
 
     report = split_report(records, ("pfam_label", "ec_label"))
     if report["cross_split_clusters"]:
@@ -202,25 +238,56 @@ def main(argv=None) -> None:
     artifacts = {}
     for split in ("train", "validation", "test"):
         path = args.out_dir / f"{split}.jsonl"
-        write_jsonl(path, [record for record in records if record["split"] == split], pfam_vocab, ec_lookup)
+        write_jsonl(
+            path,
+            [record for record in records if record["split"] == split],
+            pfam_vocab,
+            ec_lookup,
+        )
         artifacts[split] = {"path": str(path.resolve()), "sha256": sha256(path)}
     vocab_path = args.out_dir / "task_vocabs.json"
-    vocab_path.write_text(json.dumps({
-        "pfam": pfam_vocab,
-        "ec": ec_vocab,
-        "stability": {"type": "regression", "target": "deltaG", "units": "kcal/mol"},
-    }, indent=2, sort_keys=True) + "\n")
-    artifacts["task_vocabs"] = {"path": str(vocab_path.resolve()), "sha256": sha256(vocab_path)}
+    vocab_path.write_text(
+        json.dumps(
+            {
+                "pfam": pfam_vocab,
+                "ec": ec_vocab,
+                "stability": {
+                    "type": "regression",
+                    "target": "deltaG",
+                    "units": "kcal/mol",
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    artifacts["task_vocabs"] = {
+        "path": str(vocab_path.resolve()),
+        "sha256": sha256(vocab_path),
+    }
     manifest = {
         "schema_version": 1,
         "protocol": "mmseqs_cluster_held_out_multitask_protein_critic",
         "seed": args.seed,
         "inputs": {
-            "protein_records": {"path": str(args.protein_records.resolve()), "sha256": sha256(args.protein_records)},
-            "annotation_metadata": {"path": str(args.annotation_metadata.resolve()), "sha256": sha256(args.annotation_metadata)},
-            "stability_csv": {"path": str(args.stability_csv.resolve()), "sha256": sha256(args.stability_csv)},
+            "protein_records": {
+                "path": str(args.protein_records.resolve()),
+                "sha256": sha256(args.protein_records),
+            },
+            "annotation_metadata": {
+                "path": str(args.annotation_metadata.resolve()),
+                "sha256": sha256(args.annotation_metadata),
+            },
+            "stability_csv": {
+                "path": str(args.stability_csv.resolve()),
+                "sha256": sha256(args.stability_csv),
+            },
         },
         "clustering": clustering,
+        "retained_cluster_count": len(
+            {record["protein_cluster"] for record in records}
+        ),
         "exact_sequence_conflicts_quarantined": len(quarantined),
         "eligible_classes": {"pfam": pfam_labels, "ec_top_level": ec_labels},
         "minimum_class_support": minimums,
@@ -230,7 +297,9 @@ def main(argv=None) -> None:
     manifest_path = args.out_dir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
     print(
-        f"[critic-data] records={len(records)} clusters={clustering['cluster_count']} "
+        f"[critic-data] records={len(records)} "
+        f"retained_clusters={manifest['retained_cluster_count']} "
+        f"source_clusters={clustering['cluster_count']} "
         f"pfam_classes={len(pfam_vocab)} ec_classes={len(ec_vocab)} out={args.out_dir}"
     )
 

--- a/scripts/eval_multi_task_critic.py
+++ b/scripts/eval_multi_task_critic.py
@@ -3,6 +3,8 @@ import json
 import argparse
 import yaml
 import os
+import hashlib
+from pathlib import Path
 import numpy as np
 from src.protein_lm.tokenizer import ProteinTokenizer
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
@@ -19,7 +21,10 @@ from sklearn.metrics import (
     classification_report,
     precision_recall_fscore_support,
     roc_auc_score,
+    mean_absolute_error,
+    mean_squared_error,
 )
+from scipy.stats import pearsonr, spearmanr
 
 
 def _device(name):
@@ -40,6 +45,27 @@ def _safe_float(value):
     if value is None or np.isnan(value):
         return None
     return float(value)
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_evaluation_artifact(checkpoint, data_path, split):
+    provenance = checkpoint.get("dataset_provenance", {})
+    if provenance.get("status") != "manifest_verified":
+        return "legacy_unverified"
+    role = "test" if split == "test" else "validation"
+    expected = provenance["artifacts"][role]["sha256"]
+    if _sha256(data_path) != expected:
+        raise ValueError(
+            f"{role} data SHA-256 does not match the checkpoint provenance"
+        )
+    return "checkpoint_verified"
 
 
 def parse_float_list(value):
@@ -73,9 +99,7 @@ def top_fraction_enrichment(y_true, y_prob, fractions):
         k = max(1, int(np.ceil(len(y_true) * fraction)))
         selected = y_true[order[:k]]
         selected_positive_rate = float(selected.mean())
-        enrichment = (
-            selected_positive_rate / prevalence if prevalence > 0.0 else np.nan
-        )
+        enrichment = selected_positive_rate / prevalence if prevalence > 0.0 else np.nan
         rows.append(
             {
                 "fraction": float(fraction),
@@ -99,10 +123,13 @@ def main():
     parser.add_argument(
         "--val_data", default="data/processed/protein_lm/multitask/val.jsonl"
     )
+    parser.add_argument("--split", choices=("validation", "test"), default="validation")
     parser.add_argument("--task_vocabs", default=None, help="Optional task vocab JSON")
     parser.add_argument("--batch_size", type=int, default=16)
     parser.add_argument("--device", default="auto", help="auto, cpu, mps, or cuda")
-    parser.add_argument("--out_json", default=None, help="Optional path for metrics JSON")
+    parser.add_argument(
+        "--out_json", default=None, help="Optional path for metrics JSON"
+    )
     parser.add_argument(
         "--thresholds",
         default="0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9",
@@ -122,13 +149,17 @@ def main():
     if os.path.exists(args.config):
         with open(args.config, "r") as f:
             cfg = yaml.safe_load(f)
-    if args.val_data == parser.get_default("val_data") and cfg.get("val_data"):
-        args.val_data = cfg["val_data"]
-    if args.task_vocabs is None:
-        args.task_vocabs = cfg.get("task_vocabs")
-
     tokenizer = ProteinTokenizer()
     state = torch.load(args.ckpt, map_location="cpu")
+    if isinstance(state, dict) and isinstance(state.get("cfg"), dict):
+        cfg = {**cfg, **state["cfg"]}
+    if args.val_data == parser.get_default("val_data"):
+        data_key = "test_data" if args.split == "test" else "val_data"
+        args.val_data = cfg.get(data_key, args.val_data)
+    if args.task_vocabs is None:
+        args.task_vocabs = cfg.get("task_vocabs")
+    provenance_status = verify_evaluation_artifact(state, args.val_data, args.split)
+    print(f"[*] Evaluation dataset provenance: {provenance_status}")
     state_dict = state.get("model_state_dict", state)
     state_dict = state_dict.get("model", state_dict)
 
@@ -141,15 +172,18 @@ def main():
     if "heads.stability.weight" in state_dict:
         task_dims["stability"] = state_dict["heads.stability.weight"].shape[0]
     multi_label_tasks = list(cfg.get("multi_label_tasks", []))
+    regression_tasks = set(cfg.get("regression_tasks", []))
     for task in multi_label_tasks:
         key = f"heads.{task}.weight"
         if key in state_dict:
             task_dims[task] = state_dict[key].shape[0]
 
     vocab_labels = {}
-    if args.task_vocabs:
+    vocabs = state.get("task_vocabs") if isinstance(state, dict) else None
+    if vocabs is None and args.task_vocabs:
         with open(args.task_vocabs, "r") as f:
             vocabs = json.load(f)
+    if vocabs:
         for task in multi_label_tasks:
             if task in vocabs:
                 vocab_labels[task] = _ordered_vocab(vocabs[task])
@@ -195,7 +229,10 @@ def main():
     results = {
         task: {"preds": [], "targets": [], "top5": [], "top10": []}
         for task in task_dims
-        if task not in multi_label_tasks
+        if task not in multi_label_tasks and task not in regression_tasks
+    }
+    regression_results = {
+        task: {"targets": [], "predictions": []} for task in regression_tasks
     }
     multi_label_results = {
         task: {"targets": [], "probs": []} for task in multi_label_tasks
@@ -235,6 +272,15 @@ def main():
 
                     results[task]["top5"].extend(has_top5)
                     results[task]["top10"].extend(has_top10)
+            for task in regression_tasks:
+                targets = batch[task].float()
+                mask = torch.isfinite(targets)
+                if mask.any():
+                    predictions = logits_dict[task].detach().cpu().squeeze(-1)
+                    regression_results[task]["targets"].extend(targets[mask].tolist())
+                    regression_results[task]["predictions"].extend(
+                        predictions[mask].tolist()
+                    )
             for task in multi_label_tasks:
                 if task not in logits_dict:
                     continue
@@ -247,9 +293,9 @@ def main():
                     torch.sigmoid(logits).cpu().numpy()
                 )
 
-    summary = {"single_label": {}, "multi_label": {}}
+    summary = {"single_label": {}, "regression": {}, "multi_label": {}}
     for task in task_dims:
-        if task in multi_label_tasks:
+        if task in multi_label_tasks or task in regression_tasks:
             continue
         y_true = results[task]["targets"]
         y_pred = results[task]["preds"]
@@ -351,6 +397,35 @@ def main():
                 "thresholds": threshold_rows,
                 "top_fraction_enrichment": enrichment_rows,
             }
+
+    for task, data in regression_results.items():
+        y_true = np.asarray(data["targets"], dtype=np.float64)
+        y_pred = np.asarray(data["predictions"], dtype=np.float64)
+        if y_true.size == 0:
+            print(f"Task: {task} has no valid {args.split} samples.")
+            continue
+        mae = mean_absolute_error(y_true, y_pred)
+        rmse = mean_squared_error(y_true, y_pred) ** 0.5
+        pearson = pearsonr(y_true, y_pred).statistic if y_true.size > 1 else np.nan
+        spearman = spearmanr(y_true, y_pred).statistic if y_true.size > 1 else np.nan
+        baseline_mae = mean_absolute_error(
+            y_true, np.full_like(y_true, np.median(y_true))
+        )
+        summary["regression"][task] = {
+            "samples": int(y_true.size),
+            "mae": float(mae),
+            "rmse": float(rmse),
+            "pearson": _safe_float(pearson),
+            "spearman": _safe_float(spearman),
+            "median_baseline_mae": float(baseline_mae),
+        }
+        print("==================================================")
+        print(f"Task: {task} ({args.split})")
+        print(
+            f"  Samples: {y_true.size} | MAE: {mae:.4f} | RMSE: {rmse:.4f} "
+            f"| Pearson: {pearson:.4f} | Spearman: {spearman:.4f} "
+            f"| Median-baseline MAE: {baseline_mae:.4f}"
+        )
 
     if args.out_json:
         with open(args.out_json, "w") as f:

--- a/src/protein_lm/dataset.py
+++ b/src/protein_lm/dataset.py
@@ -2,14 +2,22 @@ import json
 import torch
 from torch.utils.data import Dataset, Sampler
 
+
 class MultiTaskProteinDataset(Dataset):
-    def __init__(self, jsonl_path, tokenizer, max_length=512, dynamic_padding=False, multi_label_tasks=None):
+    def __init__(
+        self,
+        jsonl_path,
+        tokenizer,
+        max_length=512,
+        dynamic_padding=False,
+        multi_label_tasks=None,
+    ):
         self.tokenizer = tokenizer
         self.max_length = max_length
         self.dynamic_padding = dynamic_padding
         self.multi_label_tasks = set(multi_label_tasks or [])
         self.samples = []
-        
+
         with open(jsonl_path, "r") as f:
             for line in f:
                 self.samples.append(json.loads(line))
@@ -19,10 +27,14 @@ class MultiTaskProteinDataset(Dataset):
 
     def __getitem__(self, idx):
         s = self.samples[idx]
-        
+
         # Tokenize (Add BOS, pad/truncate, Add EOS handled by tokenizer logic if needed)
-        tokens = [self.tokenizer.bos_token_id] + self.tokenizer.encode_sequence(s["sequence"])[:self.max_length-2] + [self.tokenizer.eos_token_id]
-        
+        tokens = (
+            [self.tokenizer.bos_token_id]
+            + self.tokenizer.encode_sequence(s["sequence"])[: self.max_length - 2]
+            + [self.tokenizer.eos_token_id]
+        )
+
         attention_mask = [1] * len(tokens)
         if not self.dynamic_padding:
             pad_len = self.max_length - len(tokens)
@@ -31,13 +43,23 @@ class MultiTaskProteinDataset(Dataset):
         else:
             input_ids = tokens
 
+        if "stability_score" in s:
+            stability = torch.tensor(
+                float(s["stability_score"])
+                if s["stability_score"] is not None
+                else float("nan"),
+                dtype=torch.float32,
+            )
+        else:
+            stability = torch.tensor(s.get("stability_id", -1), dtype=torch.long)
+
         item = {
             "input_ids": torch.tensor(input_ids, dtype=torch.long),
             "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
             "sequence": s["sequence"],
             "family": torch.tensor(s.get("pfam_id", -1), dtype=torch.long),
             "function": torch.tensor(s.get("ec_id", -1), dtype=torch.long),
-            "stability": torch.tensor(s.get("stability_id", -1), dtype=torch.long)
+            "stability": stability,
         }
         for task in self.multi_label_tasks:
             labels = s.get(task)
@@ -56,17 +78,25 @@ class MultiTaskProteinDataset(Dataset):
 class LengthBucketBatchSampler(Sampler[list[int]]):
     """Batch similar-length proteins together to reduce padding waste."""
 
-    def __init__(self, dataset, batch_size, shuffle=True):
+    def __init__(self, dataset, batch_size, shuffle=True, seed=1337):
         self.dataset = dataset
         self.batch_size = int(batch_size)
         self.shuffle = shuffle
+        self.seed = int(seed)
+        self.epoch = 0
+
+    def set_epoch(self, epoch):
+        self.epoch = int(epoch)
 
     def __iter__(self):
         generator = torch.Generator()
-        generator.manual_seed(1337)
+        generator.manual_seed(self.seed + self.epoch)
         indices = list(range(len(self.dataset)))
         indices.sort(key=self.dataset.sequence_length)
-        batches = [indices[i : i + self.batch_size] for i in range(0, len(indices), self.batch_size)]
+        batches = [
+            indices[i : i + self.batch_size]
+            for i in range(0, len(indices), self.batch_size)
+        ]
         if self.shuffle:
             order = torch.randperm(len(batches), generator=generator).tolist()
             batches = [batches[i] for i in order]

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -5,6 +5,8 @@ import time
 import json
 import argparse
 import yaml
+import hashlib
+import random
 from pathlib import Path
 from src.protein_lm.tokenizer import ProteinTokenizer
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
@@ -61,18 +63,87 @@ def compute_multi_label_pos_weight(dataset, task, max_weight=100.0):
     matrix = torch.stack(labels)
     positives = matrix.sum(dim=0)
     negatives = matrix.shape[0] - positives
-    weights = torch.where(positives > 0, negatives / positives.clamp_min(1.0), torch.ones_like(positives))
+    weights = torch.where(
+        positives > 0, negatives / positives.clamp_min(1.0), torch.ones_like(positives)
+    )
     return weights.clamp(min=1.0, max=float(max_weight))
 
 
-def save_training_checkpoint(path, epoch, model, optimizer, best_val_loss):
-    checkpoint = {
-        'epoch': epoch,
-        'model_state_dict': model.state_dict(),
-        'optimizer_state_dict': optimizer.state_dict(),
-        'best_val_loss': best_val_loss,
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def bind_critic_dataset(cfg: dict, config_path: str) -> dict:
+    manifest_value = cfg.get("dataset_manifest")
+    if not manifest_value:
+        return {"status": "legacy_unverified"}
+    root = Path(config_path).resolve().parents[1]
+    manifest_path = Path(manifest_value)
+    if not manifest_path.is_absolute():
+        manifest_path = root / manifest_path
+    manifest = json.loads(manifest_path.read_text())
+    configured = {
+        "train": Path(cfg["train_data"]),
+        "validation": Path(cfg["val_data"]),
+        "test": Path(cfg["test_data"]),
+        "task_vocabs": Path(cfg["task_vocabs"]),
     }
-    torch.save(checkpoint, path)
+    verified = {}
+    for role, configured_path in configured.items():
+        if not configured_path.is_absolute():
+            configured_path = root / configured_path
+        configured_path = configured_path.resolve()
+        artifact = manifest["artifacts"][role]
+        artifact_path = Path(artifact["path"]).resolve()
+        if configured_path != artifact_path:
+            raise ValueError(f"configured {role} does not match dataset manifest")
+        actual_hash = _sha256(configured_path)
+        if actual_hash != artifact["sha256"]:
+            raise ValueError(f"{role} SHA-256 does not match dataset manifest")
+        verified[role] = {"path": str(configured_path), "sha256": actual_hash}
+    return {
+        "status": "manifest_verified",
+        "manifest": {"path": str(manifest_path), "sha256": _sha256(manifest_path)},
+        "artifacts": verified,
+        "protocol": manifest.get("protocol"),
+    }
+
+
+def task_losses(
+    logits_dict: dict,
+    batch: dict,
+    classification_tasks: tuple[str, ...],
+    regression_tasks: tuple[str, ...],
+    criterion: nn.Module,
+) -> dict[str, torch.Tensor]:
+    losses = {}
+    for task in classification_tasks:
+        targets = batch[task]
+        valid = targets != -1
+        if bool(valid.any()):
+            losses[task] = criterion(logits_dict[task][valid], targets[valid])
+    for task in regression_tasks:
+        targets = batch[task].float()
+        valid = torch.isfinite(targets)
+        if bool(valid.any()):
+            predictions = logits_dict[task].squeeze(-1)
+            losses[task] = nn.functional.smooth_l1_loss(
+                predictions[valid], targets[valid]
+            )
+    return losses
+
+
+def accumulation_group_size(
+    step: int, loader_length: int, grad_accum_steps: int
+) -> int:
+    if grad_accum_steps < 1:
+        raise ValueError("grad_accum_steps must be at least one")
+    group_start = (step // grad_accum_steps) * grad_accum_steps
+    return min(grad_accum_steps, loader_length - group_start)
 
 
 def mps_memory_summary():
@@ -88,16 +159,35 @@ def mps_memory_summary():
     return " | " + " | ".join(parts) if parts else ""
 
 
-def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=None):
-    with open(config_path, 'r') as f:
+def train_multi_task(
+    config_path,
+    resume_path=None,
+    run_id=None,
+    transfer_from=None,
+    max_time_minutes=None,
+):
+    with open(config_path, "r") as f:
         cfg = yaml.safe_load(f)
-        
-    device_name = cfg.get("device", "mps" if torch.backends.mps.is_available() else "cpu")
+    if max_time_minutes is not None:
+        cfg["max_time_minutes"] = float(max_time_minutes)
+
+    device_name = cfg.get(
+        "device", "mps" if torch.backends.mps.is_available() else "cpu"
+    )
     device = torch.device(device_name)
     print(f"[*] Using device: {device}", flush=True)
 
     tokenizer = ProteinTokenizer()
-    
+    seed = int(cfg.get("seed", 1337))
+    random.seed(seed)
+    torch.manual_seed(seed)
+    dataset_provenance = bind_critic_dataset(cfg, config_path)
+    if dataset_provenance["status"] == "manifest_verified":
+        print(
+            f"[*] Dataset manifest verified: {dataset_provenance['manifest']['path']}",
+            flush=True,
+        )
+
     # Load vocabs to get task dimensions. Keep the production default, but allow
     # tests and small smoke runs to provide a self-contained vocab file.
     task_vocabs_path = cfg.get(
@@ -106,11 +196,17 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
     )
     with open(task_vocabs_path, "r") as f:
         vocabs = json.load(f)
-        
+
+    regression_tasks = tuple(cfg.get("regression_tasks", []))
+    classification_tasks = tuple(
+        task
+        for task in ("family", "function", "stability")
+        if task not in regression_tasks
+    )
     task_dims = {
         "family": len(vocabs["pfam"]),
         "function": len(vocabs["ec"]),
-        "stability": len(vocabs["stability"])
+        "stability": 1 if "stability" in regression_tasks else len(vocabs["stability"]),
     }
     multi_label_tasks = list(cfg.get("multi_label_tasks", []))
     for task in multi_label_tasks:
@@ -125,10 +221,10 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
         n_head=cfg.get("n_head", 4),
         n_embd=cfg.get("n_embd", 128),
         dropout=cfg.get("dropout", 0.1),
-        num_classes=0, # Dummy value for multi-task backbone
+        num_classes=0,  # Dummy value for multi-task backbone
         use_checkpoint=cfg.get("use_checkpoint", False),
         pooling=cfg.get("pooling", "mean"),
-        bidirectional=cfg.get("bidirectional", True)
+        bidirectional=cfg.get("bidirectional", True),
     )
 
     print("[*] Building model...", flush=True)
@@ -140,12 +236,22 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             raise ValueError("--transfer_from and --resume are mutually exclusive")
         transfer_checkpoint = Path(transfer_checkpoint)
         if not transfer_checkpoint.exists():
-            raise FileNotFoundError(f"Transfer checkpoint not found: {transfer_checkpoint}")
-        loaded, skipped = load_compatible_model_weights(model, transfer_checkpoint, map_location=device)
-        print(f"[*] Transferred {loaded} compatible tensors from {transfer_checkpoint}", flush=True)
+            raise FileNotFoundError(
+                f"Transfer checkpoint not found: {transfer_checkpoint}"
+            )
+        loaded, skipped = load_compatible_model_weights(
+            model, transfer_checkpoint, map_location=device
+        )
+        print(
+            f"[*] Transferred {loaded} compatible tensors from {transfer_checkpoint}",
+            flush=True,
+        )
         if skipped:
-            print(f"[*] Skipped {len(skipped)} incompatible tensors, typically task-specific heads", flush=True)
-    
+            print(
+                f"[*] Skipped {len(skipped)} incompatible tensors, typically task-specific heads",
+                flush=True,
+            )
+
     print("[*] Loading datasets...", flush=True)
     dynamic_padding = bool(cfg.get("dynamic_padding", False))
     train_ds = MultiTaskProteinDataset(
@@ -166,25 +272,40 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
     if dynamic_padding:
         train_loader = DataLoader(
             train_ds,
-            batch_sampler=LengthBucketBatchSampler(train_ds, cfg.get("batch_size", 8), shuffle=True),
-            collate_fn=lambda batch: collate_protein_batch(batch, tokenizer.pad_token_id),
+            batch_sampler=LengthBucketBatchSampler(
+                train_ds,
+                cfg.get("batch_size", 8),
+                shuffle=True,
+                seed=seed,
+            ),
+            collate_fn=lambda batch: collate_protein_batch(
+                batch, tokenizer.pad_token_id
+            ),
         )
         val_loader = DataLoader(
             val_ds,
-            batch_sampler=LengthBucketBatchSampler(val_ds, cfg.get("batch_size", 8), shuffle=False),
-            collate_fn=lambda batch: collate_protein_batch(batch, tokenizer.pad_token_id),
+            batch_sampler=LengthBucketBatchSampler(
+                val_ds, cfg.get("batch_size", 8), shuffle=False
+            ),
+            collate_fn=lambda batch: collate_protein_batch(
+                batch, tokenizer.pad_token_id
+            ),
         )
     else:
         train_loader = DataLoader(
             train_ds,
             batch_size=cfg.get("batch_size", 8),
             shuffle=True,
-            collate_fn=lambda batch: collate_protein_batch(batch, tokenizer.pad_token_id),
+            collate_fn=lambda batch: collate_protein_batch(
+                batch, tokenizer.pad_token_id
+            ),
         )
         val_loader = DataLoader(
             val_ds,
             batch_size=cfg.get("batch_size", 8),
-            collate_fn=lambda batch: collate_protein_batch(batch, tokenizer.pad_token_id),
+            collate_fn=lambda batch: collate_protein_batch(
+                batch, tokenizer.pad_token_id
+            ),
         )
     print(
         f"[*] Dataset sizes: train={len(train_ds)} val={len(val_ds)} "
@@ -193,7 +314,7 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
     )
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=float(cfg.get("lr", 1e-4)))
-    
+
     # CrossEntropyLoss with ignore_index=-1 handles the missing labels
     criterion = nn.CrossEntropyLoss(ignore_index=-1)
     multi_label_criteria = {}
@@ -206,7 +327,9 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
                 train_ds, task, max_weight=pos_weight_max
             ).to(device)
         elif isinstance(pos_weight_cfg, dict) and task in pos_weight_cfg:
-            pos_weight = torch.tensor(pos_weight_cfg[task], dtype=torch.float32, device=device)
+            pos_weight = torch.tensor(
+                pos_weight_cfg[task], dtype=torch.float32, device=device
+            )
         if pos_weight is not None:
             print(
                 f"[*] Multi-label pos_weight for {task}: "
@@ -215,19 +338,25 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
             )
         multi_label_criteria[task] = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
 
-    best_val_loss = float('inf')
+    best_val_loss = float("inf")
     start_epoch = 0
     optimizer_step = 0
+    resume_microbatch_idx = 0
     if resume_path and Path(resume_path).exists():
         print(f"[*] Resuming from checkpoint: {resume_path}", flush=True)
         checkpoint = torch.load(resume_path, map_location=device)
-        model.load_state_dict(checkpoint['model_state_dict'])
-        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-        start_epoch = checkpoint['epoch'] + 1
-        best_val_loss = checkpoint.get('best_val_loss', float('inf'))
-        optimizer_step = int(checkpoint.get('optimizer_step', 0))
+        model.load_state_dict(checkpoint["model_state_dict"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        epoch_complete = bool(checkpoint.get("epoch_complete", True))
+        start_epoch = checkpoint["epoch"] + (1 if epoch_complete else 0)
+        resume_microbatch_idx = (
+            0 if epoch_complete else int(checkpoint.get("microbatch_idx", 0))
+        )
+        best_val_loss = checkpoint.get("best_val_loss", float("inf"))
+        optimizer_step = int(checkpoint.get("optimizer_step", 0))
         print(
-            f"[*] Resumed checkpoint. Next epoch: {start_epoch + 1} "
+            f"[*] Resumed checkpoint. Next epoch: {start_epoch + 1}, "
+            f"microbatch: {resume_microbatch_idx} "
             f"with best val loss: {best_val_loss:.4f}",
             flush=True,
         )
@@ -243,34 +372,36 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
         f"step checkpoint every {checkpoint_every_steps or 'disabled'} steps",
         flush=True,
     )
-    
+
     max_time_minutes = cfg.get("max_time_minutes", None)
     if max_time_minutes:
         print(f"[*] Wall-time limit configured: {max_time_minutes} minutes", flush=True)
-    
+
     if not run_id:
         run_id = cfg.get("run_id", None)
     if not run_id:
         from datetime import date
+
         today = date.today().strftime("%Y-%m-%d")
         tag = Path(config_path).stem
         run_id = f"{today}_{tag}_{model_cfg.n_layer}L{model_cfg.n_head}H_d{model_cfg.n_embd}_e{epochs}"
-    
+
     runs_dir = Path("runs") / run_id
     out_dir = runs_dir / "checkpoints"
     scores_dir = runs_dir / "scores"
-    
+
     out_dir.mkdir(parents=True, exist_ok=True)
     scores_dir.mkdir(parents=True, exist_ok=True)
     run_logger = RunLogger(runs_dir / "logs" / "train.log")
     run_logger.__enter__()
-    
+
     log_csv = scores_dir / "curves.csv"
     import csv
+
     if not log_csv.exists():
         with open(log_csv, "w", newline="") as f:
             csv.writer(f).writerow(["epoch", "train_loss", "val_loss"])
-    
+
     time_limit_reached = False
     start_time = time.perf_counter()
     wall_timer = WallTimer(max_time_minutes)
@@ -278,45 +409,76 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
         every_steps=int(cfg.get("checkpoint_every_steps", 0) or 0),
         every_minutes=float(cfg.get("checkpoint_every_minutes", 0.0) or 0.0),
     )
+    current_microbatch_idx = 0
+
     def checkpoint_payload(epoch_idx: int) -> dict:
         return {
-            'epoch': epoch_idx,
-            'model_state_dict': model.state_dict(),
-            'optimizer_state_dict': optimizer.state_dict(),
-            'best_val_loss': best_val_loss,
-            'optimizer_step': optimizer_step,
-            'cfg': cfg,
+            "epoch": epoch_idx,
+            "model_state_dict": model.state_dict(),
+            "optimizer_state_dict": optimizer.state_dict(),
+            "best_val_loss": best_val_loss,
+            "optimizer_step": optimizer_step,
+            "microbatch_idx": current_microbatch_idx,
+            "epoch_complete": False,
+            "cfg": cfg,
+            "dataset_provenance": dataset_provenance,
+            "task_vocabs": vocabs,
+            "model_spec": {
+                "vocab_size": model_cfg.vocab_size,
+                "block_size": model_cfg.block_size,
+                "n_layer": model_cfg.n_layer,
+                "n_head": model_cfg.n_head,
+                "n_embd": model_cfg.n_embd,
+                "dropout": model_cfg.dropout,
+                "pooling": model_cfg.pooling,
+                "bidirectional": model_cfg.bidirectional,
+                "task_dims": task_dims,
+                "regression_tasks": list(regression_tasks),
+            },
         }
 
     def save_last(epoch_idx: int, reason: str) -> None:
         payload = checkpoint_payload(epoch_idx)
         payload["checkpoint_reason"] = reason
+        payload["epoch_complete"] = reason == "epoch"
+        if payload["epoch_complete"]:
+            payload["microbatch_idx"] = 0
         save_checkpoint_atomic(payload, out_dir / "last_critic.pt")
         checkpoint_policy.mark_saved(optimizer_step)
-        print(f"[checkpoint] saved {out_dir / 'last_critic.pt'} reason={reason} step={optimizer_step}")
+        print(
+            f"[checkpoint] saved {out_dir / 'last_critic.pt'} reason={reason} step={optimizer_step}"
+        )
 
     for epoch in range(start_epoch, epochs):
         if time_limit_reached:
             break
+        if dynamic_padding:
+            train_loader.batch_sampler.set_epoch(epoch)
         model.train()
         train_loss = 0.0
         recent_loss = 0.0
         recent_steps = 0
         optimizer.zero_grad()
-        
+
         for step, batch in enumerate(train_loader):
+            if epoch == start_epoch and step < resume_microbatch_idx:
+                continue
+            current_microbatch_idx = step + 1
             input_ids = batch["input_ids"].to(device)
             attention_mask = batch.get("attention_mask")
             if attention_mask is not None:
                 attention_mask = attention_mask.to(device)
-            
+
             logits_dict = model(input_ids, attention_mask=attention_mask)
-            
+
             loss = 0
             tasks_added = 0
 
-            # Saliency contrast regularizer (Phase 4 active-site focus)
-            if "attention_weights" in logits_dict:
+            # Legacy motif supervision is opt-in and disabled for corrected critics.
+            saliency_regularizer_weight = float(
+                cfg.get("saliency_regularizer_weight", 0.0)
+            )
+            if saliency_regularizer_weight > 0.0 and "attention_weights" in logits_dict:
                 attn_weights = logits_dict["attention_weights"]  # (B, T)
                 saliency_loss = 0.0
                 saliency_count = 0
@@ -335,37 +497,45 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
                         saliency_loss += -torch.log(active_mass + 1e-8)
                         saliency_count += 1
                 if saliency_count > 0:
-                    loss += 5.0 * (saliency_loss / saliency_count)
-            for task in ["family", "function", "stability"]:
-                targets = batch[task].to(device)
-                # Check if there's at least one valid label in the batch for this task
-                if (targets != -1).any():
-                     loss += criterion(logits_dict[task], targets)
-                     tasks_added += 1
+                    loss += saliency_regularizer_weight * (
+                        saliency_loss / saliency_count
+                    )
+            supervised_losses = task_losses(
+                logits_dict,
+                {
+                    task: batch[task].to(device)
+                    for task in (*classification_tasks, *regression_tasks)
+                },
+                classification_tasks,
+                regression_tasks,
+                criterion,
+            )
+            if supervised_losses:
+                loss += torch.stack(list(supervised_losses.values())).mean()
+                tasks_added += 1
             for task in multi_label_tasks:
                 targets = batch[task].to(device)
                 if targets.numel() and (targets >= 0).any():
                     loss += multi_label_criteria[task](logits_dict[task], targets)
                     tasks_added += 1
-            
+
             if tasks_added > 0:
-                loss = loss / grad_accum_steps
+                group_size = accumulation_group_size(
+                    step, len(train_loader), grad_accum_steps
+                )
+                loss = loss / group_size
                 loss.backward()
-                train_loss += loss.item() * grad_accum_steps
-                recent_loss += loss.item() * grad_accum_steps
+                train_loss += loss.item() * group_size
+                recent_loss += loss.item() * group_size
                 recent_steps += 1
-            
+
             if (step + 1) % grad_accum_steps == 0 or (step + 1) == len(train_loader):
                 optimizer.step()
                 optimizer.zero_grad()
                 optimizer_step += 1
-                
-                if device.type == "mps":
-                    torch.mps.empty_cache()
+
                 if checkpoint_policy.should_save(optimizer_step):
                     save_last(epoch, reason="periodic")
-            elif (step + 1) % 250 == 0 and device.type == "mps":
-                torch.mps.empty_cache()
 
             if log_every_steps and (step + 1) % log_every_steps == 0:
                 elapsed = time.perf_counter() - start_time
@@ -382,23 +552,35 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
                 recent_loss = 0.0
                 recent_steps = 0
 
-            if checkpoint_every_steps and (step + 1) % checkpoint_every_steps == 0:
-                step_checkpoint = out_dir / "last_step_critic.pt"
-                save_training_checkpoint(step_checkpoint, epoch, model, optimizer, best_val_loss)
-                print(f"[checkpoint] Saved step checkpoint to {step_checkpoint}", flush=True)
-
             # Check wall-time limit at the end of every step
             if wall_timer.expired():
-                print(f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.", flush=True)
+                print(
+                    f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.",
+                    flush=True,
+                )
+                optimizer_boundary = (step + 1) % grad_accum_steps == 0 or (
+                    step + 1
+                ) == len(train_loader)
+                if not optimizer_boundary:
+                    optimizer.zero_grad(set_to_none=True)
+                    current_microbatch_idx = (
+                        step // grad_accum_steps
+                    ) * grad_accum_steps
                 save_last(epoch, reason="wall_time")
-                print(f"[success] Gracefully saved checkpoint to {out_dir / 'last_critic.pt'}. Exiting.", flush=True)
+                print(
+                    f"[success] Gracefully saved checkpoint to {out_dir / 'last_critic.pt'}. Exiting.",
+                    flush=True,
+                )
                 time_limit_reached = True
                 break
-            
+
+        if time_limit_reached:
+            break
+        resume_microbatch_idx = 0
         train_loss /= len(train_loader)
         if device.type == "mps":
             torch.mps.empty_cache()
-        
+
         model.eval()
         val_loss = 0.0
         val_tasks_total = 0
@@ -409,33 +591,46 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
                 if attention_mask is not None:
                     attention_mask = attention_mask.to(device)
                 logits_dict = model(input_ids, attention_mask=attention_mask)
-                
+
                 batch_loss = 0
                 batch_tasks = 0
-                for task in ["family", "function", "stability"]:
-                    targets = batch[task].to(device)
-                    if (targets != -1).any():
-                        batch_loss += criterion(logits_dict[task], targets)
-                        batch_tasks += 1
+                supervised_losses = task_losses(
+                    logits_dict,
+                    {
+                        task: batch[task].to(device)
+                        for task in (*classification_tasks, *regression_tasks)
+                    },
+                    classification_tasks,
+                    regression_tasks,
+                    criterion,
+                )
+                if supervised_losses:
+                    batch_loss += torch.stack(list(supervised_losses.values())).mean()
+                    batch_tasks += 1
                 for task in multi_label_tasks:
                     targets = batch[task].to(device)
                     if targets.numel() and (targets >= 0).any():
-                        batch_loss += multi_label_criteria[task](logits_dict[task], targets)
+                        batch_loss += multi_label_criteria[task](
+                            logits_dict[task], targets
+                        )
                         batch_tasks += 1
-                
+
                 if batch_tasks > 0:
                     val_loss += batch_loss.item()
                     val_tasks_total += 1
-        
+
         if val_tasks_total > 0:
             val_loss /= val_tasks_total
         if device.type == "mps":
             torch.mps.empty_cache()
-        print(f"Epoch {epoch+1}/{epochs} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}", flush=True)
-        
+        print(
+            f"Epoch {epoch + 1}/{epochs} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}",
+            flush=True,
+        )
+
         with open(log_csv, "a", newline="") as f:
             csv.writer(f).writerow([epoch + 1, f"{train_loss:.4f}", f"{val_loss:.4f}"])
-        
+
         improved = False
         if val_loss < best_val_loss:
             best_val_loss = val_loss
@@ -445,14 +640,32 @@ def train_multi_task(config_path, resume_path=None, run_id=None, transfer_from=N
         save_last(epoch, reason="epoch")
 
         if improved:
-            save_checkpoint_atomic(model.state_dict(), out_dir / "best_critic.pt")
+            best_payload = checkpoint_payload(epoch)
+            best_payload["checkpoint_reason"] = "best_epoch"
+            best_payload["epoch_complete"] = True
+            best_payload["microbatch_idx"] = 0
+            save_checkpoint_atomic(best_payload, out_dir / "best_critic.pt")
             print("  -> Saved new best model.", flush=True)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True, help="Path to YAML config")
-    parser.add_argument("--resume", default=None, help="Path to checkpoint file to resume from")
-    parser.add_argument("--transfer_from", default=None, help="Checkpoint to partially initialize compatible weights from")
+    parser.add_argument(
+        "--resume", default=None, help="Path to checkpoint file to resume from"
+    )
+    parser.add_argument(
+        "--transfer_from",
+        default=None,
+        help="Checkpoint to partially initialize compatible weights from",
+    )
     parser.add_argument("--run_id", default=None, help="Unique run id")
+    parser.add_argument("--max_time_minutes", type=float, default=None)
     args = parser.parse_args()
-    train_multi_task(args.config, args.resume, args.run_id, args.transfer_from)
+    train_multi_task(
+        args.config,
+        args.resume,
+        args.run_id,
+        args.transfer_from,
+        args.max_time_minutes,
+    )

--- a/tests/test_corrected_protein_critic_config.py
+++ b/tests/test_corrected_protein_critic_config.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_corrected_critic_config_freezes_architecture_and_tasks():
+    cfg = yaml.safe_load(
+        (ROOT / "configs" / "corrected_protein_critic_v1.yaml").read_text()
+    )
+    assert (cfg["n_layer"], cfg["n_head"], cfg["n_embd"]) == (8, 8, 256)
+    assert cfg["bidirectional"] is True
+    assert cfg["pooling"] == "attention"
+    assert cfg["transfer_from"] is None
+    assert cfg["saliency_regularizer_weight"] == 0.0
+    assert cfg["regression_tasks"] == ["stability"]
+    assert cfg["dataset_manifest"].endswith("corrected-v2/manifest.json")

--- a/tests/test_multi_task_wall_time.py
+++ b/tests/test_multi_task_wall_time.py
@@ -1,40 +1,44 @@
-import os
 import sys
 import yaml
-import pytest
 import subprocess
 import json
 import shutil
+import torch
 from pathlib import Path
+
 
 def test_train_multi_task_wall_time_limit(tmp_path):
     # Create tiny train and val jsonl files
     train_data = tmp_path / "train.jsonl"
     val_data = tmp_path / "val.jsonl"
-    
+
     sample = {
         "sequence": "MKLVFLVLLFLGAVG",
         "pfam_id": 0,
         "ec_id": 0,
-        "stability_id": 0
+        "stability_id": 0,
     }
-    
+
     with open(train_data, "w") as f:
         # Write multiple samples to allow multiple batches/steps
         for _ in range(20):
             f.write(json.dumps(sample) + "\n")
-            
+
     with open(val_data, "w") as f:
         for _ in range(5):
             f.write(json.dumps(sample) + "\n")
 
     task_vocabs = tmp_path / "task_vocabs.json"
-    task_vocabs.write_text(json.dumps({
-        "pfam": {"pfam_0": 0},
-        "ec": {"ec_0": 0},
-        "stability": {"stable": 0},
-    }))
-            
+    task_vocabs.write_text(
+        json.dumps(
+            {
+                "pfam": {"pfam_0": 0},
+                "ec": {"ec_0": 0},
+                "stability": {"stable": 0},
+            }
+        )
+    )
+
     # Create tiny config
     config_data = {
         "device": "cpu",
@@ -53,41 +57,49 @@ def test_train_multi_task_wall_time_limit(tmp_path):
         "out_dir": str(tmp_path / "checkpoints"),
         "max_time_minutes": 0.0001,  # extremely small limit: 6ms
     }
-    
+
     config_file = tmp_path / "config.yaml"
     with open(config_file, "w") as f:
         yaml.safe_dump(config_data, f)
-        
+
     # Run train_multi_task.py in a subprocess from workspace root with a custom run_id
     run_id = "test_run_multi_task_wall_time_temp"
     cmd = [
         sys.executable,
-        "-m", "src.protein_lm.train_multi_task",
-        "--config", str(config_file),
-        "--run_id", run_id,
+        "-m",
+        "src.protein_lm.train_multi_task",
+        "--config",
+        str(config_file),
+        "--run_id",
+        run_id,
     ]
-    
+
     workspace_root = Path(__file__).resolve().parents[1]
     runs_dir = Path(workspace_root) / "runs" / run_id
-    
+
     # Ensure any previous temp run dir is clean
     if runs_dir.exists():
         shutil.rmtree(runs_dir)
-        
+
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, cwd=workspace_root)
         print("STDOUT:", result.stdout)
         print("STDERR:", result.stderr)
-        
+
         assert result.returncode == 0
-        
+
         # Verify that checkpoints directory contains last_critic.pt
         last_critic_pt = runs_dir / "checkpoints" / "last_critic.pt"
         assert last_critic_pt.exists()
-        
+        checkpoint = torch.load(last_critic_pt, map_location="cpu")
+        assert checkpoint["checkpoint_reason"] == "wall_time"
+        assert checkpoint["epoch_complete"] is False
+        assert not (runs_dir / "checkpoints" / "best_critic.pt").exists()
+
         # Verify curves.csv contains header and exists
         curves_csv = runs_dir / "scores" / "curves.csv"
         assert curves_csv.exists()
+        assert len(curves_csv.read_text().splitlines()) == 1
     finally:
         if runs_dir.exists():
             shutil.rmtree(runs_dir)

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -1,9 +1,19 @@
 import json
+import hashlib
 
+import pytest
 import torch
 
-from scripts.eval_multi_task_critic import threshold_metrics, top_fraction_enrichment
-from scripts.prepare_protein_type_dataset import PROTEIN_TYPE_LABELS, protein_type_labels, row_to_sample
+from scripts.eval_multi_task_critic import (
+    threshold_metrics,
+    top_fraction_enrichment,
+    verify_evaluation_artifact,
+)
+from scripts.prepare_protein_type_dataset import (
+    PROTEIN_TYPE_LABELS,
+    protein_type_labels,
+    row_to_sample,
+)
 from src.protein_lm.config import ProteinClassifierConfig
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
 from src.protein_lm.tokenizer import ProteinTokenizer
@@ -13,8 +23,10 @@ from src.protein_lm.dataset import (
     collate_protein_batch,
 )
 from src.protein_lm.train_multi_task import (
+    accumulation_group_size,
     compute_multi_label_pos_weight,
     load_compatible_model_weights,
+    task_losses,
 )
 
 
@@ -94,12 +106,33 @@ def test_length_bucket_sampler_groups_sorted_lengths(tmp_path):
         {"sequence": "M" * 3},
     ]
     data.write_text("".join(json.dumps(row) + "\n" for row in rows))
-    dataset = MultiTaskProteinDataset(data, tokenizer, max_length=32, dynamic_padding=True)
+    dataset = MultiTaskProteinDataset(
+        data, tokenizer, max_length=32, dynamic_padding=True
+    )
 
     batches = list(LengthBucketBatchSampler(dataset, batch_size=2, shuffle=False))
     lengths = [[dataset.sequence_length(i) for i in batch] for batch in batches]
     assert lengths == [sorted(lengths[0]), sorted(lengths[1])]
     assert max(lengths[0]) <= min(lengths[1])
+
+
+def test_length_bucket_sampler_varies_reproducibly_by_epoch(tmp_path):
+    tokenizer = ProteinTokenizer()
+    data = tmp_path / "data.jsonl"
+    rows = [{"sequence": "M" * length} for length in range(2, 18)]
+    data.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    dataset = MultiTaskProteinDataset(
+        data, tokenizer, max_length=32, dynamic_padding=True
+    )
+    sampler = LengthBucketBatchSampler(dataset, batch_size=2, shuffle=True, seed=7)
+
+    epoch_zero = list(sampler)
+    sampler.set_epoch(1)
+    epoch_one = list(sampler)
+    sampler.set_epoch(0)
+
+    assert epoch_zero != epoch_one
+    assert list(sampler) == epoch_zero
 
 
 def test_multitask_model_uses_attention_mask():
@@ -152,7 +185,9 @@ def test_transfer_loads_matching_backbone_and_skips_heads(tmp_path):
 
     assert loaded > 0
     assert "heads.family.weight" in skipped
-    assert torch.allclose(target.backbone.token_embedding.weight, source.backbone.token_embedding.weight)
+    assert torch.allclose(
+        target.backbone.token_embedding.weight, source.backbone.token_embedding.weight
+    )
 
 
 def test_compute_multi_label_pos_weight_from_dataset(tmp_path):
@@ -195,3 +230,59 @@ def test_eval_helpers_report_thresholds_and_enrichment():
     assert enrichment[0]["positive_rate"] == 0.5
     assert abs(enrichment[0]["enrichment"] - 1.25) < 1e-6
     assert abs(enrichment[1]["positive_rate"] - 0.4) < 1e-6
+
+
+def test_eval_verifies_checkpoint_bound_split(tmp_path):
+    data = tmp_path / "validation.jsonl"
+    data.write_text('{"sequence":"MKT"}\n')
+    expected = hashlib.sha256(data.read_bytes()).hexdigest()
+    checkpoint = {
+        "dataset_provenance": {
+            "status": "manifest_verified",
+            "artifacts": {"validation": {"sha256": expected}},
+        }
+    }
+
+    assert (
+        verify_evaluation_artifact(checkpoint, data, "validation")
+        == "checkpoint_verified"
+    )
+    data.write_text('{"sequence":"CHANGED"}\n')
+    with pytest.raises(ValueError, match="checkpoint provenance"):
+        verify_evaluation_artifact(checkpoint, data, "validation")
+
+
+def test_corrected_dataset_exposes_continuous_stability(tmp_path):
+    tokenizer = ProteinTokenizer()
+    data = tmp_path / "data.jsonl"
+    data.write_text(json.dumps({"sequence": "MKT", "stability_score": 2.75}) + "\n")
+    item = MultiTaskProteinDataset(data, tokenizer, dynamic_padding=True)[0]
+    assert item["stability"].dtype == torch.float32
+    assert item["stability"].item() == 2.75
+
+
+def test_task_losses_balance_classification_and_regression():
+    logits = {
+        "family": torch.tensor([[4.0, 0.0], [0.0, 4.0]]),
+        "stability": torch.tensor([[1.5], [10.0]]),
+    }
+    batch = {
+        "family": torch.tensor([0, -1]),
+        "stability": torch.tensor([2.0, float("nan")]),
+    }
+    losses = task_losses(
+        logits,
+        batch,
+        ("family",),
+        ("stability",),
+        torch.nn.CrossEntropyLoss(),
+    )
+    assert set(losses) == {"family", "stability"}
+    assert losses["family"].item() < 0.1
+    assert losses["stability"].item() == 0.125
+
+
+def test_partial_accumulation_group_uses_actual_size():
+    assert accumulation_group_size(0, loader_length=10, grad_accum_steps=4) == 4
+    assert accumulation_group_size(8, loader_length=10, grad_accum_steps=4) == 2
+    assert accumulation_group_size(9, loader_length=10, grad_accum_steps=4) == 2


### PR DESCRIPTION
## Summary
- freeze a target-bearing v2 ProteinCritic dataset and corrected 8L8H-d256 training configuration
- add continuous stability regression, task-balanced losses, correct partial accumulation, epoch-aware bucket shuffling, and resumable wall-time checkpoints
- bind training and evaluation to dataset hashes and embed provenance, vocabularies, and model specification in checkpoints
- update the corrected training track, workflow guide, benchmark records, and development log

## Verification
- pytest -q: 350 passed, 1 skipped, 1 xpassed
- targeted ruff check on changed Python files
- two-minute real-data MPS smoke: manifest verified, one optimizer step committed, incomplete checkpoint saved at microbatch 8, no validation or best checkpoint emitted

## Scope
This prepares the corrected critic for training. It does not train or calibrate the final critic; calibration requires logits from the completed checkpoint.