### PR TITLE
Benchmark and report corrected ProteinCritic training

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -173,11 +173,14 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
   seven top-level EC classes, and continuous MegaScale `deltaG`. Stability has eight
   train, one validation, and one test scaffold cluster, so it is a limited
   scaffold-held-out regression rather than a universal stability probability.
-- [ ] Retrain Pfam-family, EC-function, stability, and declared structural/protein-
+- [x] Retrain Pfam-family, EC-function, stability, and declared structural/protein-
   type heads under the corrected split; do not initialize from a holdout-exposed
   critic unless the transfer protocol proves compatibility and isolation.
   The regression-aware, manifest-bound trainer and evaluator are implemented. The
-  remaining task is the full corrected training and held-out evaluation run.
+  corrected 8L8H-d256 run completed in 139 minutes with batch 2, accumulation 16,
+  and context 512. Epoch 9 is the validation-selected checkpoint. Pfam/EC learn
+  nontrivial held-out signal, while stability generalization varies by scaffold;
+  the eight training stability clusters contain 930/47/46/29/29/21/13/7 records.
 - [ ] Calibrate every probability-producing head and report class-aware metrics,
   confidence intervals, reliability, and generated-protein OOD behavior.
 - [ ] Version the passing critic checkpoint and bind it to its dataset, labels,

--- a/configs/corrected_protein_critic_mps_benchmark.yaml
+++ b/configs/corrected_protein_critic_mps_benchmark.yaml
@@ -1,0 +1,29 @@
+candidates:
+  - name: b1_e32_ctx512
+    batch_size: 1
+    grad_accum_steps: 32
+    block_size: 512
+  - name: b2_e32_ctx512
+    batch_size: 2
+    grad_accum_steps: 16
+    block_size: 512
+  - name: b4_e32_ctx512
+    batch_size: 4
+    grad_accum_steps: 8
+    block_size: 512
+  - name: b8_e32_ctx512
+    batch_size: 8
+    grad_accum_steps: 4
+    block_size: 512
+  - name: b2_e32_ctx256
+    batch_size: 2
+    grad_accum_steps: 16
+    block_size: 256
+  - name: b4_e32_ctx256
+    batch_size: 4
+    grad_accum_steps: 8
+    block_size: 256
+  - name: b8_e32_ctx256
+    batch_size: 8
+    grad_accum_steps: 4
+    block_size: 256

--- a/configs/corrected_protein_critic_v1.yaml
+++ b/configs/corrected_protein_critic_v1.yaml
@@ -28,12 +28,12 @@ regression_tasks:
   - stability
 multi_label_tasks: []
 
-batch_size: 8
-grad_accum_steps: 8
+batch_size: 2
+grad_accum_steps: 16
 epochs: 10
 lr: 0.0001
 dynamic_padding: true
-log_every_steps: 100
+log_every_steps: 200
 checkpoint_every_steps: 0
 checkpoint_every_minutes: 30
 max_time_minutes: null

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1031,6 +1031,25 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     a held-out median baseline. Dataset v2 removes targetless records after class
     gates, reducing the trainable corpus from 34,705 to 15,054 records without
     changing the frozen source clustering or retained labels.
+*   **Corrected ProteinCritic MPS Selection and Training (2026-08-05):** The
+    initial batch-8/context-512 run entered an MPS driver-memory stall after 104
+    microbatches. An isolated real-data sweep selected batch 2, accumulation 16,
+    and context 512 at 10.60 sequences/second and 1.39 GiB peak driver memory.
+    The replacement 10-epoch run completed without a stall in about 139 minutes;
+    epoch 9 had the best validation loss (`1.76185`). Held-out Pfam top-1/top-5
+    accuracy was 36.7%/72.7% on validation and 38.5%/73.8% on test. Coarse EC
+    top-1/top-5 was 42.1%/94.3% and 43.9%/95.4%. Stability beat the training-
+    median MAE baseline on both held-out scaffolds, but validation Spearman was
+    -0.077 versus +0.296 on test. The stability training set is dominated by one
+    scaffold (930 of 1,122 records), so the head is scaffold-dependent and is not
+    yet approved as a universal stability probability or guidance signal.
+*   **ProteinCritic Evaluation and Logging Correction (2026-08-05):** Replaced
+    held-out-derived regression baselines with training-distribution mean/median
+    baselines and added balanced accuracy, macro-F1, multiclass NLL, Brier score,
+    and ECE. Future training logs report every 200 microbatches with optimizer
+    step, learning rate, sequence/residue throughput, per-task losses, MPS memory,
+    and epoch wall time. Versioned results are in
+    `docs/benchmarks/corrected_protein_critic_training_v1.json`.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -153,6 +153,21 @@ The trainer verifies every dataset artifact against the manifest before training
 treats `stability_score` as continuous regression, and stores the dataset provenance
 and model specification in each checkpoint.
 
+Before changing physical batch size or context on MPS, run the isolated critic
+benchmark:
+
+```bash
+caffeinate -i python -m scripts.benchmark_protein_critic_training \
+  --config configs/corrected_protein_critic_v1.yaml \
+  --matrix configs/corrected_protein_critic_mps_benchmark.yaml \
+  --out runs/corrected-protein-critic-mps-benchmark \
+  --force-gpu
+```
+
+The corrected M2/8 GB selection is batch 2, accumulation 16, and context 512.
+Context 256 is faster but truncates most Pfam/EC-labelled proteins and is not the
+primary scientific configuration.
+
 ---
 
 ## 3. Synonymous and Shuffling Controls

--- a/docs/benchmarks/corrected_protein_critic_mps_benchmark.json
+++ b/docs/benchmarks/corrected_protein_critic_mps_benchmark.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "status": "completed",
+  "device": "Apple M2 MPS",
+  "effective_batch_size": 32,
+  "selected": {
+    "context": 512,
+    "batch_size": 2,
+    "gradient_accumulation": 16,
+    "sequences_per_second": 10.5957,
+    "peak_driver_gib": 1.39
+  },
+  "context_512": [
+    {"batch_size": 1, "accumulation": 32, "sequences_per_second": 4.0257, "peak_driver_gib": 2.04},
+    {"batch_size": 2, "accumulation": 16, "sequences_per_second": 10.5957, "peak_driver_gib": 1.39},
+    {"batch_size": 4, "accumulation": 8, "sequences_per_second": 10.0695, "peak_driver_gib": 2.32},
+    {"batch_size": 8, "accumulation": 4, "sequences_per_second": 2.0176, "peak_driver_gib": 4.20}
+  ],
+  "context_256": [
+    {"batch_size": 2, "accumulation": 16, "sequences_per_second": 23.2938, "peak_driver_gib": 0.42},
+    {"batch_size": 4, "accumulation": 8, "sequences_per_second": 36.0669, "peak_driver_gib": 0.64},
+    {"batch_size": 8, "accumulation": 4, "sequences_per_second": 41.8071, "peak_driver_gib": 1.17}
+  ],
+  "decision": "Use context 512 because context 256 truncates 65.7% of training proteins and 75.0% of EC-labelled proteins."
+}

--- a/docs/benchmarks/corrected_protein_critic_training_v1.json
+++ b/docs/benchmarks/corrected_protein_critic_training_v1.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "run_id": "corrected-protein-critic-v1-b2e32-seed1337",
+  "status": "trained_evaluated_not_yet_calibrated",
+  "dataset_id": "corrected-protein-critic-v2",
+  "training": {
+    "device": "mps",
+    "architecture": "bidirectional_8L8H_d256_attention_pooling",
+    "context": 512,
+    "batch_size": 2,
+    "gradient_accumulation": 16,
+    "effective_batch_size": 32,
+    "epochs": 10,
+    "runtime_minutes": 139,
+    "best_epoch": 9,
+    "best_validation_loss": 1.7618500577030523,
+    "final_validation_loss": 1.7881
+  },
+  "checkpoint_sha256": {
+    "best": "37467f1a6da8f09cddbb7d36dde0c3d7e0379d3f072105106e727d0ba55dfde0",
+    "last": "f6b730c14b5e9247c5a111011b556b5fe0b4bca5f47ec55ac6c21290c6100967"
+  },
+  "validation": {
+    "pfam": {
+      "top1_accuracy": 0.3668903803,
+      "balanced_accuracy": 0.3089989945,
+      "macro_f1": 0.2607205218,
+      "top5_accuracy": 0.7270693512,
+      "ece": 0.1037626437
+    },
+    "ec_top_level": {
+      "top1_accuracy": 0.4206500956,
+      "balanced_accuracy": 0.2190029002,
+      "macro_f1": 0.2093103741,
+      "top5_accuracy": 0.9426386233,
+      "ece": 0.0779735524
+    },
+    "stability_delta_g": {
+      "mae": 1.0923950106,
+      "rmse": 1.2948164428,
+      "pearson": -0.020507581,
+      "spearman": -0.0772620722,
+      "training_median_baseline_mae": 1.2097608129,
+      "training_mean_baseline_rmse": 1.2051391149
+    }
+  },
+  "test": {
+    "pfam": {
+      "top1_accuracy": 0.3847780127,
+      "balanced_accuracy": 0.3017729205,
+      "macro_f1": 0.2670396759,
+      "top5_accuracy": 0.7378435518,
+      "ece": 0.0608958131
+    },
+    "ec_top_level": {
+      "top1_accuracy": 0.4390715667,
+      "balanced_accuracy": 0.2380342699,
+      "macro_f1": 0.2232624696,
+      "top5_accuracy": 0.9535783366,
+      "ece": 0.0838703104
+    },
+    "stability_delta_g": {
+      "mae": 0.7618134744,
+      "rmse": 1.1218989357,
+      "pearson": 0.248130179,
+      "spearman": 0.2963662461,
+      "training_median_baseline_mae": 2.5780145115,
+      "training_mean_baseline_rmse": 2.020461319
+    }
+  },
+  "stability_scaffold_imbalance": {
+    "training_clusters": 8,
+    "records_by_cluster": [930, 47, 46, 29, 29, 21, 13, 7],
+    "validation_clusters": 1,
+    "test_clusters": 1
+  },
+  "limitations": [
+    "Classification probabilities have not been temperature calibrated.",
+    "Rare Pfam and EC classes have low or zero recall despite nontrivial top-k accuracy.",
+    "Stability behavior varies by held-out scaffold and the training labels are dominated by one scaffold.",
+    "The test split was evaluated once after selecting epoch 9 on validation and must not guide hyperparameter selection."
+  ]
+}

--- a/scripts/benchmark_protein_critic_training.py
+++ b/scripts/benchmark_protein_critic_training.py
@@ -1,0 +1,369 @@
+"""Subprocess-isolated ProteinCritic MPS throughput benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import torch
+import yaml
+
+from src.protein_lm.config import ProteinClassifierConfig
+from src.protein_lm.dataset import MultiTaskProteinDataset, collate_protein_batch
+from src.protein_lm.models_multi import MultiTaskProteinClassifier
+from src.protein_lm.tokenizer import ProteinTokenizer
+from src.protein_lm.train_multi_task import task_losses
+
+
+def stratified_indices(dataset, count: int) -> list[int]:
+    """Select a deterministic length-stratified sample, including both endpoints."""
+    count = min(int(count), len(dataset))
+    if count < 1:
+        raise ValueError("sample count must be positive")
+    ordered = sorted(range(len(dataset)), key=dataset.sequence_length)
+    if count == 1:
+        return [ordered[len(ordered) // 2]]
+    positions = [round(i * (len(ordered) - 1) / (count - 1)) for i in range(count)]
+    return [ordered[position] for position in positions]
+
+
+def candidate_batches(indices: list[int], batch_size: int) -> list[list[int]]:
+    batch_size = int(batch_size)
+    if batch_size < 1:
+        raise ValueError("batch size must be positive")
+    return [indices[i : i + batch_size] for i in range(0, len(indices), batch_size)]
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "mps":
+        torch.mps.synchronize()
+    elif device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _memory(device: torch.device) -> tuple[int, int]:
+    if device.type == "mps":
+        current = getattr(torch.mps, "current_allocated_memory", lambda: 0)()
+        driver = getattr(torch.mps, "driver_allocated_memory", lambda: 0)()
+        return int(current), int(driver)
+    if device.type == "cuda":
+        return int(torch.cuda.max_memory_allocated(device)), int(
+            torch.cuda.max_memory_reserved(device)
+        )
+    return 0, 0
+
+
+def _device(name: str) -> torch.device:
+    if name == "auto":
+        if torch.backends.mps.is_available():
+            return torch.device("mps")
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+    return torch.device(name)
+
+
+def run_worker(args) -> dict:
+    cfg = yaml.safe_load(Path(args.config).read_text()) or {}
+    device = _device(args.device)
+    if args.force_gpu and device.type == "cpu":
+        raise RuntimeError(
+            "GPU benchmark requested but neither MPS nor CUDA is available"
+        )
+    torch.manual_seed(int(cfg.get("seed", 1337)))
+
+    tokenizer = ProteinTokenizer()
+    vocabs = json.loads(Path(cfg["task_vocabs"]).read_text())
+    regression_tasks = tuple(cfg.get("regression_tasks", []))
+    classification_tasks = tuple(
+        task
+        for task in ("family", "function", "stability")
+        if task not in regression_tasks
+    )
+    task_dims = {
+        "family": len(vocabs["pfam"]),
+        "function": len(vocabs["ec"]),
+        "stability": 1 if "stability" in regression_tasks else len(vocabs["stability"]),
+    }
+    block_size = int(args.block_size or cfg.get("block_size", 512))
+    model_cfg = ProteinClassifierConfig(
+        vocab_size=len(tokenizer.vocab),
+        block_size=block_size,
+        n_layer=int(cfg.get("n_layer", 4)),
+        n_head=int(cfg.get("n_head", 4)),
+        n_embd=int(cfg.get("n_embd", 128)),
+        dropout=float(cfg.get("dropout", 0.1)),
+        num_classes=0,
+        use_checkpoint=bool(args.use_checkpoint),
+        pooling=cfg.get("pooling", "mean"),
+        bidirectional=bool(cfg.get("bidirectional", True)),
+    )
+    model = MultiTaskProteinClassifier(model_cfg, task_dims).to(device).train()
+    dataset = MultiTaskProteinDataset(
+        cfg["train_data"],
+        tokenizer,
+        max_length=block_size,
+        dynamic_padding=True,
+    )
+    effective_batch = int(args.batch_size) * int(args.grad_accum_steps)
+    measured_indices = stratified_indices(dataset, effective_batch * int(args.groups))
+    batches = candidate_batches(measured_indices, args.batch_size)
+    warmup_indices = stratified_indices(dataset, args.batch_size)
+    warmup_batches = candidate_batches(warmup_indices, args.batch_size)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=float(cfg.get("lr", 1e-4)))
+    criterion = torch.nn.CrossEntropyLoss(ignore_index=-1)
+
+    def execute(
+        batch_indices: list[int], divisor: int
+    ) -> tuple[int, int, dict[str, float]]:
+        batch = collate_protein_batch(
+            [dataset[index] for index in batch_indices], tokenizer.pad_token_id
+        )
+        input_ids = batch["input_ids"].to(device)
+        attention_mask = batch["attention_mask"].to(device)
+        logits = model(input_ids, attention_mask=attention_mask)
+        losses = task_losses(
+            logits,
+            {
+                task: batch[task].to(device)
+                for task in (*classification_tasks, *regression_tasks)
+            },
+            classification_tasks,
+            regression_tasks,
+            criterion,
+        )
+        if not losses:
+            raise RuntimeError("benchmark batch has no supervised targets")
+        (torch.stack(list(losses.values())).mean() / divisor).backward()
+        task_values = {
+            name: float(value.detach().cpu()) for name, value in losses.items()
+        }
+        return int(attention_mask.sum()), int(input_ids.numel()), task_values
+
+    optimizer.zero_grad(set_to_none=True)
+    for batch_indices in warmup_batches:
+        execute(batch_indices, len(warmup_batches))
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+    _sync(device)
+
+    if device.type == "mps":
+        reset_peak = getattr(torch.mps, "reset_peak_memory_stats", None)
+        if callable(reset_peak):
+            reset_peak()
+    elif device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats(device)
+
+    batch_seconds = []
+    optimizer_seconds = []
+    useful_residues = 0
+    padded_tokens = 0
+    task_sums: dict[str, float] = {}
+    task_counts: dict[str, int] = {}
+    peak_current = 0
+    peak_driver = 0
+    started = time.perf_counter()
+    for group in range(int(args.groups)):
+        group_batches = batches[
+            group * int(args.grad_accum_steps) : (group + 1)
+            * int(args.grad_accum_steps)
+        ]
+        optimizer.zero_grad(set_to_none=True)
+        for batch_indices in group_batches:
+            _sync(device)
+            before = time.perf_counter()
+            useful, padded, values = execute(batch_indices, len(group_batches))
+            _sync(device)
+            batch_seconds.append(time.perf_counter() - before)
+            useful_residues += useful
+            padded_tokens += padded
+            for task, value in values.items():
+                task_sums[task] = task_sums.get(task, 0.0) + value
+                task_counts[task] = task_counts.get(task, 0) + 1
+            current, driver = _memory(device)
+            peak_current = max(peak_current, current)
+            peak_driver = max(peak_driver, driver)
+        _sync(device)
+        before = time.perf_counter()
+        optimizer.step()
+        _sync(device)
+        optimizer_seconds.append(time.perf_counter() - before)
+    wall_seconds = time.perf_counter() - started
+
+    ordered = sorted(batch_seconds)
+
+    def percentile(fraction: float) -> float:
+        index = min(len(ordered) - 1, math.ceil(fraction * len(ordered)) - 1)
+        return ordered[index]
+
+    seq_count = len(measured_indices)
+    seq_per_sec = seq_count / wall_seconds
+    return {
+        "status": "ok",
+        "device": str(device),
+        "batch_size": int(args.batch_size),
+        "grad_accum_steps": int(args.grad_accum_steps),
+        "effective_batch_size": effective_batch,
+        "block_size": block_size,
+        "use_checkpoint": bool(args.use_checkpoint),
+        "groups": int(args.groups),
+        "sequences": seq_count,
+        "useful_residues": useful_residues,
+        "padded_tokens": padded_tokens,
+        "padding_fraction": 1.0 - useful_residues / max(padded_tokens, 1),
+        "wall_seconds": wall_seconds,
+        "seq_per_sec": seq_per_sec,
+        "residues_per_sec": useful_residues / wall_seconds,
+        "estimated_train_hours_per_epoch": len(dataset) / seq_per_sec / 3600.0,
+        "microbatch_p50_seconds": percentile(0.50),
+        "microbatch_p95_seconds": percentile(0.95),
+        "microbatch_max_seconds": max(batch_seconds),
+        "optimizer_mean_seconds": sum(optimizer_seconds) / len(optimizer_seconds),
+        "peak_allocated_bytes": peak_current,
+        "peak_driver_bytes": peak_driver,
+        "task_losses": {
+            task: task_sums[task] / task_counts[task] for task in sorted(task_sums)
+        },
+        "sample_min_length": min(dataset.sequence_length(i) for i in measured_indices),
+        "sample_max_length": max(dataset.sequence_length(i) for i in measured_indices),
+    }
+
+
+def run_candidate(
+    config: str, candidate: dict, timeout_seconds: int, force_gpu: bool
+) -> dict:
+    command = [
+        sys.executable,
+        "-m",
+        "scripts.benchmark_protein_critic_training",
+        "--worker",
+        "--config",
+        config,
+        "--batch-size",
+        str(candidate["batch_size"]),
+        "--grad-accum-steps",
+        str(candidate["grad_accum_steps"]),
+        "--groups",
+        str(candidate.get("groups", 1)),
+        "--device",
+        str(candidate.get("device", "auto")),
+    ]
+    if candidate.get("block_size"):
+        command.extend(["--block-size", str(candidate["block_size"])])
+    if candidate.get("use_checkpoint"):
+        command.append("--use-checkpoint")
+    if force_gpu:
+        command.append("--force-gpu")
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {**candidate, "status": "timeout", "timeout_seconds": timeout_seconds}
+    if completed.returncode != 0:
+        return {
+            **candidate,
+            "status": "error",
+            "returncode": completed.returncode,
+            "error": completed.stderr[-4000:],
+        }
+    lines = [
+        line
+        for line in completed.stdout.splitlines()
+        if line.startswith("RESULT_JSON=")
+    ]
+    if not lines:
+        return {**candidate, "status": "error", "error": "worker emitted no result"}
+    result = json.loads(lines[-1].split("=", 1)[1])
+    result["name"] = candidate["name"]
+    return result
+
+
+def write_results(out_dir: Path, results: list[dict]) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "results.json").write_text(
+        json.dumps({"results": results}, indent=2) + "\n"
+    )
+    fields = [
+        "name",
+        "status",
+        "device",
+        "batch_size",
+        "grad_accum_steps",
+        "effective_batch_size",
+        "block_size",
+        "seq_per_sec",
+        "residues_per_sec",
+        "estimated_train_hours_per_epoch",
+        "padding_fraction",
+        "microbatch_p50_seconds",
+        "microbatch_p95_seconds",
+        "microbatch_max_seconds",
+        "optimizer_mean_seconds",
+        "peak_allocated_bytes",
+        "peak_driver_bytes",
+        "error",
+    ]
+    with (out_dir / "results.csv").open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(results)
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--matrix")
+    parser.add_argument("--out", default="runs/protein_critic_mps_benchmark")
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--force-gpu", action="store_true")
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--batch-size", type=int)
+    parser.add_argument("--grad-accum-steps", type=int)
+    parser.add_argument("--groups", type=int, default=1)
+    parser.add_argument("--block-size", type=int)
+    parser.add_argument("--use-checkpoint", action="store_true")
+    parser.add_argument("--device", default="auto")
+    args = parser.parse_args(argv)
+    if args.worker:
+        result = run_worker(args)
+        print("RESULT_JSON=" + json.dumps(result, sort_keys=True), flush=True)
+        return
+    if not args.matrix:
+        raise ValueError("--matrix is required for a benchmark sweep")
+    matrix = yaml.safe_load(Path(args.matrix).read_text()) or {}
+    results = []
+    for candidate in matrix.get("candidates", []):
+        print(f"[critic-bench] running {candidate['name']}", flush=True)
+        result = run_candidate(
+            args.config,
+            candidate,
+            timeout_seconds=int(args.timeout_seconds),
+            force_gpu=bool(args.force_gpu),
+        )
+        results.append(result)
+        if result["status"] == "ok":
+            print(
+                f"[critic-bench] {candidate['name']}: "
+                f"{result['seq_per_sec']:.2f} seq/s, "
+                f"{result['estimated_train_hours_per_epoch']:.2f} train h/epoch, "
+                f"driver={result['peak_driver_bytes'] / 1024**3:.2f} GiB",
+                flush=True,
+            )
+        else:
+            print(f"[critic-bench] {candidate['name']}: {result['status']}", flush=True)
+        write_results(Path(args.out), results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_multi_task_critic.py
+++ b/scripts/eval_multi_task_critic.py
@@ -18,7 +18,10 @@ from torch.utils.data import DataLoader
 from sklearn.metrics import (
     accuracy_score,
     average_precision_score,
+    balanced_accuracy_score,
     classification_report,
+    f1_score,
+    log_loss,
     precision_recall_fscore_support,
     roc_auc_score,
     mean_absolute_error,
@@ -110,6 +113,38 @@ def top_fraction_enrichment(y_true, y_prob, fractions):
             }
         )
     return rows
+
+
+def expected_calibration_error(y_true, y_prob, n_bins=15):
+    confidence = y_prob.max(axis=1)
+    predictions = y_prob.argmax(axis=1)
+    correctness = predictions == y_true
+    edges = np.linspace(0.0, 1.0, int(n_bins) + 1)
+    ece = 0.0
+    for lower, upper in zip(edges[:-1], edges[1:]):
+        mask = (confidence > lower) & (confidence <= upper)
+        if mask.any():
+            ece += mask.mean() * abs(correctness[mask].mean() - confidence[mask].mean())
+    return float(ece)
+
+
+def training_regression_reference(path, task):
+    field = "stability_score" if task == "stability" else task
+    values = []
+    with Path(path).open() as handle:
+        for line in handle:
+            value = json.loads(line).get(field)
+            if value is not None and np.isfinite(value):
+                values.append(float(value))
+    if not values:
+        raise ValueError(f"no finite training targets found for regression task {task}")
+    array = np.asarray(values, dtype=np.float64)
+    return {
+        "samples": int(array.size),
+        "mean": float(array.mean()),
+        "median": float(np.median(array)),
+        "standard_deviation": float(array.std()),
+    }
 
 
 def main():
@@ -227,7 +262,7 @@ def main():
         loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False)
 
     results = {
-        task: {"preds": [], "targets": [], "top5": [], "top10": []}
+        task: {"preds": [], "targets": [], "probs": [], "top5": [], "top10": []}
         for task in task_dims
         if task not in multi_label_tasks and task not in regression_tasks
     }
@@ -259,6 +294,9 @@ def main():
                     preds = torch.argmax(logits, dim=-1)
                     results[task]["preds"].extend(preds.cpu().tolist())
                     results[task]["targets"].extend(gold.cpu().tolist())
+                    results[task]["probs"].extend(
+                        torch.softmax(logits, dim=-1).tolist()
+                    )
 
                     # Top-5 and Top-10
                     num_classes = logits.size(-1)
@@ -301,10 +339,23 @@ def main():
         y_pred = results[task]["preds"]
         if len(y_true) > 0:
             acc = accuracy_score(y_true, y_pred)
+            balanced_acc = balanced_accuracy_score(y_true, y_pred)
+            macro_f1 = f1_score(y_true, y_pred, average="macro", zero_division=0)
+            weighted_f1 = f1_score(y_true, y_pred, average="weighted", zero_division=0)
+            probabilities = np.asarray(results[task]["probs"], dtype=np.float64)
+            probabilities /= probabilities.sum(axis=1, keepdims=True)
+            labels = np.arange(probabilities.shape[1])
+            nll = log_loss(y_true, probabilities, labels=labels)
+            one_hot = np.eye(probabilities.shape[1])[np.asarray(y_true)]
+            brier = np.mean(np.sum((probabilities - one_hot) ** 2, axis=1))
+            ece = expected_calibration_error(np.asarray(y_true), probabilities)
             print("==================================================")
             print(f"Task: {task}")
             print(f"  Samples evaluated: {len(y_true)}")
             print(f"  Top-1 Accuracy: {acc:.4f}")
+            print(f"  Balanced Accuracy: {balanced_acc:.4f}")
+            print(f"  Macro-F1: {macro_f1:.4f}")
+            print(f"  NLL: {nll:.4f} | ECE: {ece:.4f}")
             if task in ["family", "function"]:
                 top5_acc = sum(results[task]["top5"]) / len(y_true)
                 top10_acc = sum(results[task]["top10"]) / len(y_true)
@@ -313,6 +364,14 @@ def main():
             summary["single_label"][task] = {
                 "samples": len(y_true),
                 "top1_accuracy": float(acc),
+                "balanced_accuracy": float(balanced_acc),
+                "macro_f1": float(macro_f1),
+                "weighted_f1": float(weighted_f1),
+                "negative_log_likelihood": float(nll),
+                "multiclass_brier": float(brier),
+                "expected_calibration_error": float(ece),
+                "top5_accuracy": float(sum(results[task]["top5"]) / len(y_true)),
+                "top10_accuracy": float(sum(results[task]["top10"]) / len(y_true)),
             }
             print("--------------------------------------------------")
             print(classification_report(y_true, y_pred, zero_division=0))
@@ -408,23 +467,28 @@ def main():
         rmse = mean_squared_error(y_true, y_pred) ** 0.5
         pearson = pearsonr(y_true, y_pred).statistic if y_true.size > 1 else np.nan
         spearman = spearmanr(y_true, y_pred).statistic if y_true.size > 1 else np.nan
-        baseline_mae = mean_absolute_error(
-            y_true, np.full_like(y_true, np.median(y_true))
-        )
+        reference = training_regression_reference(cfg["train_data"], task)
+        median_predictions = np.full_like(y_true, reference["median"])
+        mean_predictions = np.full_like(y_true, reference["mean"])
+        baseline_mae = mean_absolute_error(y_true, median_predictions)
+        baseline_rmse = mean_squared_error(y_true, mean_predictions) ** 0.5
         summary["regression"][task] = {
             "samples": int(y_true.size),
             "mae": float(mae),
             "rmse": float(rmse),
             "pearson": _safe_float(pearson),
             "spearman": _safe_float(spearman),
-            "median_baseline_mae": float(baseline_mae),
+            "training_reference": reference,
+            "training_median_baseline_mae": float(baseline_mae),
+            "training_mean_baseline_rmse": float(baseline_rmse),
         }
         print("==================================================")
         print(f"Task: {task} ({args.split})")
         print(
             f"  Samples: {y_true.size} | MAE: {mae:.4f} | RMSE: {rmse:.4f} "
             f"| Pearson: {pearson:.4f} | Spearman: {spearman:.4f} "
-            f"| Median-baseline MAE: {baseline_mae:.4f}"
+            f"| Training-median MAE: {baseline_mae:.4f} "
+            f"| Training-mean RMSE: {baseline_rmse:.4f}"
         )
 
     if args.out_json:

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -452,12 +452,18 @@ def train_multi_task(
     for epoch in range(start_epoch, epochs):
         if time_limit_reached:
             break
+        epoch_started = time.perf_counter()
         if dynamic_padding:
             train_loader.batch_sampler.set_epoch(epoch)
         model.train()
         train_loss = 0.0
         recent_loss = 0.0
         recent_steps = 0
+        recent_sequences = 0
+        recent_residues = 0
+        recent_task_sums = {}
+        recent_task_counts = {}
+        recent_started = time.perf_counter()
         optimizer.zero_grad()
 
         for step, batch in enumerate(train_loader):
@@ -513,6 +519,12 @@ def train_multi_task(
             if supervised_losses:
                 loss += torch.stack(list(supervised_losses.values())).mean()
                 tasks_added += 1
+                for task, task_loss in supervised_losses.items():
+                    recent_task_sums[task] = (
+                        recent_task_sums.get(task, torch.zeros((), device=device))
+                        + task_loss.detach()
+                    )
+                    recent_task_counts[task] = recent_task_counts.get(task, 0) + 1
             for task in multi_label_tasks:
                 targets = batch[task].to(device)
                 if targets.numel() and (targets >= 0).any():
@@ -528,6 +540,8 @@ def train_multi_task(
                 train_loss += loss.item() * group_size
                 recent_loss += loss.item() * group_size
                 recent_steps += 1
+                recent_sequences += input_ids.shape[0]
+                recent_residues += int(attention_mask.sum().item())
 
             if (step + 1) % grad_accum_steps == 0 or (step + 1) == len(train_loader):
                 optimizer.step()
@@ -539,18 +553,34 @@ def train_multi_task(
 
             if log_every_steps and (step + 1) % log_every_steps == 0:
                 elapsed = time.perf_counter() - start_time
+                interval_elapsed = time.perf_counter() - recent_started
                 avg_recent_loss = recent_loss / max(recent_steps, 1)
+                task_text = " ".join(
+                    f"{task}_loss={float(total.cpu()) / recent_task_counts[task]:.4f}"
+                    for task, total in sorted(recent_task_sums.items())
+                )
+                task_suffix = f" {task_text}" if task_text else ""
+                memory_suffix = mps_memory_summary() if device.type == "mps" else ""
                 print(
                     f"[progress] epoch={epoch + 1}/{epochs} "
                     f"step={step + 1}/{len(train_loader)} "
                     f"elapsed_min={elapsed / 60:.1f} "
                     f"recent_loss={avg_recent_loss:.4f} "
+                    f"optimizer_step={optimizer_step} "
+                    f"lr={optimizer.param_groups[0]['lr']:.2e} "
+                    f"seq_per_sec={recent_sequences / max(interval_elapsed, 1e-9):.2f} "
+                    f"residues_per_sec={recent_residues / max(interval_elapsed, 1e-9):.0f} "
                     f"batch_seq_len={input_ids.shape[1]}"
-                    f"{mps_memory_summary() if device.type == 'mps' else ''}",
+                    f"{task_suffix}{memory_suffix}",
                     flush=True,
                 )
                 recent_loss = 0.0
                 recent_steps = 0
+                recent_sequences = 0
+                recent_residues = 0
+                recent_task_sums = {}
+                recent_task_counts = {}
+                recent_started = time.perf_counter()
 
             # Check wall-time limit at the end of every step
             if wall_timer.expired():
@@ -625,6 +655,10 @@ def train_multi_task(
             torch.mps.empty_cache()
         print(
             f"Epoch {epoch + 1}/{epochs} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}",
+            flush=True,
+        )
+        print(
+            f"[timing] epoch={epoch + 1} wall_sec={time.perf_counter() - epoch_started:.2f}",
             flush=True,
         )
 

--- a/tests/test_corrected_protein_critic_config.py
+++ b/tests/test_corrected_protein_critic_config.py
@@ -17,3 +17,6 @@ def test_corrected_critic_config_freezes_architecture_and_tasks():
     assert cfg["saliency_regularizer_weight"] == 0.0
     assert cfg["regression_tasks"] == ["stability"]
     assert cfg["dataset_manifest"].endswith("corrected-v2/manifest.json")
+    assert cfg["batch_size"] == 2
+    assert cfg["grad_accum_steps"] == 16
+    assert cfg["log_every_steps"] == 200

--- a/tests/test_protein_critic_training_benchmark.py
+++ b/tests/test_protein_critic_training_benchmark.py
@@ -1,0 +1,28 @@
+from scripts.benchmark_protein_critic_training import (
+    candidate_batches,
+    stratified_indices,
+)
+
+
+class LengthDataset:
+    def __init__(self, lengths):
+        self.lengths = lengths
+
+    def __len__(self):
+        return len(self.lengths)
+
+    def sequence_length(self, index):
+        return self.lengths[index]
+
+
+def test_stratified_indices_include_length_endpoints():
+    dataset = LengthDataset([50, 10, 40, 20, 30])
+    selected = stratified_indices(dataset, 3)
+    assert [dataset.sequence_length(index) for index in selected] == [10, 30, 50]
+
+
+def test_candidate_batches_preserve_same_sample():
+    indices = list(range(8))
+    batches = candidate_batches(indices, 3)
+    assert batches == [[0, 1, 2], [3, 4, 5], [6, 7]]
+    assert [index for batch in batches for index in batch] == indices

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -2,11 +2,14 @@ import json
 import hashlib
 
 import pytest
+import numpy as np
 import torch
 
 from scripts.eval_multi_task_critic import (
+    expected_calibration_error,
     threshold_metrics,
     top_fraction_enrichment,
+    training_regression_reference,
     verify_evaluation_artifact,
 )
 from scripts.prepare_protein_type_dataset import (
@@ -230,6 +233,25 @@ def test_eval_helpers_report_thresholds_and_enrichment():
     assert enrichment[0]["positive_rate"] == 0.5
     assert abs(enrichment[0]["enrichment"] - 1.25) < 1e-6
     assert abs(enrichment[1]["positive_rate"] - 0.4) < 1e-6
+
+
+def test_multiclass_calibration_error():
+    y_true = np.asarray([0, 1])
+    perfect = np.asarray([[1.0, 0.0], [0.0, 1.0]])
+    assert expected_calibration_error(y_true, perfect) == 0.0
+
+
+def test_regression_reference_uses_training_targets(tmp_path):
+    data = tmp_path / "train.jsonl"
+    data.write_text(
+        "".join(
+            json.dumps({"sequence": "MKT", "stability_score": value}) + "\n"
+            for value in (1.0, 2.0, 9.0)
+        )
+    )
+    reference = training_regression_reference(data, "stability")
+    assert reference["samples"] == 3
+    assert reference["median"] == 2.0
 
 
 def test_eval_verifies_checkpoint_bound_split(tmp_path):


### PR DESCRIPTION
## Summary
- add an isolated real-data ProteinCritic MPS batch/context benchmark and select batch 2, accumulation 16, context 512
- record the completed corrected 10-epoch run, checkpoint hashes, held-out metrics, limitations, and stability scaffold imbalance
- correct regression baselines to use training targets and add balanced accuracy, macro-F1, NLL, Brier, and ECE
- enrich future trainer progress logs with throughput, task losses, optimizer state, memory, and epoch timing
- update the workflow, conductor plan, and development log

## Results
- completed 10 epochs in about 139 minutes without an MPS stall
- validation-selected epoch 9, validation loss 1.76185
- test Pfam top-1/top-5 38.48%/73.78%
- test coarse EC top-1/top-5 43.91%/95.36%
- stability remains scaffold-dependent and is not promoted as a universal guidance score

## Verification
- pytest -q: 354 passed, 1 skipped, 1 xpassed
- focused ruff checks pass
- corrected validation and test artifacts verified against checkpoint provenance