### PR TITLE
Add controlled ProteinCritic class-balance ablation

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -183,6 +183,14 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
   the eight training stability clusters contain 930/47/46/29/29/21/13/7 records.
 - [ ] Calibrate every probability-producing head and report class-aware metrics,
   confidence intervals, reliability, and generated-protein OOD behavior.
+  Before further test evaluation, run one validation-selected class-balance ablation
+  against the completed seed-1337 baseline. The only experimental change is
+  training-split square-root inverse-frequency weighting (maximum 4x) for Pfam and
+  EC cross-entropy; architecture, data, seed, context, batch/accumulation, learning
+  rate, and ten-epoch budget remain fixed. Validation loss stays unweighted. Promote
+  only if both heads improve balanced accuracy or macro-F1 without more than a
+  three-point absolute top-1 loss, and stability validation MAE regresses by no more
+  than 5%. Do not inspect test metrics until that validation decision is recorded.
 - [ ] Version the passing critic checkpoint and bind it to its dataset, labels,
   architecture, and calibration artifacts.
 

--- a/configs/corrected_protein_critic_class_balanced_v1.yaml
+++ b/configs/corrected_protein_critic_class_balanced_v1.yaml
@@ -1,0 +1,41 @@
+critic_training_contract:
+  schema_version: 1
+  dataset_id: corrected-protein-critic-v2
+  role: corrected_external_critic_class_balance_ablation
+
+dataset_manifest: data/processed/protein_lm/corrected-v2/manifest.json
+train_data: data/processed/protein_lm/corrected-v2/train.jsonl
+val_data: data/processed/protein_lm/corrected-v2/validation.jsonl
+test_data: data/processed/protein_lm/corrected-v2/test.jsonl
+task_vocabs: data/processed/protein_lm/corrected-v2/task_vocabs.json
+
+run_id: corrected-protein-critic-class-balanced-v1-seed1337
+seed: 1337
+device: mps
+
+block_size: 512
+n_layer: 8
+n_head: 8
+n_embd: 256
+dropout: 0.1
+bidirectional: true
+pooling: attention
+use_checkpoint: false
+transfer_from: null
+saliency_regularizer_weight: 0.0
+
+regression_tasks:
+  - stability
+multi_label_tasks: []
+classification_class_weighting: sqrt_inverse_frequency
+classification_class_weight_max: 4.0
+
+batch_size: 2
+grad_accum_steps: 16
+epochs: 10
+lr: 0.0001
+dynamic_padding: true
+log_every_steps: 200
+checkpoint_every_steps: 0
+checkpoint_every_minutes: 30
+max_time_minutes: null

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1050,6 +1050,15 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     step, learning rate, sequence/residue throughput, per-task losses, MPS memory,
     and epoch wall time. Versioned results are in
     `docs/benchmarks/corrected_protein_critic_training_v1.json`.
+*   **ProteinCritic Class-Balance Ablation Freeze (2026-08-05):** Prepared one
+    controlled follow-up to the corrected seed-1337 critic. Pfam and EC training
+    losses use square-root inverse-frequency weights computed exclusively from the
+    frozen training split and capped at 4x; validation loss remains unweighted.
+    Dataset, architecture, context 512, batch 2/accumulation 16, seed, learning
+    rate, and ten-epoch budget are unchanged. Promotion is validation-only and
+    requires improved class-aware discrimination, no greater than a three-point
+    top-1 loss per head, and no more than 5% stability-MAE regression. Test remains
+    sealed until the decision is recorded.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -168,6 +168,18 @@ The corrected M2/8 GB selection is batch 2, accumulation 16, and context 512.
 Context 256 is faster but truncates most Pfam/EC-labelled proteins and is not the
 primary scientific configuration.
 
+After the unweighted baseline is frozen, run the validation-selected class-balance
+ablation with:
+
+```bash
+caffeinate -i python -m src.protein_lm.train_multi_task \
+  --config configs/corrected_protein_critic_class_balanced_v1.yaml
+```
+
+This config changes only the Pfam/EC training objective. It computes square-root
+inverse-frequency weights from training labels, leaves validation loss unweighted,
+and keeps the test split sealed until the conductor promotion decision is recorded.
+
 ---
 
 ## 3. Synonymous and Shuffling Controls

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -69,6 +69,54 @@ def compute_multi_label_pos_weight(dataset, task, max_weight=100.0):
     return weights.clamp(min=1.0, max=float(max_weight))
 
 
+def compute_classification_class_weight(
+    dataset,
+    task: str,
+    num_classes: int,
+    mode: str = "sqrt_inverse_frequency",
+    max_weight: float = 4.0,
+) -> torch.Tensor:
+    """Compute class weights from training labels only."""
+    sample_fields = {
+        "family": "pfam_id",
+        "function": "ec_id",
+        "stability": "stability_id",
+    }
+    if task not in sample_fields:
+        raise ValueError(f"Unsupported classification task: {task}")
+    if mode not in {"inverse_frequency", "sqrt_inverse_frequency"}:
+        raise ValueError(f"Unsupported classification class-weighting mode: {mode}")
+    if num_classes < 1:
+        raise ValueError("num_classes must be positive")
+    if max_weight <= 0:
+        raise ValueError("classification_class_weight_max must be positive")
+
+    counts = torch.zeros(num_classes, dtype=torch.float32)
+    field = sample_fields[task]
+    for sample in dataset.samples:
+        label = sample.get(field, -1)
+        if label is None or int(label) == -1:
+            continue
+        label = int(label)
+        if label < 0 or label >= num_classes:
+            raise ValueError(
+                f"Training label {label} for {task} is outside [0, {num_classes})"
+            )
+        counts[label] += 1
+
+    missing = torch.nonzero(counts == 0, as_tuple=False).flatten().tolist()
+    if missing:
+        raise ValueError(
+            f"Training split has no examples for {task} classes: {missing}"
+        )
+
+    weights = counts.sum() / (num_classes * counts)
+    if mode == "sqrt_inverse_frequency":
+        weights = weights.sqrt()
+    weights = weights / weights.mean()
+    return weights.clamp(max=float(max_weight))
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -118,14 +166,15 @@ def task_losses(
     batch: dict,
     classification_tasks: tuple[str, ...],
     regression_tasks: tuple[str, ...],
-    criterion: nn.Module,
+    criterion: nn.Module | dict[str, nn.Module],
 ) -> dict[str, torch.Tensor]:
     losses = {}
     for task in classification_tasks:
         targets = batch[task]
         valid = targets != -1
         if bool(valid.any()):
-            losses[task] = criterion(logits_dict[task][valid], targets[valid])
+            task_criterion = criterion[task] if isinstance(criterion, dict) else criterion
+            losses[task] = task_criterion(logits_dict[task][valid], targets[valid])
     for task in regression_tasks:
         targets = batch[task].float()
         valid = torch.isfinite(targets)
@@ -315,8 +364,34 @@ def train_multi_task(
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=float(cfg.get("lr", 1e-4)))
 
-    # CrossEntropyLoss with ignore_index=-1 handles the missing labels
-    criterion = nn.CrossEntropyLoss(ignore_index=-1)
+    # Class weights are derived only from the training split. Validation remains
+    # unweighted so its loss describes the frozen held-out distribution.
+    classification_weighting = cfg.get("classification_class_weighting", "none")
+    classification_weight_max = float(
+        cfg.get("classification_class_weight_max", 4.0)
+    )
+    train_classification_criteria = {}
+    for task in classification_tasks:
+        class_weight = None
+        if classification_weighting != "none":
+            class_weight = compute_classification_class_weight(
+                train_ds,
+                task,
+                task_dims[task],
+                mode=classification_weighting,
+                max_weight=classification_weight_max,
+            ).to(device)
+            print(
+                f"[*] Classification weight for {task}: "
+                f"min={float(class_weight.min().cpu()):.4f} "
+                f"max={float(class_weight.max().cpu()):.4f} "
+                f"mean={float(class_weight.mean().cpu()):.4f}",
+                flush=True,
+            )
+        train_classification_criteria[task] = nn.CrossEntropyLoss(
+            weight=class_weight, ignore_index=-1
+        )
+    validation_classification_criterion = nn.CrossEntropyLoss(ignore_index=-1)
     multi_label_criteria = {}
     pos_weight_cfg = cfg.get("multi_label_pos_weight")
     pos_weight_max = cfg.get("multi_label_pos_weight_max", 100.0)
@@ -514,7 +589,7 @@ def train_multi_task(
                 },
                 classification_tasks,
                 regression_tasks,
-                criterion,
+                train_classification_criteria,
             )
             if supervised_losses:
                 loss += torch.stack(list(supervised_losses.values())).mean()
@@ -632,7 +707,7 @@ def train_multi_task(
                     },
                     classification_tasks,
                     regression_tasks,
-                    criterion,
+                    validation_classification_criterion,
                 )
                 if supervised_losses:
                     batch_loss += torch.stack(list(supervised_losses.values())).mean()

--- a/tests/test_corrected_protein_critic_config.py
+++ b/tests/test_corrected_protein_critic_config.py
@@ -20,3 +20,27 @@ def test_corrected_critic_config_freezes_architecture_and_tasks():
     assert cfg["batch_size"] == 2
     assert cfg["grad_accum_steps"] == 16
     assert cfg["log_every_steps"] == 200
+
+
+def test_class_balanced_critic_config_changes_only_training_objective():
+    baseline = yaml.safe_load(
+        (ROOT / "configs" / "corrected_protein_critic_v1.yaml").read_text()
+    )
+    ablation = yaml.safe_load(
+        (
+            ROOT
+            / "configs"
+            / "corrected_protein_critic_class_balanced_v1.yaml"
+        ).read_text()
+    )
+    allowed_changes = {
+        "critic_training_contract",
+        "run_id",
+        "classification_class_weighting",
+        "classification_class_weight_max",
+    }
+    for key in set(baseline) | set(ablation):
+        if key not in allowed_changes:
+            assert ablation[key] == baseline[key]
+    assert ablation["classification_class_weighting"] == "sqrt_inverse_frequency"
+    assert ablation["classification_class_weight_max"] == 4.0

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -27,6 +27,7 @@ from src.protein_lm.dataset import (
 )
 from src.protein_lm.train_multi_task import (
     accumulation_group_size,
+    compute_classification_class_weight,
     compute_multi_label_pos_weight,
     load_compatible_model_weights,
     task_losses,
@@ -302,6 +303,43 @@ def test_task_losses_balance_classification_and_regression():
     assert set(losses) == {"family", "stability"}
     assert losses["family"].item() < 0.1
     assert losses["stability"].item() == 0.125
+
+
+def test_classification_class_weights_upweight_rare_training_classes():
+    dataset = type(
+        "Dataset",
+        (),
+        {"samples": [{"pfam_id": 0}] * 9 + [{"pfam_id": 1}]},
+    )()
+    weights = compute_classification_class_weight(
+        dataset,
+        "family",
+        num_classes=2,
+        mode="sqrt_inverse_frequency",
+        max_weight=4.0,
+    )
+    assert weights.mean().item() == pytest.approx(1.0)
+    assert weights[1].item() == pytest.approx(3.0 * weights[0].item())
+
+
+def test_classification_class_weights_reject_missing_training_class():
+    dataset = type("Dataset", (), {"samples": [{"ec_id": 0}]})()
+    with pytest.raises(ValueError, match="no examples"):
+        compute_classification_class_weight(dataset, "function", num_classes=2)
+
+
+def test_task_losses_select_task_specific_classification_criterion():
+    logits = {
+        "family": torch.tensor([[4.0, 0.0]]),
+        "function": torch.tensor([[4.0, 0.0]]),
+    }
+    batch = {"family": torch.tensor([0]), "function": torch.tensor([0])}
+    criteria = {
+        "family": torch.nn.CrossEntropyLoss(weight=torch.tensor([1.0, 1.0])),
+        "function": torch.nn.CrossEntropyLoss(weight=torch.tensor([1.0, 2.0])),
+    }
+    losses = task_losses(logits, batch, ("family", "function"), (), criteria)
+    assert set(losses) == {"family", "function"}
 
 
 def test_partial_accumulation_group_uses_actual_size():


### PR DESCRIPTION
Summary:
- add training-only, task-specific class weighting for ProteinCritic classification heads
- freeze a matched square-root inverse-frequency Pfam/EC ablation config
- keep validation unweighted and document validation-only promotion gates
- update the corrected training track, workflow guide, and development log

Protocol:
The ablation changes only the Pfam/EC training objective. Dataset, 8L8H-d256 architecture, context 512, batch 2/accumulation 16, seed 1337, learning rate, and ten-epoch budget remain fixed. Test stays sealed until the validation decision is recorded.

Actual training-derived weight ranges:
- Pfam: 0.3121 to 1.6585 across 43 classes
- EC: 0.5483 to 1.4926 across 7 classes

Testing:
- focused Ruff checks passed
- focused tests: 20 passed
- full suite: 358 passed, 1 skipped, 1 xpassed