### PR TITLE
Make interrupted ProteinCritic runs recoverable

### DIFF
--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -191,10 +191,12 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
   only if both heads improve balanced accuracy or macro-F1 without more than a
   three-point absolute top-1 loss, and stability validation MAE regresses by no more
   than 5%. Do not inspect test metrics until that validation decision is recorded.
-  The first attempt stalled in an MPS uninterruptible wait at epoch 1 microbatch
-  4,400 before its first 30-minute checkpoint. It produced no epoch or checkpoint
-  artifact and is excluded from evaluation. Retry 1 changes only the run ID and
-  periodic checkpoint cadence (five minutes) so another driver stall is resumable.
+  The first attempt stopped progressing at epoch 1 microbatch 4,400 before its
+  first 30-minute checkpoint. The observed macOS wait state is consistent with
+  either system sleep (for example, lid closure) or an MPS driver wait; the logs
+  cannot distinguish them. It produced no epoch or checkpoint artifact and is
+  excluded from evaluation. Retry 1 changes only the run ID and periodic checkpoint
+  cadence (five minutes) so a future interruption loses at most a bounded interval.
 - [ ] Version the passing critic checkpoint and bind it to its dataset, labels,
   architecture, and calibration artifacts.
 

--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -191,6 +191,10 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
   only if both heads improve balanced accuracy or macro-F1 without more than a
   three-point absolute top-1 loss, and stability validation MAE regresses by no more
   than 5%. Do not inspect test metrics until that validation decision is recorded.
+  The first attempt stalled in an MPS uninterruptible wait at epoch 1 microbatch
+  4,400 before its first 30-minute checkpoint. It produced no epoch or checkpoint
+  artifact and is excluded from evaluation. Retry 1 changes only the run ID and
+  periodic checkpoint cadence (five minutes) so another driver stall is resumable.
 - [ ] Version the passing critic checkpoint and bind it to its dataset, labels,
   architecture, and calibration artifacts.
 

--- a/configs/corrected_protein_critic_class_balanced_v1.yaml
+++ b/configs/corrected_protein_critic_class_balanced_v1.yaml
@@ -9,7 +9,7 @@ val_data: data/processed/protein_lm/corrected-v2/validation.jsonl
 test_data: data/processed/protein_lm/corrected-v2/test.jsonl
 task_vocabs: data/processed/protein_lm/corrected-v2/task_vocabs.json
 
-run_id: corrected-protein-critic-class-balanced-v1-seed1337
+run_id: corrected-protein-critic-class-balanced-v1-seed1337-retry1
 seed: 1337
 device: mps
 
@@ -37,5 +37,5 @@ lr: 0.0001
 dynamic_padding: true
 log_every_steps: 200
 checkpoint_every_steps: 0
-checkpoint_every_minutes: 30
+checkpoint_every_minutes: 5
 max_time_minutes: null

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1059,6 +1059,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     requires improved class-aware discrimination, no greater than a three-point
     top-1 loss per head, and no more than 5% stability-MAE regression. Test remains
     sealed until the decision is recorded.
+*   **ProteinCritic Class-Balance MPS Stall (2026-08-05):** The first ablation
+    attempt reached epoch 1 microbatch 4,400 in 21.2 active minutes, then remained
+    in macOS uninterruptible-wait state without log progress for about 84 minutes.
+    It stalled before the 30-minute periodic checkpoint and produced neither a
+    completed epoch nor a checkpoint, so it is not evaluable. The process was
+    terminated and its partial logs retained. Retry 1 keeps every scientific and
+    optimization setting fixed, uses a distinct run ID, and reduces periodic
+    checkpoint cadence to five minutes for recoverability.
 
 ---
 *End of Log*

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1059,13 +1059,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     requires improved class-aware discrimination, no greater than a three-point
     top-1 loss per head, and no more than 5% stability-MAE regression. Test remains
     sealed until the decision is recorded.
-*   **ProteinCritic Class-Balance MPS Stall (2026-08-05):** The first ablation
+*   **ProteinCritic Class-Balance Interrupted Attempt (2026-08-05):** The first ablation
     attempt reached epoch 1 microbatch 4,400 in 21.2 active minutes, then remained
-    in macOS uninterruptible-wait state without log progress for about 84 minutes.
-    It stalled before the 30-minute periodic checkpoint and produced neither a
-    completed epoch nor a checkpoint, so it is not evaluable. The process was
-    terminated and its partial logs retained. Retry 1 keeps every scientific and
-    optimization setting fixed, uses a distinct run ID, and reduces periodic
+    in a macOS wait state without log progress for about 84 minutes. This observation
+    cannot distinguish system sleep (including lid closure) from an MPS driver wait.
+    The interruption preceded the 30-minute periodic checkpoint and produced neither
+    a completed epoch nor a checkpoint, so the attempt is not evaluable. The process
+    was terminated and its partial logs retained. Retry 1 keeps every scientific
+    and optimization setting fixed, uses a distinct run ID, and reduces periodic
     checkpoint cadence to five minutes for recoverability.
 
 ---

--- a/tests/test_corrected_protein_critic_config.py
+++ b/tests/test_corrected_protein_critic_config.py
@@ -38,9 +38,12 @@ def test_class_balanced_critic_config_changes_only_training_objective():
         "run_id",
         "classification_class_weighting",
         "classification_class_weight_max",
+        "checkpoint_every_minutes",
     }
     for key in set(baseline) | set(ablation):
         if key not in allowed_changes:
             assert ablation[key] == baseline[key]
     assert ablation["classification_class_weighting"] == "sqrt_inverse_frequency"
     assert ablation["classification_class_weight_max"] == 4.0
+    assert ablation["checkpoint_every_minutes"] == 5
+    assert ablation["run_id"].endswith("seed1337-retry1")


### PR DESCRIPTION
Summary:
- record the interrupted class-balance attempt as non-evaluable
- preserve its partial logs and use a distinct retry run ID
- reduce periodic checkpoint cadence from 30 minutes to 5 minutes
- keep all scientific, model, optimizer, seed, and epoch settings unchanged

Interruption evidence:
The first attempt stopped logging at epoch 1 microbatch 4400 after 21.2 active minutes and produced no checkpoint or completed epoch. The observed macOS wait state cannot distinguish system sleep, including lid closure, from an MPS driver wait.

Testing:
- focused config tests: 2 passed
- full suite: 358 passed, 1 skipped, 1 xpassed