### PR TITLE
Add shared collision-safe training lifecycle

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -4,6 +4,11 @@ This file tracks all major tracks for the project. Each track has its own detail
 
 ---
 
+- [ ] **Track: Shared Training Run Lifecycle**
+*Link: [./tracks/shared_training_run_lifecycle_20260805/](./tracks/shared_training_run_lifecycle_20260805/)*
+*Summary: Centralize collision-safe run allocation, locking, resume lineage and
+epoch validation, completion markers, and logging across all model trainers.*
+
 - [x] **Track: Motif Mining & Cluster Analysis**
 *Link: [./tracks/motif_mining_20260210/](./tracks/motif_mining_20260210/)*
 

--- a/conductor/tracks/corrected_model_training_20260721/plan.md
+++ b/conductor/tracks/corrected_model_training_20260721/plan.md
@@ -197,6 +197,18 @@ corrected report passes its promotion criteria. Otherwise pause and audit.
   cannot distinguish them. It produced no epoch or checkpoint artifact and is
   excluded from evaluation. Retry 1 changes only the run ID and periodic checkpoint
   cadence (five minutes) so a future interruption loses at most a bounded interval.
+  Retry 1 ultimately completed after recovery. Validation-only evaluation rejects
+  class weighting: Pfam balanced accuracy/macro-F1 fell from 0.3090/0.2607 to
+  0.2846/0.2484, although EC improved from 0.2190/0.2093 to 0.2419/0.2288 and
+  stability MAE improved from 1.0924 to 1.0486. The test split remains sealed.
+- [ ] Compare the corrected critic with XGBoost on the identical frozen splits.
+  Pfam and EC controls use training-fitted amino-acid composition, sequence length,
+  and dipeptide/3-mer features; stability additionally uses declared
+  physicochemical descriptors. Select XGBoost hyperparameters on validation only
+  and report the same class-aware or regression metrics and confidence intervals.
+- [ ] Run separate XGBoost probes on frozen ProteinCritic embeddings and raw
+  sequence features. Treat improved embedding-probe performance as representation
+  evidence only when it also exceeds the matched raw-feature XGBoost control.
 - [ ] Version the passing critic checkpoint and bind it to its dataset, labels,
   architecture, and calibration artifacts.
 

--- a/conductor/tracks/corrected_model_training_20260721/spec.md
+++ b/conductor/tracks/corrected_model_training_20260721/spec.md
@@ -110,6 +110,13 @@ cluster leakage, per-head discrimination, calibration, confidence intervals, and
 out-of-distribution behavior on generated proteins. Legacy critic checkpoints remain
 exploratory and cannot decide corrected CodonLM promotion.
 
+Use XGBoost as a classical nonlinear control on the same homology/scaffold splits.
+For Pfam and EC, compare the critic with amino-acid composition, length, and local
+k-mer features. For stability, add predeclared physicochemical descriptors and use
+regression. Also compare XGBoost on frozen critic embeddings with XGBoost on raw
+features; classifier capacity must not be attributed to representation learning.
+All preprocessing and hyperparameter selection are training/validation-only.
+
 ## Stage 4: Multi-Offset Long-Range Extension
 
 Multi-offset heads predict future tokens such as `n+4`, `n+8`, `n+16`, and `n+32`

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/plan.md
@@ -102,6 +102,11 @@ reported downstream evidence uses corrected checkpoints and controlled splits.
   the declared family, function, stability, and structural tasks.
 - [ ] Report leakage, class balance, discrimination, calibration, confidence
   intervals, and generated-protein OOD behavior for every head.
+- [ ] Benchmark Pfam/EC classification and stability regression against XGBoost
+  trained on raw protein composition, length, local k-mers, and declared
+  physicochemical descriptors using the identical frozen splits.
+- [ ] Compare XGBoost on corrected embeddings with XGBoost on raw sequence features
+  so nonlinear probe capacity is not confused with pretrained representation value.
 - [ ] Version and provenance-bind any critic allowed to support corrected evaluation
   or generation guidance.
 

--- a/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
+++ b/conductor/tracks/leakage_controlled_revalidation_20260719/spec.md
@@ -101,12 +101,21 @@ declared head, measure generated-protein out-of-distribution behavior, and bind 
 checkpoint to its dataset and evaluation artifacts. Legacy critic results remain
 exploratory.
 
+The critic evaluation must include classical XGBoost controls on training-fitted raw
+protein features under the identical homology/scaffold splits. Classification uses
+amino-acid composition, length, and local k-mers; stability regression may add
+declared physicochemical descriptors. XGBoost on frozen model embeddings is a
+separate nonlinear-probe condition and must be compared directly with raw-feature
+XGBoost before attributing gains to pretrained representations.
+
 ## Corrected Evaluation Protocol
 1. Compare uniform, unigram, bigram, trigram, and CodonLM loss, perplexity, and
    bits/codon on identical token streams.
 2. Extract embeddings causally from corrected checkpoints with complete provenance.
 3. Rerun EC, essentiality, AMR, and DNA-shape evaluations with controlled group or
    protein-homology holdouts and shared folds for all controls.
+   Include paired XGBoost-on-embedding and XGBoost-on-raw-feature conditions where
+   sample size and label support permit them.
 4. Report balanced accuracy, macro-F1, macro-AUPRC, AUROC where defined, and
    class-aware confidence intervals.
 5. Audit generated sequences against training nucleotide and protein records before

--- a/conductor/tracks/shared_training_run_lifecycle_20260805/plan.md
+++ b/conductor/tracks/shared_training_run_lifecycle_20260805/plan.md
@@ -1,0 +1,33 @@
+# Shared Training Run Lifecycle Plan
+
+## Phase 1: Runtime Contract
+
+- [x] Add atomic serial-directory allocation and active-run locking.
+- [x] Add standard checkpoint, score, log, metadata, and completion paths.
+- [x] Add generic progress and newest-`last` resume validation.
+- [ ] Add immutable-setting fingerprints and explicit fork semantics. Immutable
+  fingerprints are implemented; explicit checkpoint forks remain open.
+- [x] Test duplicate, concurrent, completed, stale-best, epoch-target, and valid
+  resume cases.
+
+## Phase 2: Primary Trainers
+
+- [x] Migrate CodonLM without changing its existing checkpoint fields or scientific logic.
+- [x] Migrate multitask ProteinCritic and preserve `last_critic.pt` compatibility.
+- [x] Verify fresh serial allocation, mid-epoch resume, completion, and logging on CPU.
+  A bounded MPS lifecycle preflight remains required before global enforcement.
+
+## Phase 3: Remaining Model Trainers
+
+- [ ] Migrate protein LM and protein classifier.
+- [ ] Add resume support and migrate Protein EBM.
+- [ ] Migrate NoProp and explicitly document its experimental checkpoint contract.
+- [ ] Inventory ancillary fine-tuning entry points and either migrate or mark them
+  non-resumable with overwrite protection.
+
+## Phase 4: Documentation and Enforcement
+
+- [ ] Document fresh, resume, fork, and completed-run commands.
+- [ ] Add CI contract tests covering every registered trainer.
+- [ ] Record migration status in the development log.
+- [ ] Reject direct unguarded writes to canonical `last`/`best` paths in trainers.

--- a/conductor/tracks/shared_training_run_lifecycle_20260805/spec.md
+++ b/conductor/tracks/shared_training_run_lifecycle_20260805/spec.md
@@ -1,0 +1,29 @@
+# Shared Training Run Lifecycle
+
+## Objective
+
+Prevent every model trainer from overwriting an existing or more advanced run by
+centralizing run-directory allocation, locking, resume validation, logging paths,
+checkpoint lineage, and completion state in `src/training/runtime.py`.
+
+## Contract
+
+- A fresh launch atomically creates the requested directory or the next `-rNNN`
+  serial directory; it never writes into an existing artifact-bearing directory.
+- A resume appends only to the checkpoint's existing run directory unless an
+  explicit fork is requested with a new run ID.
+- Appending requires the selected checkpoint to be the run's newest `last`
+  checkpoint. A validation-selected `best` checkpoint is for evaluation or an
+  explicit fork, not in-place resume.
+- Configured epochs are the total target. The target must exceed completed
+  checkpoint progress.
+- A filesystem lock prevents concurrent writers.
+- Completion is recorded atomically and makes the run immutable.
+- Model-specific payloads, checkpoint names, objectives, and optimizer restoration
+  remain owned by each trainer.
+
+## Compatibility
+
+Legacy checkpoints remain readable. When legacy progress cannot be interpreted
+unambiguously, in-place resume fails with an actionable error instead of guessing.
+

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1068,6 +1068,17 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     was terminated and its partial logs retained. Retry 1 keeps every scientific
     and optimization setting fixed, uses a distinct run ID, and reduces periodic
     checkpoint cadence to five minutes for recoverability.
+*   **ProteinCritic Class-Balance Decision (2026-08-05):** The recovered run's
+    validation-selected epoch 9 reached loss 1.75596. Square-root class weighting
+    improved EC balanced accuracy/macro-F1 by 0.0229/0.0195 and stability MAE by
+    4.0%, but reduced Pfam balanced accuracy/macro-F1 by 0.0244/0.0124. It therefore
+    fails the predeclared two-head gate and is not promoted; test remains sealed.
+*   **Shared Training Lifecycle Phase 1-2 (2026-08-05):** Added a common run owner
+    with atomic serial allocation, exclusive writer locks, newest-last resume and
+    total-epoch validation, curve-history checks, immutable-setting fingerprints,
+    completion markers, shared log paths, RNG capture/restore, and numbered best
+    checkpoints. CodonLM and multitask ProteinCritic are the first migrated trainers;
+    ProteinLM, classifier, EBM, and NoProp remain explicitly open in Phase 3.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -127,6 +127,12 @@ python -m scripts.evaluate_test \
 
 ## Corrected ProteinCritic Dataset
 
+Training runs are collision-safe. A fresh launch whose run ID already exists is
+written to the next `-rNNN` directory. In-place continuation requires `--resume`
+with that run's newest `last` checkpoint and a configured total epoch target greater
+than its completed epoch count. Use a new run ID to fork from an older or best
+checkpoint; best checkpoints are evaluation artifacts, not in-place resume points.
+
 Build the homology-cluster-held-out critic artifacts before critic training:
 
 ```bash

--- a/src/codonlm/training/loop.py
+++ b/src/codonlm/training/loop.py
@@ -27,11 +27,16 @@ from src.codonlm.data_loading import (
 from src.codonlm.replay import GeneratedTerminationReplayDataset
 from src.training.runtime import (
     PeriodicCheckpointPolicy,
-    RunLogger,
     WallTimeLimitException,
     WallTimer,
     save_checkpoint_atomic,
     default_device,
+)
+from src.training.run_lifecycle import (
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
 )
 
 from src.codonlm.training.config import (
@@ -39,7 +44,6 @@ from src.codonlm.training.config import (
     _ensure_path_list,
     _normalize_run_id,
     _auto_run_id,
-    _prepare_output_dirs,
     _normalize_offset_weights,
 )
 from src.codonlm.training.checkpoint import _read_itos, _load_transfer_state_dict
@@ -405,9 +409,20 @@ def run_training(cfg: dict, args) -> None:
         run_id = _auto_run_id(cfg, args.config)
     if run_id:
         cfg["run_id"] = run_id
-    outdir = cfg["out_dir"]
-    scores_base = cfg.get("scores_dir", "outputs/scores")
-    ckpt_dir, scores_dir = _prepare_output_dirs(outdir, scores_base, run_id)
+    configured_epochs = cfg.get("epochs")
+    target_epochs = int(configured_epochs) if configured_epochs is not None else None
+    run_fingerprint = configuration_fingerprint(cfg)
+    training_run = TrainingRun.open(
+        "runs",
+        run_id,
+        resume=resume_path,
+        last_checkpoint_name="last.pt",
+        target_epochs=target_epochs,
+        config_fingerprint=run_fingerprint,
+    )
+    run_id = training_run.run_dir.name
+    cfg["run_id"] = run_id
+    ckpt_dir, scores_dir = training_run.checkpoints, training_run.scores
     accumulation_health = AccumulationHealth()
 
     vocabulary_snapshot = snapshot_vocabulary(
@@ -421,7 +436,7 @@ def run_training(cfg: dict, args) -> None:
     )
 
     shutil.copy2(args.config, ckpt_dir / "config.yaml")
-    run_logger = RunLogger(ckpt_dir.parent / "logs" / "train.log")
+    run_logger = training_run.logger()
     run_logger.__enter__()
 
     def write_failure_meta(exc: Exception) -> None:
@@ -881,6 +896,7 @@ def run_training(cfg: dict, args) -> None:
                     scheduler.load_state_dict(ckpt_resume["scheduler"])
                 except Exception as exc:
                     print(f"[resume] scheduler state load failed: {exc}")
+            restore_rng_state(ckpt_resume.get("rng_state"))
             start_epoch = int(ckpt_resume.get("epoch", 0))
             step = int(ckpt_resume.get("step", step))
             consumed_train_tokens = int(
@@ -971,6 +987,20 @@ def run_training(cfg: dict, args) -> None:
                 "accumulation_health": accumulation_health.state_dict(),
                 "max_nonfinite_accumulation_groups": max_nonfinite_groups,
                 "epoch_train_metrics": dict(epoch_train_metrics),
+                "run_progress": {
+                    "completed_epochs": (
+                        epoch_idx if val_loss != float("inf") else max(0, epoch_idx - 1)
+                    ),
+                    "current_epoch": epoch_idx,
+                    "microbatch": (
+                        0
+                        if val_loss != float("inf")
+                        else int(current_resume_microbatch_idx)
+                    ),
+                    "optimizer_step": step,
+                },
+                "rng_state": capture_rng_state(),
+                "run_fingerprint": run_fingerprint,
             }
             if use_shape_guidance and encoder is not None:
                 payload["encoder"] = encoder.state_dict()
@@ -1408,6 +1438,9 @@ def run_training(cfg: dict, args) -> None:
 
             if improved:
                 save_checkpoint_atomic(ckpt_payload, ckpt_dir / "best.pt")
+                save_checkpoint_atomic(
+                    ckpt_payload, ckpt_dir / f"best_epoch_{epoch_idx:03d}.pt"
+                )
             elif int(cfg.get("early_stop_patience", 5)) > 0 and no_improve >= int(
                 cfg.get("early_stop_patience", 5)
             ):
@@ -1421,6 +1454,7 @@ def run_training(cfg: dict, args) -> None:
             f"[checkpoint] saved {ckpt_dir / 'last.pt'} after nonfinite-group limit"
         )
         write_failure_meta(exc)
+        training_run.close()
         raise
     except WallTimeLimitException:
         print(f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.")
@@ -1462,6 +1496,7 @@ def run_training(cfg: dict, args) -> None:
         write_meta(ckpt_dir, meta)
 
         print(f"[timing] train_wall_sec={total_time:.2f} train_cpu_sec={train_cpu1-train_cpu0:.2f}")
+        training_run.close()
         return
     except Exception as exc:
         exc_str = str(exc).lower()
@@ -1510,10 +1545,12 @@ def run_training(cfg: dict, args) -> None:
                     "[OOM SAFEGUARD] Immutable primary config was not modified; "
                     "a new versioned runtime contract is required to change batch size."
                 )
+            training_run.close()
             raise exc
         else:
             print(f"[error] training failed: {exc}", file=sys.stderr)
             write_failure_meta(exc)
+            training_run.close()
             raise
 
     train_wall1 = time.perf_counter()
@@ -1548,5 +1585,14 @@ def run_training(cfg: dict, args) -> None:
         metrics_path.write_text(json.dumps(meta, indent=2) + "\n")
 
     write_meta(ckpt_dir, meta)
+    training_run.mark_complete(
+        {
+            "run_id": run_id,
+            "completed_epochs": history[-1]["epoch"] if history else start_epoch,
+            "best_epoch": best_epoch,
+            "best_validation_loss": meta["best_val_loss"],
+        }
+    )
+    training_run.close()
 
     print(f"[timing] train_wall_sec={total_time:.2f} train_cpu_sec={train_cpu1-train_cpu0:.2f}")

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -18,9 +18,14 @@ from src.protein_lm.dataset import (
 )
 from src.training.runtime import (
     PeriodicCheckpointPolicy,
-    RunLogger,
     WallTimer,
     save_checkpoint_atomic,
+)
+from src.training.run_lifecycle import (
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
 )
 
 
@@ -413,6 +418,27 @@ def train_multi_task(
             )
         multi_label_criteria[task] = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
 
+    epochs = int(cfg.get("epochs", 5))
+    run_fingerprint = configuration_fingerprint(cfg)
+    if not run_id:
+        run_id = cfg.get("run_id", None)
+    if not run_id:
+        from datetime import date
+
+        today = date.today().strftime("%Y-%m-%d")
+        tag = Path(config_path).stem
+        run_id = f"{today}_{tag}_{model_cfg.n_layer}L{model_cfg.n_head}H_d{model_cfg.n_embd}_e{epochs}"
+    training_run = TrainingRun.open(
+        "runs",
+        run_id,
+        resume=resume_path,
+        last_checkpoint_name="last_critic.pt",
+        target_epochs=epochs,
+        config_fingerprint=run_fingerprint,
+    )
+    run_id = training_run.run_dir.name
+    cfg["run_id"] = run_id
+
     best_val_loss = float("inf")
     start_epoch = 0
     optimizer_step = 0
@@ -429,6 +455,7 @@ def train_multi_task(
         )
         best_val_loss = checkpoint.get("best_val_loss", float("inf"))
         optimizer_step = int(checkpoint.get("optimizer_step", 0))
+        restore_rng_state(checkpoint.get("rng_state"))
         print(
             f"[*] Resumed checkpoint. Next epoch: {start_epoch + 1}, "
             f"microbatch: {resume_microbatch_idx} "
@@ -437,7 +464,6 @@ def train_multi_task(
         )
 
     print("[*] Starting Multi-Task Training...", flush=True)
-    epochs = cfg.get("epochs", 5)
     grad_accum_steps = cfg.get("grad_accum_steps", 1)
     print(f"[*] Gradient accumulation steps: {grad_accum_steps}", flush=True)
     log_every_steps = cfg.get("log_every_steps", 100)
@@ -452,22 +478,9 @@ def train_multi_task(
     if max_time_minutes:
         print(f"[*] Wall-time limit configured: {max_time_minutes} minutes", flush=True)
 
-    if not run_id:
-        run_id = cfg.get("run_id", None)
-    if not run_id:
-        from datetime import date
-
-        today = date.today().strftime("%Y-%m-%d")
-        tag = Path(config_path).stem
-        run_id = f"{today}_{tag}_{model_cfg.n_layer}L{model_cfg.n_head}H_d{model_cfg.n_embd}_e{epochs}"
-
-    runs_dir = Path("runs") / run_id
-    out_dir = runs_dir / "checkpoints"
-    scores_dir = runs_dir / "scores"
-
-    out_dir.mkdir(parents=True, exist_ok=True)
-    scores_dir.mkdir(parents=True, exist_ok=True)
-    run_logger = RunLogger(runs_dir / "logs" / "train.log")
+    out_dir = training_run.checkpoints
+    scores_dir = training_run.scores
+    run_logger = training_run.logger()
     run_logger.__enter__()
 
     log_csv = scores_dir / "curves.csv"
@@ -486,7 +499,7 @@ def train_multi_task(
     )
     current_microbatch_idx = 0
 
-    def checkpoint_payload(epoch_idx: int) -> dict:
+    def checkpoint_payload(epoch_idx: int, *, epoch_complete: bool = False) -> dict:
         return {
             "epoch": epoch_idx,
             "model_state_dict": model.state_dict(),
@@ -494,7 +507,15 @@ def train_multi_task(
             "best_val_loss": best_val_loss,
             "optimizer_step": optimizer_step,
             "microbatch_idx": current_microbatch_idx,
-            "epoch_complete": False,
+            "epoch_complete": epoch_complete,
+            "run_progress": {
+                "completed_epochs": epoch_idx + 1 if epoch_complete else epoch_idx,
+                "current_epoch": epoch_idx + 1,
+                "microbatch": 0 if epoch_complete else current_microbatch_idx,
+                "optimizer_step": optimizer_step,
+            },
+            "rng_state": capture_rng_state(),
+            "run_fingerprint": run_fingerprint,
             "cfg": cfg,
             "dataset_provenance": dataset_provenance,
             "task_vocabs": vocabs,
@@ -513,9 +534,10 @@ def train_multi_task(
         }
 
     def save_last(epoch_idx: int, reason: str) -> None:
-        payload = checkpoint_payload(epoch_idx)
+        epoch_complete = reason == "epoch"
+        payload = checkpoint_payload(epoch_idx, epoch_complete=epoch_complete)
         payload["checkpoint_reason"] = reason
-        payload["epoch_complete"] = reason == "epoch"
+        payload["epoch_complete"] = epoch_complete
         if payload["epoch_complete"]:
             payload["microbatch_idx"] = 0
         save_checkpoint_atomic(payload, out_dir / "last_critic.pt")
@@ -749,12 +771,25 @@ def train_multi_task(
         save_last(epoch, reason="epoch")
 
         if improved:
-            best_payload = checkpoint_payload(epoch)
+            best_payload = checkpoint_payload(epoch, epoch_complete=True)
             best_payload["checkpoint_reason"] = "best_epoch"
             best_payload["epoch_complete"] = True
             best_payload["microbatch_idx"] = 0
             save_checkpoint_atomic(best_payload, out_dir / "best_critic.pt")
+            save_checkpoint_atomic(
+                best_payload, out_dir / f"best_critic_epoch_{epoch + 1:03d}.pt"
+            )
             print("  -> Saved new best model.", flush=True)
+
+    if not time_limit_reached:
+        training_run.mark_complete(
+            {
+                "run_id": run_id,
+                "completed_epochs": epochs,
+                "best_validation_loss": best_val_loss,
+            }
+        )
+    training_run.close()
 
 
 if __name__ == "__main__":

--- a/src/training/run_lifecycle.py
+++ b/src/training/run_lifecycle.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import atexit
+import csv
+import hashlib
+import json
+import os
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+
+class RunLifecycleError(RuntimeError):
+    """Raised when a launch would corrupt or ambiguously extend a training run."""
+
+
+@dataclass(frozen=True)
+class RunProgress:
+    completed_epochs: int
+    current_epoch: int
+    microbatch: int
+    optimizer_step: int
+
+
+DEFAULT_MUTABLE_CONFIG_KEYS = {
+    "checkpoint_every_minutes",
+    "checkpoint_every_steps",
+    "epochs",
+    "log_every_steps",
+    "max_time_minutes",
+    "run_id",
+}
+
+
+def configuration_fingerprint(
+    config: dict[str, Any], mutable_keys: set[str] | None = None
+) -> str:
+    excluded = DEFAULT_MUTABLE_CONFIG_KEYS if mutable_keys is None else mutable_keys
+    immutable = {key: value for key, value in config.items() if key not in excluded}
+    encoded = json.dumps(immutable, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def checkpoint_progress(payload: dict[str, Any]) -> RunProgress:
+    progress = payload.get("run_progress")
+    if not isinstance(progress, dict):
+        if "epoch" in payload and "epoch_complete" in payload:
+            epoch = int(payload["epoch"])
+            complete = bool(payload["epoch_complete"])
+            return RunProgress(
+                completed_epochs=epoch + 1 if complete else epoch,
+                current_epoch=epoch + 1,
+                microbatch=0 if complete else int(payload.get("microbatch_idx", 0)),
+                optimizer_step=int(payload.get("optimizer_step", 0)),
+            )
+        raise RunLifecycleError(
+            "Checkpoint has no unambiguous run_progress metadata. Legacy checkpoints "
+            "must be migrated explicitly before in-place resume."
+        )
+    return RunProgress(
+        completed_epochs=int(progress.get("completed_epochs", 0)),
+        current_epoch=int(progress.get("current_epoch", 0)),
+        microbatch=int(progress.get("microbatch", 0)),
+        optimizer_step=int(progress.get("optimizer_step", 0)),
+    )
+
+
+def capture_rng_state() -> dict[str, Any]:
+    numpy_state = np.random.get_state()
+    state: dict[str, Any] = {
+        "python": random.getstate(),
+        "numpy": {
+            "bit_generator": numpy_state[0],
+            "state": numpy_state[1].tolist(),
+            "position": numpy_state[2],
+            "has_gauss": numpy_state[3],
+            "cached_gaussian": numpy_state[4],
+        },
+        "torch_cpu": torch.get_rng_state(),
+    }
+    if torch.cuda.is_available():
+        state["torch_cuda"] = torch.cuda.get_rng_state_all()
+    get_mps_state = getattr(torch.mps, "get_rng_state", None)
+    if torch.backends.mps.is_available() and callable(get_mps_state):
+        state["torch_mps"] = get_mps_state()
+    return state
+
+
+def restore_rng_state(state: dict[str, Any] | None) -> None:
+    if not state:
+        return
+    random.setstate(state["python"])
+    numpy_state = state["numpy"]
+    np.random.set_state(
+        (
+            numpy_state["bit_generator"],
+            np.asarray(numpy_state["state"], dtype=np.uint32),
+            numpy_state["position"],
+            numpy_state["has_gauss"],
+            numpy_state["cached_gaussian"],
+        )
+    )
+    torch.set_rng_state(state["torch_cpu"])
+    if "torch_cuda" in state and torch.cuda.is_available():
+        torch.cuda.set_rng_state_all(state["torch_cuda"])
+    set_mps_state = getattr(torch.mps, "set_rng_state", None)
+    if "torch_mps" in state and callable(set_mps_state):
+        set_mps_state(state["torch_mps"])
+
+
+class TrainingRun:
+    """Own a collision-safe training directory for one process."""
+
+    def __init__(self, run_dir: Path, resume_checkpoint: Path | None) -> None:
+        self.run_dir = run_dir
+        self.resume_checkpoint = resume_checkpoint
+        self.checkpoints = run_dir / "checkpoints"
+        self.scores = run_dir / "scores"
+        self.logs = run_dir / "logs"
+        self.completion_path = run_dir / "run_complete.json"
+        self.lock_path = run_dir / ".run.lock"
+        self._lock_fd: int | None = None
+        for path in (self.checkpoints, self.scores, self.logs):
+            path.mkdir(parents=True, exist_ok=True)
+        self._acquire_lock()
+        atexit.register(self.close)
+
+    @classmethod
+    def open(
+        cls,
+        root: str | Path,
+        run_id: str,
+        *,
+        resume: str | Path | None = None,
+        last_checkpoint_name: str = "last.pt",
+        target_epochs: int | None = None,
+        curve_filename: str = "curves.csv",
+        config_fingerprint: str | None = None,
+    ) -> "TrainingRun":
+        root = Path(root)
+        if resume is None:
+            run_dir = cls._allocate_serial(root, run_id)
+            return cls(run_dir, None)
+
+        checkpoint = Path(resume).expanduser().resolve()
+        if not checkpoint.is_file():
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint}")
+        run_dir = checkpoint.parent.parent if checkpoint.parent.name == "checkpoints" else checkpoint.parent
+        if run_dir.name != run_id:
+            raise RunLifecycleError(
+                f"Resume checkpoint belongs to run '{run_dir.name}', but run ID "
+                f"'{run_id}' was requested. Omit the override for in-place resume or "
+                "use an explicit new run ID to fork."
+            )
+        completion_path = run_dir / "run_complete.json"
+        newest = run_dir / "checkpoints" / last_checkpoint_name
+        if not newest.is_file() or checkpoint != newest.resolve():
+            raise RunLifecycleError(
+                f"Cannot resume run '{run_id}' from {checkpoint.name}. Use the newest "
+                f"{last_checkpoint_name} or provide a new run ID to fork."
+            )
+        payload = torch.load(checkpoint, map_location="cpu")
+        progress = checkpoint_progress(payload)
+        saved_fingerprint = payload.get("run_fingerprint")
+        if (
+            config_fingerprint is not None
+            and saved_fingerprint is not None
+            and config_fingerprint != saved_fingerprint
+        ):
+            raise RunLifecycleError(
+                "Resume configuration changes immutable run settings. Use the "
+                "checkpoint's configuration or a new run ID to fork."
+            )
+        cls._validate_curve_history(
+            run_dir / "scores" / curve_filename, progress.completed_epochs
+        )
+        if target_epochs is not None and int(target_epochs) <= progress.completed_epochs:
+            raise RunLifecycleError(
+                f"Run has {progress.completed_epochs} completed epochs, but target "
+                f"epochs is {target_epochs}. Set epochs greater than "
+                f"{progress.completed_epochs} or use a new run ID."
+            )
+        if completion_path.exists() and target_epochs is None:
+            raise RunLifecycleError(
+                f"Run '{run_id}' is complete. Specify a greater total epoch target "
+                "or use a new run ID."
+            )
+        run = cls(run_dir, checkpoint)
+        if completion_path.exists():
+            archived = run_dir / f"run_complete_epoch_{progress.completed_epochs:03d}.json"
+            os.replace(completion_path, archived)
+        return run
+
+    @staticmethod
+    def _validate_curve_history(path: Path, completed_epochs: int) -> None:
+        if not path.exists():
+            return
+        with path.open(newline="") as handle:
+            rows = list(csv.reader(handle))
+        epochs = []
+        for row in rows[1:]:
+            if not row:
+                continue
+            try:
+                epochs.append(int(row[0]))
+            except ValueError as exc:
+                raise RunLifecycleError(
+                    f"Invalid epoch value in curve history: {row[0]!r}"
+                ) from exc
+        if epochs != sorted(set(epochs)):
+            raise RunLifecycleError(
+                f"Curve history contains duplicate or decreasing epochs: {path}"
+            )
+        if epochs and epochs[-1] > completed_epochs:
+            raise RunLifecycleError(
+                f"Curve history reaches epoch {epochs[-1]}, but the selected last "
+                f"checkpoint has only {completed_epochs} completed epochs. Use a new "
+                "run ID or repair the run explicitly."
+            )
+
+    @staticmethod
+    def _allocate_serial(root: Path, run_id: str) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        for serial in range(1, 10000):
+            name = run_id if serial == 1 else f"{run_id}-r{serial:03d}"
+            candidate = root / name
+            try:
+                candidate.mkdir()
+                return candidate
+            except FileExistsError:
+                continue
+        raise RunLifecycleError(f"Could not allocate a serial directory for {run_id}")
+
+    def _acquire_lock(self) -> None:
+        try:
+            self._lock_fd = os.open(
+                self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
+            )
+        except FileExistsError as exc:
+            raise RunLifecycleError(
+                f"Run directory is already locked: {self.run_dir}"
+            ) from exc
+        os.write(self._lock_fd, f"pid={os.getpid()}\n".encode())
+
+    def mark_complete(self, metadata: dict[str, Any]) -> None:
+        payload = {"status": "complete", **metadata}
+        temporary = self.completion_path.with_suffix(".json.tmp")
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, self.completion_path)
+
+    def logger(self, filename: str = "train.log"):
+        from src.training.runtime import RunLogger
+
+        return RunLogger(self.logs / filename)
+
+    def close(self) -> None:
+        if self._lock_fd is None:
+            return
+        os.close(self._lock_fd)
+        self._lock_fd = None
+        try:
+            self.lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def __enter__(self) -> "TrainingRun":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        self.close()
+        return False

--- a/tests/test_training_run_lifecycle.py
+++ b/tests/test_training_run_lifecycle.py
@@ -1,0 +1,125 @@
+import json
+import random
+
+import numpy as np
+import pytest
+import torch
+
+from src.training.run_lifecycle import (
+    RunLifecycleError,
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
+)
+
+
+def _checkpoint(path, *, completed_epochs, current_epoch=0, microbatch=0):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "run_progress": {
+                "completed_epochs": completed_epochs,
+                "current_epoch": current_epoch,
+                "microbatch": microbatch,
+                "optimizer_step": 17,
+            }
+        },
+        path,
+    )
+
+
+def test_fresh_duplicate_run_allocates_serial_directory(tmp_path):
+    first = TrainingRun.open(tmp_path, "experiment")
+    first.close()
+    second = TrainingRun.open(tmp_path, "experiment")
+    assert first.run_dir.name == "experiment"
+    assert second.run_dir.name == "experiment-r002"
+    second.close()
+
+
+def test_active_run_lock_rejects_second_writer(tmp_path):
+    run = TrainingRun.open(tmp_path, "experiment")
+    checkpoint = run.checkpoints / "last.pt"
+    _checkpoint(checkpoint, completed_epochs=1)
+    with pytest.raises(RunLifecycleError, match="already locked"):
+        TrainingRun.open(
+            tmp_path, "experiment", resume=checkpoint, target_epochs=2
+        )
+    run.close()
+
+
+def test_resume_requires_newest_last_checkpoint(tmp_path):
+    run = TrainingRun.open(tmp_path, "experiment")
+    last = run.checkpoints / "last.pt"
+    best = run.checkpoints / "best.pt"
+    _checkpoint(last, completed_epochs=3)
+    _checkpoint(best, completed_epochs=2)
+    run.close()
+    with pytest.raises(RunLifecycleError, match="newest last.pt"):
+        TrainingRun.open(tmp_path, "experiment", resume=best, target_epochs=4)
+
+
+def test_resume_rejects_non_increasing_epoch_target(tmp_path):
+    run = TrainingRun.open(tmp_path, "experiment")
+    last = run.checkpoints / "last.pt"
+    _checkpoint(last, completed_epochs=5)
+    run.close()
+    with pytest.raises(RunLifecycleError, match="5 completed epochs"):
+        TrainingRun.open(tmp_path, "experiment", resume=last, target_epochs=5)
+
+
+def test_completed_run_rejects_equal_target_and_allows_extension(tmp_path):
+    run = TrainingRun.open(tmp_path, "experiment")
+    last = run.checkpoints / "last.pt"
+    _checkpoint(last, completed_epochs=2)
+    run.mark_complete({"completed_epochs": 2})
+    run.close()
+    assert json.loads((run.run_dir / "run_complete.json").read_text())["status"] == "complete"
+    with pytest.raises(RunLifecycleError, match="2 completed epochs"):
+        TrainingRun.open(tmp_path, "experiment", resume=last, target_epochs=2)
+    resumed = TrainingRun.open(tmp_path, "experiment", resume=last, target_epochs=3)
+    assert not resumed.completion_path.exists()
+    assert (run.run_dir / "run_complete_epoch_002.json").exists()
+    resumed.close()
+
+
+def test_rng_state_round_trip():
+    random.seed(7)
+    np.random.seed(7)
+    torch.manual_seed(7)
+    state = capture_rng_state()
+    expected = (random.random(), np.random.random(), torch.rand(1))
+    restore_rng_state(state)
+    actual = (random.random(), np.random.random(), torch.rand(1))
+    assert actual[0] == expected[0]
+    assert actual[1] == expected[1]
+    assert torch.equal(actual[2], expected[2])
+
+
+def test_resume_rejects_duplicate_curve_history(tmp_path):
+    run = TrainingRun.open(tmp_path, "experiment")
+    last = run.checkpoints / "last.pt"
+    _checkpoint(last, completed_epochs=2)
+    (run.scores / "curves.csv").write_text(
+        "epoch,train_loss,val_loss\n1,2,3\n1,2,3\n"
+    )
+    run.close()
+    with pytest.raises(RunLifecycleError, match="duplicate or decreasing"):
+        TrainingRun.open(tmp_path, "experiment", resume=last, target_epochs=3)
+
+
+def test_configuration_fingerprint_ignores_operational_settings():
+    baseline = {"n_layer": 8, "lr": 1e-4, "epochs": 10, "max_time_minutes": 30}
+    operational_change = {
+        **baseline,
+        "epochs": 15,
+        "max_time_minutes": 60,
+        "checkpoint_every_minutes": 5,
+    }
+    assert configuration_fingerprint(baseline) == configuration_fingerprint(
+        operational_change
+    )
+    assert configuration_fingerprint(baseline) != configuration_fingerprint(
+        {**baseline, "lr": 2e-4}
+    )


### PR DESCRIPTION
Summary:
- add a shared TrainingRun owner for atomic serial allocation, exclusive locks, standard paths, resume validation, completion markers, and lifecycle-owned logs
- add standardized checkpoint progress, immutable configuration fingerprints, RNG capture/restore, curve-history validation, and numbered best checkpoints
- migrate CodonLM and multitask ProteinCritic without changing model objectives
- record the rejected ProteinCritic class-balance validation result
- add XGBoost raw-feature and embedding controls to corrected evaluation tracks
- create the repository-wide lifecycle migration conductor track

Resume contract:
- fresh duplicate run IDs allocate -rNNN directories
- in-place resume requires the newest last checkpoint
- equal or lower total epoch targets fail
- greater total epoch targets may extend a completed run
- stale best checkpoints require a new run ID
- concurrent writers and duplicate curve histories fail closed

Scope:
This is Phase 1-2. ProteinLM, protein classifier, EBM, and NoProp remain explicitly open in Phase 3 rather than being silently treated as protected.

Testing:
- targeted Ruff checks passed
- full suite: 366 passed, 1 skipped, 1 xpassed
- repository-wide Ruff remains blocked by 135 pre-existing failures in unrelated legacy files