### PR TITLE
Migrate remaining trainers to shared run lifecycle

### DIFF
--- a/conductor/tracks/shared_training_run_lifecycle_20260805/plan.md
+++ b/conductor/tracks/shared_training_run_lifecycle_20260805/plan.md
@@ -19,15 +19,16 @@
 
 ## Phase 3: Remaining Model Trainers
 
-- [ ] Migrate protein LM and protein classifier.
-- [ ] Add resume support and migrate Protein EBM.
-- [ ] Migrate NoProp and explicitly document its experimental checkpoint contract.
+- [x] Migrate protein LM and protein classifier with deterministic mid-epoch resume.
+- [x] Add epoch-boundary resume support and migrate Protein EBM.
+- [x] Migrate NoProp, including all layer-specific optimizer states, and explicitly
+  document its experimental checkpoint contract.
 - [ ] Inventory ancillary fine-tuning entry points and either migrate or mark them
   non-resumable with overwrite protection.
 
 ## Phase 4: Documentation and Enforcement
 
-- [ ] Document fresh, resume, fork, and completed-run commands.
+- [x] Document fresh, resume, fork, and completed-run commands.
 - [ ] Add CI contract tests covering every registered trainer.
 - [ ] Record migration status in the development log.
 - [ ] Reject direct unguarded writes to canonical `last`/`best` paths in trainers.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1079,6 +1079,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     completion markers, shared log paths, RNG capture/restore, and numbered best
     checkpoints. CodonLM and multitask ProteinCritic are the first migrated trainers;
     ProteinLM, classifier, EBM, and NoProp remain explicitly open in Phase 3.
+*   **Shared Training Lifecycle Phase 3 (2026-08-06):** Migrated ProteinLM, the
+    protein classifier, Protein EBM, and NoProp to the collision-safe run owner.
+    ProteinLM/classifier now restore model, optimizer, scheduler, RNG, and an
+    optimizer-boundary microbatch position against deterministic epoch permutations.
+    EBM restores its head optimizer at epoch boundaries. NoProp now saves `last.pt`
+    every epoch with the embedding, every block optimizer, and output-head optimizer.
+    Run locking now uses kernel-released advisory locks so a killed process cannot
+    leave a permanently stale lock file.
 
 ---
 *End of Log*

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -133,6 +133,12 @@ with that run's newest `last` checkpoint and a configured total epoch target gre
 than its completed epoch count. Use a new run ID to fork from an older or best
 checkpoint; best checkpoints are evaluation artifacts, not in-place resume points.
 
+This lifecycle also applies to ProteinLM, the single-task protein classifier,
+Protein EBM, and NoProp. ProteinLM/classifier checkpoints can resume at recorded
+optimizer-safe microbatch boundaries using a deterministic epoch sampler. EBM and
+NoProp currently resume only from completed epochs. NoProp checkpoints include the
+embedding, per-block, and output-head optimizer states.
+
 Build the homology-cluster-held-out critic artifacts before critic training:
 
 ```bash

--- a/src/codonlm/train_noprop.py
+++ b/src/codonlm/train_noprop.py
@@ -6,19 +6,20 @@ instead of global backpropagation.
 
 import argparse
 import yaml
-import time
-import json
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
-import numpy as np
-from pathlib import Path
 from torch.utils.data import DataLoader
 
 from .model_tiny_gpt import NoPropTinyGPT
 from .data_loading import PackedDataset, dynamic_lm_collate_fn
-from .train_codon_lm import _ensure_path_list, _normalize_run_id, _auto_run_id, _prepare_output_dirs
+from .train_codon_lm import _ensure_path_list, _normalize_run_id, _auto_run_id
 from src.training.runtime import save_checkpoint_atomic
+from src.training.run_lifecycle import (
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
+)
 from .training.vocabulary import (
     resolve_vocabulary_contract,
     snapshot_vocabulary,
@@ -31,6 +32,7 @@ def main():
     ap.add_argument("--run_id", default=None)
     ap.add_argument("--device", default=None)
     ap.add_argument("--noise_sigma", type=float, default=0.1, help="Sigma of Gaussian noise added to targets")
+    ap.add_argument("--resume", default=None)
     args = ap.parse_args()
 
     with open(args.config, "r") as f:
@@ -45,7 +47,21 @@ def main():
 
     # Set run ID
     run_id = _normalize_run_id(args.run_id) or _auto_run_id(cfg, args.config)
-    ckpt_root, scores_root = _prepare_output_dirs("runs", "runs", run_id)
+    epochs = int(cfg.get("epochs", 5))
+    run_fingerprint = configuration_fingerprint(
+        {**cfg, "noise_sigma": args.noise_sigma}
+    )
+    training_run = TrainingRun.open(
+        "runs",
+        run_id,
+        resume=args.resume,
+        target_epochs=epochs,
+        config_fingerprint=run_fingerprint,
+    )
+    run_id = training_run.run_dir.name
+    ckpt_root, scores_root = training_run.checkpoints, training_run.scores
+    run_logger = training_run.logger()
+    run_logger.__enter__()
     print(f"[noprop] run_id: {run_id}")
 
     # Load datasets
@@ -95,13 +111,26 @@ def main():
     opts_blocks = [torch.optim.AdamW(block.parameters(), lr=lr) for block in model.blocks]
     opt_head = torch.optim.AdamW(list(model.ln_f.parameters()) + list(model.head.parameters()), lr=lr)
 
-    epochs = cfg.get("epochs", 5)
     noise_sigma = args.noise_sigma
+    start_epoch = 1
+    best_val_loss = float("inf")
+    if args.resume:
+        checkpoint = torch.load(args.resume, map_location=device, weights_only=False)
+        model.load_state_dict(checkpoint["model"])
+        opt_emb.load_state_dict(checkpoint["optimizers"]["embedding"])
+        for optimizer, state in zip(opts_blocks, checkpoint["optimizers"]["blocks"]):
+            optimizer.load_state_dict(state)
+        opt_head.load_state_dict(checkpoint["optimizers"]["head"])
+        best_val_loss = float(checkpoint.get("best_val_loss", float("inf")))
+        start_epoch = int(checkpoint["epoch"]) + 1
+        restore_rng_state(checkpoint.get("rng_state"))
 
     print(f"[noprop] starting training for {epochs} epochs")
-    best_val_loss = float("inf")
+    curves_path = scores_root / "curves.csv"
+    if not curves_path.exists():
+        curves_path.write_text("epoch,train_ce,val_ce\n")
 
-    for epoch in range(1, epochs + 1):
+    for epoch in range(start_epoch, epochs + 1):
         # Training loop
         model.train()
         train_loss_ce = 0.0
@@ -135,23 +164,23 @@ def main():
             h_prev = h
 
             # Step-by-step block-wise training
-            for l, block in enumerate(model.blocks):
+            for layer_index, block in enumerate(model.blocks):
                 # Detach context input from graph to stop gradient propagation
-                h_in = h_prev.detach() if l > 0 else h_prev
+                h_in = h_prev.detach() if layer_index > 0 else h_prev
 
-                opts_blocks[l].zero_grad()
+                opts_blocks[layer_index].zero_grad()
                 h_out, pred_y = block(h_in, noisy_targets=y_noisy, attn_mask=attn_mask)
 
                 loss_mse_elementwise = F.mse_loss(pred_y, y_clean, reduction="none")
                 loss_mse = (loss_mse_elementwise * non_pad_mask).sum() / (non_pad_mask.sum() * pred_y.size(-1) + 1e-8)
                 loss_mse.backward()
 
-                opts_blocks[l].step()
-                if l == 0:
+                opts_blocks[layer_index].step()
+                if layer_index == 0:
                     # Also update embeddings via block 0 output
                     opt_emb.step()
 
-                train_loss_blocks[l] += loss_mse.item()
+                train_loss_blocks[layer_index] += loss_mse.item()
                 h_prev = h_out
 
             # 2. Step final head
@@ -190,11 +219,11 @@ def main():
                     attn_mask = (seg.unsqueeze(-1) == seg.unsqueeze(-2)).unsqueeze(1)
 
                 h_prev = h
-                for l, block in enumerate(model.blocks):
+                for layer_index, block in enumerate(model.blocks):
                     h_out, pred_y = block(h_prev, noisy_targets=y_clean, attn_mask=attn_mask)
                     loss_mse_elementwise = F.mse_loss(pred_y, y_clean, reduction="none")
                     loss_mse = (loss_mse_elementwise * non_pad_mask).sum() / (non_pad_mask.sum() * pred_y.size(-1) + 1e-8)
-                    val_loss_blocks[l] += loss_mse.item()
+                    val_loss_blocks[layer_index] += loss_mse.item()
                     h_prev = h_out
 
                 h_final = model.ln_f(h_prev)
@@ -211,15 +240,40 @@ def main():
 
         # Save checkpoint
         avg_val_loss = val_loss_ce / n_val
+        payload = {
+            "model": model.state_dict(),
+            "optimizers": {
+                "embedding": opt_emb.state_dict(),
+                "blocks": [optimizer.state_dict() for optimizer in opts_blocks],
+                "head": opt_head.state_dict(),
+            },
+            "epoch": epoch,
+            "epoch_complete": True,
+            "val_loss": avg_val_loss,
+            "best_val_loss": min(best_val_loss, avg_val_loss),
+            "run_fingerprint": run_fingerprint,
+            "rng_state": capture_rng_state(),
+            "run_progress": {
+                "completed_epochs": epoch,
+                "current_epoch": epoch,
+                "microbatch": 0,
+                "optimizer_step": epoch * len(train_loader),
+            },
+        }
+        save_checkpoint_atomic(payload, ckpt_root / "last.pt")
+        with curves_path.open("a") as handle:
+            handle.write(f"{epoch},{train_loss_ce / n_train:.6f},{avg_val_loss:.6f}\n")
         if avg_val_loss < best_val_loss:
             best_val_loss = avg_val_loss
             ckpt_path = ckpt_root / "best.pt"
-            save_checkpoint_atomic({
-                "model": model.state_dict(),
-                "epoch": epoch,
-                "val_loss": avg_val_loss
-            }, ckpt_path)
+            save_checkpoint_atomic(payload, ckpt_path)
+            save_checkpoint_atomic(payload, ckpt_root / f"best_epoch_{epoch:03d}.pt")
             print(f"  [noprop] saved new best checkpoint to {ckpt_path}")
+
+    training_run.mark_complete(
+        {"completed_epochs": epochs, "best_validation_loss": best_val_loss}
+    )
+    training_run.close()
 
 if __name__ == "__main__":
     main()

--- a/src/protein_lm/data.py
+++ b/src/protein_lm/data.py
@@ -51,7 +51,17 @@ class ProteinDataset(Dataset):
         return torch.tensor(input_ids, dtype=torch.long)
 
 
-def create_dataloader(split_path, batch_size, num_workers, tokenizer, block_size, shuffle=True, dataset_class=ProteinDataset, label_field=None):
+def create_dataloader(
+    split_path,
+    batch_size,
+    num_workers,
+    tokenizer,
+    block_size,
+    shuffle=True,
+    dataset_class=ProteinDataset,
+    label_field=None,
+    generator=None,
+):
     """
     Creates a DataLoader for a given dataset split.
     Can be used for both language modeling and classification.
@@ -65,7 +75,8 @@ def create_dataloader(split_path, batch_size, num_workers, tokenizer, block_size
         dataset,
         batch_size=batch_size,
         num_workers=num_workers,
-        shuffle=shuffle
+        shuffle=shuffle,
+        generator=generator,
     )
 
 class ProteinClassificationDataset(ProteinDataset):
@@ -108,5 +119,4 @@ class ProteinClassificationDataset(ProteinDataset):
         label = sample.get(self.label_field)
         
         return torch.tensor(input_ids, dtype=torch.long), torch.tensor(self.label_map.get(label, -1), dtype=torch.long)
-
 

--- a/src/protein_lm/train_classifier.py
+++ b/src/protein_lm/train_classifier.py
@@ -10,9 +10,15 @@ from src.protein_lm.config import ProteinClassifierConfig, load_config
 from src.protein_lm.tokenizer import ProteinTokenizer
 from src.protein_lm.models import ProteinClassifier
 from src.protein_lm.data import create_dataloader, ProteinClassificationDataset
-from src.training.runtime import RunLogger, WallTimer, save_checkpoint_atomic
+from src.training.runtime import WallTimer, save_checkpoint_atomic
+from src.training.run_lifecycle import (
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
+)
 
-def train_classifier(config_path: str):
+def train_classifier(config_path: str, resume=None, run_id=None):
     """
     Trains the protein classifier.
     """
@@ -25,10 +31,17 @@ def train_classifier(config_path: str):
     data_config = config_data.get('data', {})
 
     # --- 2. Setup ---
-    run_id = Path(config_path).stem
-    output_dir = Path("outputs") / "protein_classifier" / run_id
-    output_dir.mkdir(exist_ok=True, parents=True)
-    run_logger = RunLogger(output_dir / "logs" / "train.log")
+    epochs = int(training_config["epochs"])
+    run_id = run_id or config_data.get("run_id") or Path(config_path).stem
+    run_fingerprint = configuration_fingerprint(config_data)
+    training_run = TrainingRun.open(
+        Path("runs") / "protein_classifier",
+        run_id,
+        resume=resume,
+        target_epochs=epochs,
+        config_fingerprint=run_fingerprint,
+    )
+    run_logger = training_run.logger()
     run_logger.__enter__()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -36,9 +49,11 @@ def train_classifier(config_path: str):
 
     tokenizer = ProteinTokenizer()
     classifier_config.vocab_size = len(tokenizer.vocab)
+    seed = int(training_config.get("seed", 1337))
+    train_generator = torch.Generator()
 
     # --- 3. Data Loading ---
-    num_workers = os.cpu_count() // 2
+    num_workers = int(training_config.get("num_workers", (os.cpu_count() or 2) // 2))
     train_loader = create_dataloader(
         data_config['train_path'],
         training_config['batch_size'],
@@ -47,7 +62,8 @@ def train_classifier(config_path: str):
         block_size=classifier_config.block_size,
         shuffle=True,
         dataset_class=ProteinClassificationDataset,
-        label_field='func_label' # This assumes the label is in the 'func_label' field
+        label_field='func_label', # This assumes the label is in the 'func_label' field
+        generator=train_generator,
     )
     val_loader = create_dataloader(
         data_config['val_path'],
@@ -74,46 +90,78 @@ def train_classifier(config_path: str):
         weight_decay=training_config.get('weight_decay', 0.01)
     )
     criterion = nn.CrossEntropyLoss()
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=training_config['epochs'])
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
     wall_timer = WallTimer(training_config.get("max_time_minutes"))
     optimizer_step = 0
+    start_epoch = 0
+    resume_microbatch = 0
+    if resume:
+        checkpoint = torch.load(resume, map_location=device, weights_only=False)
+        model.load_state_dict(checkpoint["model_state_dict"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
+        optimizer_step = int(checkpoint.get("optimizer_step", 0))
+        complete = bool(checkpoint.get("epoch_complete", True))
+        start_epoch = int(checkpoint["epoch"]) + (1 if complete else 0)
+        resume_microbatch = 0 if complete else int(checkpoint.get("microbatch_idx", 0))
+        restore_rng_state(checkpoint.get("rng_state"))
+    current_microbatch = 0
 
     def save_checkpoint(path: Path, epoch: int, loss: float, reason: str) -> None:
+        complete = reason == "epoch"
         save_checkpoint_atomic({
             'epoch': epoch,
             'model_state_dict': model.state_dict(),
             'optimizer_state_dict': optimizer.state_dict(),
+            'scheduler_state_dict': scheduler.state_dict(),
             'loss': loss,
             'optimizer_step': optimizer_step,
             'checkpoint_reason': reason,
             'cfg': config_data,
+            'epoch_complete': complete,
+            'microbatch_idx': 0 if complete else current_microbatch,
+            'run_fingerprint': run_fingerprint,
+            'rng_state': capture_rng_state(),
+            'run_progress': {
+                'completed_epochs': epoch + 1 if complete else epoch,
+                'current_epoch': epoch + 1,
+                'microbatch': 0 if complete else current_microbatch,
+                'optimizer_step': optimizer_step,
+            },
         }, path)
 
     # --- 5. Training Loop ---
-    for epoch in range(training_config['epochs']):
+    grad_accum = int(training_config.get('grad_accum_steps', 1))
+    for epoch in range(start_epoch, epochs):
+        train_generator.manual_seed(seed + epoch)
         model.train()
+        optimizer.zero_grad(set_to_none=True)
         for i, (input_ids, labels) in enumerate(train_loader):
+            if epoch == start_epoch and i < resume_microbatch:
+                continue
+            current_microbatch = i + 1
             input_ids, labels = input_ids.to(device), labels.to(device)
 
             logits = model(input_ids)
             loss = criterion(logits, labels)
             
-            loss = loss / training_config.get('grad_accum_steps', 1)
-            loss.backward()
+            (loss / grad_accum).backward()
 
-            if (i + 1) % training_config.get('grad_accum_steps', 1) == 0:
+            boundary = (i + 1) % grad_accum == 0 or (i + 1) == len(train_loader)
+            if boundary:
                 optimizer.step()
-                optimizer.zero_grad()
+                optimizer.zero_grad(set_to_none=True)
                 optimizer_step += 1
                 every_steps = int(training_config.get("checkpoint_every_steps", 0) or 0)
                 if every_steps > 0 and optimizer_step % every_steps == 0:
-                    save_checkpoint(output_dir / "last.pt", epoch, float("inf"), "periodic")
+                    save_checkpoint(training_run.checkpoints / "last.pt", epoch, float("inf"), "periodic")
 
             if i % 100 == 0:
                 print(f"Epoch {epoch+1}/{training_config['epochs']}, Step {i}, Loss: {loss.item():.4f}")
             if wall_timer.expired():
-                save_checkpoint(output_dir / "last.pt", epoch, float("inf"), "wall_time")
-                print(f"[success] Wall-time reached; saved {output_dir / 'last.pt'}.")
+                save_checkpoint(training_run.checkpoints / "last.pt", epoch, float("inf"), "wall_time")
+                print(f"[success] Wall-time reached; saved {training_run.checkpoints / 'last.pt'}.")
+                training_run.close()
                 return
         
         scheduler.step()
@@ -141,12 +189,17 @@ def train_classifier(config_path: str):
         print(f"Epoch {epoch+1}, Val Loss: {val_loss:.4f}, Accuracy: {accuracy:.4f}, F1: {f1:.4f}")
 
         # --- 7. Checkpointing ---
-        save_checkpoint(output_dir / f"checkpoint_epoch_{epoch+1}.pt", epoch, val_loss, "epoch")
-        save_checkpoint(output_dir / "last.pt", epoch, val_loss, "epoch")
+        save_checkpoint(training_run.checkpoints / f"epoch_{epoch+1:03d}.pt", epoch, val_loss, "epoch")
+        save_checkpoint(training_run.checkpoints / "last.pt", epoch, val_loss, "epoch")
+
+    training_run.mark_complete({"completed_epochs": epochs})
+    training_run.close()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a protein classifier.")
     parser.add_argument("--config", type=str, required=True, help="Path to the config YAML file.")
+    parser.add_argument("--resume")
+    parser.add_argument("--run-id")
     args = parser.parse_args()
-    train_classifier(args.config)
+    train_classifier(args.config, resume=args.resume, run_id=args.run_id)

--- a/src/protein_lm/train_ebm.py
+++ b/src/protein_lm/train_ebm.py
@@ -9,7 +9,6 @@ import argparse
 import random
 import yaml
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from pathlib import Path
@@ -19,6 +18,13 @@ from src.protein_lm.dataset import MultiTaskProteinDataset, LengthBucketBatchSam
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
 from src.protein_lm.config import ProteinClassifierConfig
 from src.protein_lm.ebm import ProteinLatentEBM
+from src.training.run_lifecycle import (
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
+)
+from src.training.runtime import save_checkpoint_atomic
 
 AMINO_ACIDS = ['A', 'R', 'N', 'D', 'C', 'Q', 'E', 'G', 'H', 'I', 'L', 'K', 'M', 'F', 'P', 'S', 'T', 'W', 'Y', 'V']
 
@@ -43,6 +49,8 @@ def parse_args():
     parser.add_argument("--function_dim", type=int, default=1000, help="Classifier function dimension")
     parser.add_argument("--hidden_dim", type=int, default=512, help="Hidden size of the EBM network")
     parser.add_argument("--out_dir", default="runs/protein_ebm", help="Output directory for checkpoints")
+    parser.add_argument("--run_id", default=None)
+    parser.add_argument("--resume", default=None)
     parser.add_argument("--seed", type=int, default=1337, help="RNG seed")
     return parser.parse_args()
 
@@ -59,9 +67,34 @@ def main():
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
+    requested_dir = Path(args.out_dir)
+    run_id = args.run_id or requested_dir.name
+    fingerprint = configuration_fingerprint(
+        {
+            **cfg,
+            "critic_ckpt": str(Path(args.critic_ckpt).resolve()),
+            "lr": args.lr,
+            "pooling": args.pooling,
+            "family_dim": args.family_dim,
+            "function_dim": args.function_dim,
+            "hidden_dim": args.hidden_dim,
+            "seed": args.seed,
+        }
+    )
+    training_run = TrainingRun.open(
+        requested_dir.parent,
+        run_id,
+        resume=args.resume,
+        last_checkpoint_name="last_ebm.pt",
+        target_epochs=args.epochs,
+        config_fingerprint=fingerprint,
+    )
+    run_logger = training_run.logger()
+    run_logger.__enter__()
+
     # Initialize tokenizer and datasets
     tokenizer = ProteinTokenizer()
-    print(f"[ebm-train] loading dataset paths from config")
+    print("[ebm-train] loading dataset paths from config")
     train_dataset = MultiTaskProteinDataset(cfg["train_data"], tokenizer, max_length=cfg.get("block_size", 512))
     val_dataset = MultiTaskProteinDataset(cfg["val_data"], tokenizer, max_length=cfg.get("block_size", 512))
 
@@ -69,7 +102,8 @@ def main():
     train_sampler = LengthBucketBatchSampler(train_dataset, batch_size=batch_size, shuffle=True)
     val_sampler = LengthBucketBatchSampler(val_dataset, batch_size=batch_size, shuffle=False)
 
-    collate_fn = lambda b: collate_protein_batch(b, pad_token_id=tokenizer.pad_token_id)
+    def collate_fn(batch):
+        return collate_protein_batch(batch, pad_token_id=tokenizer.pad_token_id)
     train_loader = DataLoader(train_dataset, batch_sampler=train_sampler, collate_fn=collate_fn)
     val_loader = DataLoader(val_dataset, batch_sampler=val_sampler, collate_fn=collate_fn)
 
@@ -107,14 +141,9 @@ def main():
 
     optimizer = torch.optim.AdamW(ebm.parameters(), lr=args.lr, weight_decay=0.01)
 
-    out_dir = Path(args.out_dir)
-    ckpt_dir = out_dir / "checkpoints"
-    scores_dir = out_dir / "scores"
-    logs_dir = out_dir / "logs"
-
-    ckpt_dir.mkdir(parents=True, exist_ok=True)
-    scores_dir.mkdir(parents=True, exist_ok=True)
-    logs_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = training_run.run_dir
+    ckpt_dir = training_run.checkpoints
+    scores_dir = training_run.scores
 
     # Copy config
     import shutil
@@ -125,15 +154,25 @@ def main():
 
     # Initialize curves.csv
     curves_path = scores_dir / "curves.csv"
-    with open(curves_path, "w") as f:
-        f.write("epoch,train_loss,val_loss\n")
+    if not curves_path.exists():
+        with open(curves_path, "w") as f:
+            f.write("epoch,train_loss,val_loss\n")
 
     print(f"[ebm-train] starting EBM training: epochs={args.epochs}, lr={args.lr}")
     
     best_val_loss = float("inf")
     best_epoch = 0
+    start_epoch = 1
+    if args.resume:
+        checkpoint = torch.load(args.resume, map_location=device, weights_only=False)
+        ebm.load_state_dict(checkpoint["model"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        best_val_loss = float(checkpoint.get("best_val_loss", float("inf")))
+        best_epoch = int(checkpoint.get("best_epoch", 0))
+        start_epoch = int(checkpoint["epoch"]) + 1
+        restore_rng_state(checkpoint.get("rng_state"))
 
-    for epoch in range(1, args.epochs + 1):
+    for epoch in range(start_epoch, args.epochs + 1):
         ebm.train()
         total_loss = 0.0
         n_batches = 0
@@ -231,23 +270,36 @@ def main():
             "model": ebm.state_dict(),
             "epoch": epoch,
             "val_loss": avg_val,
+            "optimizer_state_dict": optimizer.state_dict(),
+            "best_val_loss": min(best_val_loss, avg_val),
+            "best_epoch": epoch if avg_val < best_val_loss else best_epoch,
+            "epoch_complete": True,
+            "run_fingerprint": fingerprint,
+            "rng_state": capture_rng_state(),
+            "run_progress": {
+                "completed_epochs": epoch,
+                "current_epoch": epoch,
+                "microbatch": 0,
+                "optimizer_step": epoch * len(train_loader),
+            },
         }
         
         # Save epoch checkpoint
         ckpt_path = ckpt_dir / f"ebm_epoch_{epoch}.pt"
-        torch.save(payload, ckpt_path)
+        save_checkpoint_atomic(payload, ckpt_path)
         print(f"[saved] {ckpt_path}")
 
         # Save last checkpoint
         last_path = ckpt_dir / "last_ebm.pt"
-        torch.save(payload, last_path)
+        save_checkpoint_atomic(payload, last_path)
         
         # Save best checkpoint
         if avg_val < best_val_loss:
             best_val_loss = avg_val
             best_epoch = epoch
             best_path = ckpt_dir / "best_ebm.pt"
-            torch.save(payload, best_path)
+            save_checkpoint_atomic(payload, best_path)
+            save_checkpoint_atomic(payload, ckpt_dir / f"best_ebm_epoch_{epoch:03d}.pt")
             print(f"[saved] {best_path} (new best validation loss: {best_val_loss:.4f})")
 
     # Generate summary.md
@@ -268,6 +320,11 @@ def main():
 - **Backbone Critic Checkpoint:** `{args.critic_ckpt}`
 """
     summary_path.write_text(summary_content)
+    training_run.mark_complete(
+        {"completed_epochs": args.epochs, "best_epoch": best_epoch,
+         "best_validation_loss": best_val_loss}
+    )
+    training_run.close()
     print(f"[summary] Wrote run summary to {summary_path}")
     print("[ebm-train] Done training!")
 

--- a/src/protein_lm/train_lm.py
+++ b/src/protein_lm/train_lm.py
@@ -1,145 +1,160 @@
+import argparse
+import os
+from pathlib import Path
+
 import torch
 import torch.nn as nn
 import yaml
-import argparse
-from pathlib import Path
-import os
 
 from src.protein_lm.config import ProteinLMConfig, load_config
-from src.protein_lm.tokenizer import ProteinTokenizer
-from src.protein_lm.models import ProteinConditionalTransformer
 from src.protein_lm.data import create_dataloader
-from src.training.runtime import RunLogger, WallTimer, save_checkpoint_atomic
+from src.protein_lm.models import ProteinConditionalTransformer
+from src.protein_lm.tokenizer import ProteinTokenizer
+from src.training.run_lifecycle import (
+    TrainingRun,
+    capture_rng_state,
+    configuration_fingerprint,
+    restore_rng_state,
+)
+from src.training.runtime import WallTimer, save_checkpoint_atomic
 
-def train(config_path: str):
-    """
-    Trains the protein language model.
-    """
-    # --- 1. Load Configuration ---
-    # This keeps the model and training parameters separate from the code.
-    with open(config_path, 'r') as f:
-        config_data = yaml.safe_load(f)
 
+def train(config_path: str, resume: str | None = None, run_id: str | None = None):
+    with open(config_path) as handle:
+        config_data = yaml.safe_load(handle)
     lm_config = load_config(config_path, ProteinLMConfig)
-    training_config = config_data.get('training', {})
-    data_config = config_data.get('data', {})
-
-    # --- 2. Setup ---
-    run_id = Path(config_path).stem
-    output_dir = Path("outputs") / "protein_lm" / run_id
-    output_dir.mkdir(exist_ok=True, parents=True)
-    run_logger = RunLogger(output_dir / "logs" / "train.log")
-    run_logger.__enter__()
+    training_config = config_data.get("training", {})
+    data_config = config_data.get("data", {})
+    epochs = int(training_config["epochs"])
+    requested_run_id = run_id or config_data.get("run_id") or Path(config_path).stem
+    fingerprint = configuration_fingerprint(config_data)
+    training_run = TrainingRun.open(
+        Path("runs") / "protein_lm",
+        requested_run_id,
+        resume=resume,
+        target_epochs=epochs,
+        config_fingerprint=fingerprint,
+    )
+    logger = training_run.logger()
+    logger.__enter__()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Using device: {device}")
-
-    # The tokenizer vocabulary size is needed for the model's embedding layer.
     tokenizer = ProteinTokenizer()
     lm_config.vocab_size = len(tokenizer.vocab)
-
-    # --- 3. Data Loading ---
-    # Using a helper function to create dataloaders keeps this script cleaner.
-    num_workers = os.cpu_count() // 2
+    seed = int(training_config.get("seed", 1337))
+    train_generator = torch.Generator()
+    num_workers = int(training_config.get("num_workers", (os.cpu_count() or 2) // 2))
     train_loader = create_dataloader(
-        data_config['train_path'],
-        training_config['batch_size'],
-        num_workers=num_workers,
-        tokenizer=tokenizer,
-        block_size=lm_config.block_size,
-        shuffle=True
+        data_config["train_path"], training_config["batch_size"],
+        num_workers=num_workers, tokenizer=tokenizer,
+        block_size=lm_config.block_size, shuffle=True, generator=train_generator,
     )
     val_loader = create_dataloader(
-        data_config['val_path'],
-        training_config['batch_size'],
-        num_workers=num_workers,
-        tokenizer=tokenizer,
-        block_size=lm_config.block_size,
-        shuffle=False
+        data_config["val_path"], training_config["batch_size"],
+        num_workers=num_workers, tokenizer=tokenizer,
+        block_size=lm_config.block_size, shuffle=False,
     )
 
-    # --- 4. Model Initialization ---
     model = ProteinConditionalTransformer(lm_config).to(device)
     optimizer = torch.optim.AdamW(
-        model.parameters(),
-        lr=training_config['lr'],
-        weight_decay=training_config.get('weight_decay', 0.01)
+        model.parameters(), lr=training_config["lr"],
+        weight_decay=training_config.get("weight_decay", 0.01),
     )
-    # The ignore_index parameter tells the loss function to ignore padding tokens.
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
     criterion = nn.CrossEntropyLoss(ignore_index=tokenizer.pad_token_id)
-    
-    # A learning rate scheduler can help improve training performance.
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=training_config['epochs'])
     wall_timer = WallTimer(training_config.get("max_time_minutes"))
     optimizer_step = 0
+    start_epoch = 0
+    resume_microbatch = 0
+    if resume:
+        checkpoint = torch.load(resume, map_location=device, weights_only=False)
+        model.load_state_dict(checkpoint["model_state_dict"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
+        optimizer_step = int(checkpoint.get("optimizer_step", 0))
+        complete = bool(checkpoint.get("epoch_complete", True))
+        start_epoch = int(checkpoint["epoch"]) + (1 if complete else 0)
+        resume_microbatch = 0 if complete else int(checkpoint.get("microbatch_idx", 0))
+        restore_rng_state(checkpoint.get("rng_state"))
+
+    current_microbatch = 0
 
     def save_checkpoint(path: Path, epoch: int, loss: float, reason: str) -> None:
-        save_checkpoint_atomic({
-            'epoch': epoch,
-            'model_state_dict': model.state_dict(),
-            'optimizer_state_dict': optimizer.state_dict(),
-            'loss': loss,
-            'optimizer_step': optimizer_step,
-            'checkpoint_reason': reason,
-            'cfg': config_data,
-        }, path)
+        complete = reason == "epoch"
+        save_checkpoint_atomic(
+            {
+                "epoch": epoch,
+                "epoch_complete": complete,
+                "microbatch_idx": 0 if complete else current_microbatch,
+                "model_state_dict": model.state_dict(),
+                "optimizer_state_dict": optimizer.state_dict(),
+                "scheduler_state_dict": scheduler.state_dict(),
+                "loss": loss,
+                "optimizer_step": optimizer_step,
+                "checkpoint_reason": reason,
+                "cfg": config_data,
+                "run_fingerprint": fingerprint,
+                "rng_state": capture_rng_state(),
+                "run_progress": {
+                    "completed_epochs": epoch + 1 if complete else epoch,
+                    "current_epoch": epoch + 1,
+                    "microbatch": 0 if complete else current_microbatch,
+                    "optimizer_step": optimizer_step,
+                },
+            },
+            path,
+        )
 
-    # --- 5. Training Loop ---
-    for epoch in range(training_config['epochs']):
+    grad_accum = int(training_config.get("grad_accum_steps", 1))
+    for epoch in range(start_epoch, epochs):
+        train_generator.manual_seed(seed + epoch)
         model.train()
-        for i, batch in enumerate(train_loader):
+        optimizer.zero_grad(set_to_none=True)
+        for index, batch in enumerate(train_loader):
+            if epoch == start_epoch and index < resume_microbatch:
+                continue
+            current_microbatch = index + 1
             input_ids = batch.to(device)
-            # The targets are the input sequence shifted by one token to the left.
             targets = input_ids[:, 1:].contiguous()
-            # The model's input is the sequence up to the second to last token.
             logits = model(input_ids[:, :-1]).contiguous()
-
             loss = criterion(logits.view(-1, logits.size(-1)), targets.view(-1))
-            
-            # Gradient accumulation allows for a larger effective batch size.
-            loss = loss / training_config.get('grad_accum_steps', 1)
-            loss.backward()
-
-            if (i + 1) % training_config.get('grad_accum_steps', 1) == 0:
+            (loss / grad_accum).backward()
+            boundary = (index + 1) % grad_accum == 0 or index + 1 == len(train_loader)
+            if boundary:
                 optimizer.step()
-                optimizer.zero_grad()
+                optimizer.zero_grad(set_to_none=True)
                 optimizer_step += 1
-                every_steps = int(training_config.get("checkpoint_every_steps", 0) or 0)
-                if every_steps > 0 and optimizer_step % every_steps == 0:
-                    save_checkpoint(output_dir / "last.pt", epoch, float("inf"), "periodic")
-
-            if i % 100 == 0:
-                print(f"Epoch {epoch+1}/{training_config['epochs']}, Step {i}, Loss: {loss.item():.4f}")
+                every = int(training_config.get("checkpoint_every_steps", 0) or 0)
+                if every and optimizer_step % every == 0:
+                    save_checkpoint(training_run.checkpoints / "last.pt", epoch, float("inf"), "periodic")
+            if index % 100 == 0:
+                print(f"Epoch {epoch + 1}/{epochs}, Step {index}, Loss: {loss.item():.4f}")
             if wall_timer.expired():
-                save_checkpoint(output_dir / "last.pt", epoch, float("inf"), "wall_time")
-                print(f"[success] Wall-time reached; saved {output_dir / 'last.pt'}.")
+                save_checkpoint(training_run.checkpoints / "last.pt", epoch, float("inf"), "wall_time")
+                training_run.close()
                 return
-        
         scheduler.step()
-
-        # --- 6. Validation ---
         model.eval()
-        val_loss = 0
+        val_loss = 0.0
         with torch.no_grad():
             for batch in val_loader:
                 input_ids = batch.to(device)
                 targets = input_ids[:, 1:].contiguous()
                 logits = model(input_ids[:, :-1]).contiguous()
-                loss = criterion(logits.view(-1, logits.size(-1)), targets.view(-1))
-                val_loss += loss.item()
-
+                val_loss += criterion(logits.view(-1, logits.size(-1)), targets.view(-1)).item()
         val_loss /= len(val_loader)
-        perplexity = torch.exp(torch.tensor(val_loss))
-        print(f"Epoch {epoch+1}, Val Loss: {val_loss:.4f}, Val PPL: {perplexity:.4f}")
-
-        # --- 7. Checkpointing ---
-        # Saving the model allows for resuming training later.
-        save_checkpoint(output_dir / f"checkpoint_epoch_{epoch+1}.pt", epoch, val_loss, "epoch")
-        save_checkpoint(output_dir / "last.pt", epoch, val_loss, "epoch")
+        print(f"Epoch {epoch + 1}, Val Loss: {val_loss:.4f}")
+        save_checkpoint(training_run.checkpoints / f"epoch_{epoch + 1:03d}.pt", epoch, val_loss, "epoch")
+        save_checkpoint(training_run.checkpoints / "last.pt", epoch, val_loss, "epoch")
+    training_run.mark_complete({"completed_epochs": epochs})
+    training_run.close()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a protein language model.")
-    parser.add_argument("--config", type=str, required=True, help="Path to the config YAML file.")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--resume")
+    parser.add_argument("--run-id")
     args = parser.parse_args()
-    train(args.config)
+    train(args.config, resume=args.resume, run_id=args.run_id)

--- a/src/training/run_lifecycle.py
+++ b/src/training/run_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import csv
 import hashlib
+import fcntl
 import json
 import os
 import random
@@ -40,7 +41,18 @@ def configuration_fingerprint(
     config: dict[str, Any], mutable_keys: set[str] | None = None
 ) -> str:
     excluded = DEFAULT_MUTABLE_CONFIG_KEYS if mutable_keys is None else mutable_keys
-    immutable = {key: value for key, value in config.items() if key not in excluded}
+    def remove_mutable(value):
+        if isinstance(value, dict):
+            return {
+                key: remove_mutable(item)
+                for key, item in value.items()
+                if key not in excluded
+            }
+        if isinstance(value, list):
+            return [remove_mutable(item) for item in value]
+        return value
+
+    immutable = remove_mutable(config)
     encoded = json.dumps(immutable, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode()).hexdigest()
 
@@ -236,14 +248,16 @@ class TrainingRun:
         raise RunLifecycleError(f"Could not allocate a serial directory for {run_id}")
 
     def _acquire_lock(self) -> None:
+        self._lock_fd = os.open(self.lock_path, os.O_CREAT | os.O_RDWR, 0o644)
         try:
-            self._lock_fd = os.open(
-                self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
-            )
-        except FileExistsError as exc:
+            fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(self._lock_fd)
+            self._lock_fd = None
             raise RunLifecycleError(
                 f"Run directory is already locked: {self.run_dir}"
             ) from exc
+        os.ftruncate(self._lock_fd, 0)
         os.write(self._lock_fd, f"pid={os.getpid()}\n".encode())
 
     def mark_complete(self, metadata: dict[str, Any]) -> None:
@@ -260,12 +274,12 @@ class TrainingRun:
     def close(self) -> None:
         if self._lock_fd is None:
             return
+        fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
         os.close(self._lock_fd)
         self._lock_fd = None
-        try:
-            self.lock_path.unlink()
-        except FileNotFoundError:
-            pass
+
+    def __del__(self) -> None:
+        self.close()
 
     def __enter__(self) -> "TrainingRun":
         return self

--- a/tests/test_protein_trainer_lifecycle.py
+++ b/tests/test_protein_trainer_lifecycle.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import torch
+import yaml
+
+from src.protein_lm.train_lm import train
+
+
+def _write_config(tmp_path: Path, epochs: int) -> Path:
+    train_path = tmp_path / "train.jsonl"
+    val_path = tmp_path / "validation.jsonl"
+    records = [{"sequence": "MKTAA"}, {"sequence": "MQQVV"}]
+    text = "".join(json.dumps(record) + "\n" for record in records)
+    train_path.write_text(text)
+    val_path.write_text(text)
+    config = {
+        "run_id": "protein-lm-smoke",
+        "model": {
+            "vocab_size": 1,
+            "n_layer": 1,
+            "n_head": 1,
+            "n_embd": 16,
+            "block_size": 8,
+            "dropout": 0.0,
+        },
+        "training": {
+            "batch_size": 2,
+            "lr": 1e-3,
+            "epochs": epochs,
+            "grad_accum_steps": 1,
+            "num_workers": 0,
+            "seed": 7,
+        },
+        "data": {"train_path": str(train_path), "val_path": str(val_path)},
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config))
+    return path
+
+
+def test_protein_lm_serial_launch_and_completed_extension(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = _write_config(tmp_path, epochs=1)
+    train(str(config))
+    first = tmp_path / "runs" / "protein_lm" / "protein-lm-smoke"
+    checkpoint = first / "checkpoints" / "last.pt"
+    assert (first / "run_complete.json").exists()
+    payload = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    assert payload["run_progress"]["completed_epochs"] == 1
+
+    train(str(config))
+    assert (tmp_path / "runs" / "protein_lm" / "protein-lm-smoke-r002").exists()
+
+    config = _write_config(tmp_path, epochs=2)
+    train(str(config), resume=str(checkpoint), run_id="protein-lm-smoke")
+    payload = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    assert payload["run_progress"]["completed_epochs"] == 2
+    assert (first / "run_complete_epoch_001.json").exists()

--- a/tests/test_training_run_lifecycle.py
+++ b/tests/test_training_run_lifecycle.py
@@ -123,3 +123,8 @@ def test_configuration_fingerprint_ignores_operational_settings():
     assert configuration_fingerprint(baseline) != configuration_fingerprint(
         {**baseline, "lr": 2e-4}
     )
+    assert configuration_fingerprint(
+        {"training": {"epochs": 10, "lr": 1e-4}}
+    ) == configuration_fingerprint(
+        {"training": {"epochs": 20, "lr": 1e-4}}
+    )


### PR DESCRIPTION
## Summary
- migrate ProteinLM, protein classifier, Protein EBM, and NoProp training to the shared collision-safe run lifecycle
- restore model, optimizer, scheduler, RNG, and progress state with explicit resume validation
- add deterministic ProteinLM data ordering, atomic checkpoints, completion markers, and lifecycle documentation
- strengthen lifecycle locking and nested configuration fingerprint handling

## Scope
This changes training orchestration and checkpoint handling only. It does not change model architectures, loss functions, datasets, or scientific objectives. Protein EBM and NoProp resume at epoch boundaries; ProteinLM and the protein classifier can resume at optimizer-step boundaries.

## Verification
- ruff check on all changed Python files
- git diff --check
- pytest -q: 367 passed, 1 skipped, 1 xpassed