### PR TITLE
Plan model-agnostic training engine

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -1,0 +1,96 @@
+# Model-Agnostic Training Engine Plan
+
+## Phase 0: Characterize Existing Behavior
+
+- [ ] Inventory every training and fine-tuning entry point and classify its task,
+  update algorithm, optimizer topology, scheduler, resume granularity, and outputs.
+- [ ] Add characterization tests for standard backpropagation, gradient
+  accumulation remainders, nonfinite groups, validation selection, scheduler
+  timing, interruption, and resume.
+- [ ] Define the versioned `TrainingTask`, `UpdateStrategy`, metric, callback, and
+  engine-state contracts without importing CodonLM or ProteinLM modules.
+- [ ] Define compatibility rules for existing checkpoints and run directories.
+
+Exit gate: the contracts can represent every current trainer without model-name
+branches, and tests capture the behavior that migrations must preserve.
+
+## Phase 1: Minimal Shared Engine
+
+- [ ] Implement a model-agnostic `TrainingEngine` over `TrainingRun`.
+- [ ] Implement standard accumulated-backprop and optimizer/scheduler strategies.
+- [ ] Add shared device, precision, clipping, nonfinite, wall-time, validation,
+  metric aggregation, callback, and checkpoint policies.
+- [ ] Add engine contract tests with synthetic tasks and deterministic failures.
+
+Exit gate: synthetic tasks prove exact fresh, partial-group, interrupted, resumed,
+and completed behavior without importing a biological model.
+
+## Phase 2: ProteinLM Reference Migration
+
+- [ ] Implement `ProteinLMTask` as the simplest causal-language-model adapter.
+- [ ] Demonstrate fixed-seed parity for updates, scheduler state, validation loss,
+  checkpoint payload, and interrupted/resumed parameters.
+- [ ] Replace ProteinLM loop orchestration while retaining its CLI and legacy
+  checkpoint compatibility.
+
+Exit gate: ProteinLM behavior is equivalent and its trainer contains only argument,
+configuration, task, strategy, and engine assembly.
+
+## Phase 3: Supervised And Contrastive Protein Tasks
+
+- [ ] Implement the bidirectional multitask `ProteinCriticTask`.
+- [ ] Implement the protein classifier task or consolidate it with a generic
+  supervised-sequence task when the contracts genuinely match.
+- [ ] Implement `ProteinEBMTask`, keeping positive/negative construction and energy
+  metrics task-owned while using the shared optimization strategy.
+- [ ] Verify class/regression metric aggregation, frozen-backbone state, validation
+  selection, and resume parity.
+
+Exit gate: protein trainers share orchestration without changing their architectures,
+decoy distributions, losses, or scientific metrics.
+
+## Phase 4: CodonLM Migration
+
+- [ ] Implement `CodonLMTask` with packed-data masks, multi-offset heads,
+  termination loss, biophysical extensions, and existing telemetry as task hooks.
+- [ ] Characterize and preserve committed-token accounting, invalid-group recovery,
+  MPS memory telemetry, periodic checkpoints, and exact mid-epoch resume.
+- [ ] Run CPU parity tests and a bounded MPS fresh/resume smoke test.
+- [ ] Remove the old CodonLM orchestration loop only after parity gates pass.
+
+Exit gate: all declared CodonLM configurations use the shared engine without
+changing their objective, update exposure, or checkpoint compatibility.
+
+## Phase 5: Nonstandard Update Algorithms
+
+- [ ] Implement a layer-local `NoPropUpdateStrategy` with complete per-layer
+  optimizer state and resume parity.
+- [ ] Evaluate whether frozen-backbone and discriminative-learning-rate behavior
+  require strategies, optimizer factories, or parameter-group configuration.
+- [ ] Document how future training algorithms register without editing the engine.
+
+Exit gate: NoProp demonstrates that the engine supports a genuinely different
+update algorithm without model-specific branches.
+
+## Phase 6: Enforcement And Cleanup
+
+- [ ] Register every trainer and add CI contract coverage for fresh, collision,
+  resume, interruption, and completion behavior.
+- [ ] Reject new standalone training loops unless an explicit exemption documents
+  why the engine contract is insufficient.
+- [ ] Remove duplicated orchestration helpers and obsolete checkpoint writers.
+- [ ] Update workflow, architecture, development-log, and extension documentation.
+- [ ] Benchmark engine overhead and confirm it is negligible relative to model work.
+
+Exit gate: reusable mechanics have one maintained implementation, all supported
+trainers use it, and task-specific code contains only scientifically necessary
+behavior.
+
+## Planned Pull Requests
+
+1. Contracts, trainer inventory, and characterization tests.
+2. Minimal engine plus synthetic contract tests.
+3. ProteinLM reference migration.
+4. ProteinCritic, classifier, and EBM migrations.
+5. CodonLM migration and MPS parity gate.
+6. NoProp strategy, CI enforcement, documentation, and cleanup.

--- a/conductor/tracks/model_agnostic_training_engine_20260806/spec.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/spec.md
@@ -1,0 +1,74 @@
+# Model-Agnostic Training Engine
+
+## Objective
+
+Centralize reusable training mechanics so optimizer, accumulation, precision,
+validation, logging, checkpoint, interruption, and resume improvements apply to
+every compatible trainer once. Preserve model, data, objective, and scientific
+semantics behind explicit task and update-strategy interfaces.
+
+## Architecture
+
+The shared engine owns orchestration but does not inspect model types or biological
+tokens. A `TrainingTask` adapts model construction, data, loss, metrics, and
+task-specific checkpoint state. An `UpdateStrategy` owns how parameters are
+updated, allowing standard backpropagation, frozen-backbone training, contrastive
+EBM training, and layer-local NoProp to coexist without model-name conditionals in
+the engine.
+
+The existing `TrainingRun` lifecycle remains responsible for run allocation,
+locking, artifact paths, resume validation, and completion. The new engine consumes
+that service rather than duplicating it.
+
+## Required Boundaries
+
+### Shared engine responsibilities
+
+- epoch and microbatch iteration;
+- optimizer-step and scheduler-step timing;
+- gradient accumulation, remainder scaling, clipping, and nonfinite recovery;
+- device and precision policy, including MPS behavior;
+- validation cadence and metric aggregation;
+- structured progress, throughput, memory, and curve logging;
+- periodic, epoch, best, interruption, and completion checkpoints;
+- wall-time interruption and exact resumable progress;
+- callback execution and deterministic random-state restoration.
+
+### Task responsibilities
+
+- model and dataloader construction;
+- batch movement and domain-specific masks;
+- forward pass, loss components, and task metrics;
+- causal, bidirectional, contrastive, or auxiliary-objective semantics;
+- task-specific checkpoint payloads and compatibility adapters;
+- scientific evaluation outside the optimization loop.
+
+### Update-strategy responsibilities
+
+- optimizer ownership and zeroing;
+- microbatch backward behavior;
+- accumulation-group commit behavior;
+- scheduler ownership;
+- strategy-specific state serialization and restoration.
+
+## Non-Goals
+
+- Do not merge CodonLM and ProteinLM architectures or tokenizers.
+- Do not change datasets, splits, objectives, hyperparameters, or reported results.
+- Do not require all algorithms to imitate a standard single-optimizer loop.
+- Do not put `if model_type == ...` branches in the generic engine.
+- Do not remove legacy checkpoint readers until migration parity is demonstrated.
+
+## Compatibility And Acceptance
+
+Every migration must use fixed-seed characterization tests to compare the old and
+new paths for optimizer-step count, committed examples/tokens, accumulation
+remainder scaling, scheduler position, losses and metrics, checkpoint contents,
+and interrupted/resumed final parameters. Expected floating-point tolerances and
+any intentional behavior changes must be declared before implementation.
+
+Migration occurs one trainer at a time. The old implementation is removed only
+after its task adapter passes fresh-run, interruption, resume, completion, and
+artifact-contract tests on CPU. CodonLM and ProteinCritic also require a bounded MPS
+smoke test before their old orchestration paths are retired.
+

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1087,6 +1087,12 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     every epoch with the embedding, every block optimizer, and output-head optimizer.
     Run locking now uses kernel-released advisory locks so a killed process cannot
     leave a permanently stale lock file.
+*   **Model-Agnostic Training Engine Track (2026-08-06):** Opened a successor track
+    to centralize iteration, optimization, precision, validation, logging,
+    checkpoint, and resume mechanics. Separate task and update-strategy boundaries
+    preserve the necessary semantics of causal LMs, bidirectional critics,
+    contrastive EBMs, and NoProp. Fixed-seed parity and interruption/resume gates
+    are required before each legacy loop can be removed.
 
 ---
 *End of Log*


### PR DESCRIPTION
## Summary
- define the boundary between model-agnostic orchestration, task adapters, and update strategies
- establish fixed-seed parity and interruption/resume acceptance gates
- split migration into bounded PRs for the shared engine, ProteinLM, protein tasks, CodonLM, NoProp, and enforcement
- record the successor track in the development log

## Scope
Documentation and implementation plan only. This PR does not alter training behavior or scientific results.

## Verification
- git diff --check