### PR TITLE
Define model-agnostic training contracts

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -2,14 +2,14 @@
 
 ## Phase 0: Characterize Existing Behavior
 
-- [ ] Inventory every training and fine-tuning entry point and classify its task,
+- [x] Inventory every training and fine-tuning entry point and classify its task,
   update algorithm, optimizer topology, scheduler, resume granularity, and outputs.
-- [ ] Add characterization tests for standard backpropagation, gradient
+- [x] Add characterization tests for standard backpropagation, gradient
   accumulation remainders, nonfinite groups, validation selection, scheduler
   timing, interruption, and resume.
-- [ ] Define the versioned `TrainingTask`, `UpdateStrategy`, metric, callback, and
+- [x] Define the versioned `TrainingTask`, `UpdateStrategy`, metric, callback, and
   engine-state contracts without importing CodonLM or ProteinLM modules.
-- [ ] Define compatibility rules for existing checkpoints and run directories.
+- [x] Define compatibility rules for existing checkpoints and run directories.
 
 Exit gate: the contracts can represent every current trainer without model-name
 branches, and tests capture the behavior that migrations must preserve.

--- a/docs/TRAINING_ENTRYPOINT_INVENTORY.md
+++ b/docs/TRAINING_ENTRYPOINT_INVENTORY.md
@@ -1,0 +1,56 @@
+# Training Entrypoint Inventory
+
+This inventory defines the migration surface for the model-agnostic training
+engine. A registered trainer produces durable model parameters for scientific use.
+Diagnostic harnesses may execute optimizer steps but are not production trainers.
+
+| Entrypoint | Task | Update topology | Resume | Migration |
+| --- | --- | --- | --- | --- |
+| `src/codonlm/train_codon_lm.py` / `src/codonlm/training/loop.py` | causal codon LM with optional auxiliary objectives | AdamW, accumulated backprop, scheduler per committed group | exact optimizer boundary | Phase 4 |
+| `src/protein_lm/train_lm.py` | causal amino-acid LM | AdamW, accumulated backprop, cosine scheduler | optimizer boundary | Phase 2 reference |
+| `src/protein_lm/train_classifier.py` | protein sequence classifier | AdamW, accumulated backprop, cosine scheduler | optimizer boundary | Phase 3 |
+| `src/protein_lm/train_multi_task.py` | bidirectional multitask ProteinCritic | AdamW, accumulated backprop, mixed classification/regression loss | optimizer boundary | Phase 3 |
+| `src/protein_lm/train_ebm.py` | latent real-versus-corrupted ranking | AdamW on EBM head; frozen critic | epoch boundary | Phase 3 |
+| `src/codonlm/train_noprop.py` | layer-local NoProp codon model | embedding, per-block, and head optimizers | epoch boundary | Phase 5 |
+| `src/protein_lm/train_mlp_heads.py` | standalone heads over frozen features | one AdamW optimizer per head | none | ancillary; migrate or explicitly guard |
+| `scripts/train_biophysics_fusion.py` | nucleotide biophysics encoder pretraining/fusion assembly | AdamW encoder pretraining | none | ancillary; migrate or explicitly guard |
+
+## Diagnostic And Library Code
+
+- `scripts/benchmark_protein_critic_training.py`, `scripts/optimize_train_batching.py`,
+  and `scripts/profile_train.py` are diagnostic harnesses. They should call registered
+  tasks or strategies where practical, but do not own durable run semantics.
+- `scripts/analyze_saliency.py` performs an optimization-based interpretation
+  procedure, not model training.
+- `src/classifiers/mlp_head.py` is reusable library code invoked by evaluation
+  workflows rather than a standalone run owner.
+
+## Existing Characterization Coverage
+
+- `tests/test_trainer_utils.py` fixes accumulation remainder scaling and nonfinite
+  group semantics.
+- `tests/test_nonfinite_accumulation.py` fixes abort, checkpoint, and resume counters.
+- `tests/test_training_run_lifecycle.py` fixes collision, completion, curve, and
+  newest-last resume behavior.
+- `tests/test_training_preflight.py`, `tests/test_wall_time.py`, and
+  `tests/test_multi_task_wall_time.py` fix interruption and resume behavior.
+- `tests/test_protein_trainer_lifecycle.py` fixes ProteinLM serial allocation and
+  optimizer-boundary resume behavior.
+
+The migration parity suite will build on these tests and add fixed-seed parameter
+comparisons for each trainer before its existing orchestration loop is removed.
+
+## Checkpoint Compatibility Rules
+
+New engine checkpoints use a versioned, namespaced envelope with `engine`, `task`,
+`strategy`, `rng`, and `metadata` sections. The engine owns progress only; a task
+owns model and objective state; an update strategy owns every optimizer and
+scheduler it controls. This prevents the engine from interpreting model-specific
+keys.
+
+Existing checkpoints remain inputs to their current trainers during migration.
+Each task adapter may provide an explicit legacy translator for a documented schema.
+The generic engine must never infer ambiguous legacy progress or silently omit an
+optimizer. A translated checkpoint is written in the new schema only after all
+required state validates. Evaluation-only checkpoints remain usable for evaluation
+and explicit transfer, but they do not become in-place resume checkpoints.

--- a/src/training/contracts.py
+++ b/src/training/contracts.py
@@ -1,0 +1,215 @@
+"""Model-agnostic contracts for the shared training engine.
+
+These interfaces describe orchestration boundaries only. They intentionally do
+not import any CodonLM or ProteinLM module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping, Protocol, TypeVar, runtime_checkable
+
+import torch
+
+
+TRAINING_CONTRACT_VERSION = 1
+
+BatchT = TypeVar("BatchT")
+
+
+class TrainingPhase(str, Enum):
+    TRAIN = "train"
+    VALIDATION = "validation"
+
+
+@dataclass(frozen=True)
+class EngineState:
+    """Serializable progress owned by the model-agnostic engine."""
+
+    completed_epochs: int = 0
+    current_epoch: int = 0
+    microbatch: int = 0
+    optimizer_step: int = 0
+
+    def __post_init__(self) -> None:
+        for name in (
+            "completed_epochs",
+            "current_epoch",
+            "microbatch",
+            "optimizer_step",
+        ):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be non-negative")
+
+
+@dataclass(frozen=True)
+class TrainingCheckpoint:
+    """Namespaced checkpoint state shared by all future engine tasks."""
+
+    engine: EngineState
+    task: Mapping[str, Any]
+    strategy: Mapping[str, Any]
+    rng: Mapping[str, Any]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    contract_version: int = TRAINING_CONTRACT_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "training_contract_version": self.contract_version,
+            "engine": {
+                "completed_epochs": self.engine.completed_epochs,
+                "current_epoch": self.engine.current_epoch,
+                "microbatch": self.engine.microbatch,
+                "optimizer_step": self.engine.optimizer_step,
+            },
+            "task": dict(self.task),
+            "strategy": dict(self.strategy),
+            "rng": dict(self.rng),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "TrainingCheckpoint":
+        version = payload.get("training_contract_version")
+        if version != TRAINING_CONTRACT_VERSION:
+            raise ValueError(
+                "unsupported training checkpoint contract version: "
+                f"{version!r}; expected {TRAINING_CONTRACT_VERSION}"
+            )
+        required = {"engine", "task", "strategy", "rng"}
+        missing = required.difference(payload)
+        if missing:
+            raise ValueError(f"training checkpoint is missing: {sorted(missing)}")
+        engine = payload["engine"]
+        return cls(
+            engine=EngineState(
+                completed_epochs=int(engine["completed_epochs"]),
+                current_epoch=int(engine["current_epoch"]),
+                microbatch=int(engine["microbatch"]),
+                optimizer_step=int(engine["optimizer_step"]),
+            ),
+            task=payload["task"],
+            strategy=payload["strategy"],
+            rng=payload["rng"],
+            metadata=payload.get("metadata", {}),
+            contract_version=int(version),
+        )
+
+
+@dataclass(frozen=True)
+class StepContext:
+    """Engine-owned coordinates supplied to tasks and update strategies."""
+
+    phase: TrainingPhase
+    epoch: int
+    microbatch: int
+    optimizer_step: int
+    device: torch.device
+    group_size: int = 1
+
+    def __post_init__(self) -> None:
+        for name in ("epoch", "microbatch", "optimizer_step"):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be non-negative")
+        if self.group_size < 1:
+            raise ValueError("group_size must be positive")
+
+
+@dataclass(frozen=True)
+class MetricValue:
+    """A reducible metric numerator and its aggregation weight."""
+
+    total: float
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.weight < 0:
+            raise ValueError("metric weight must be non-negative")
+
+
+@dataclass
+class StepOutput:
+    """Task output consumed by an update strategy or validation reducer."""
+
+    loss: torch.Tensor
+    metrics: Mapping[str, MetricValue] = field(default_factory=dict)
+    committed_units: Mapping[str, int] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if self.loss.numel() != 1:
+            raise ValueError("step loss must be a scalar tensor")
+        for name, count in self.committed_units.items():
+            if count < 0:
+                raise ValueError(f"committed unit {name!r} must be non-negative")
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Outcome of committing or aborting an accumulation group."""
+
+    committed: bool
+    optimizer_steps: int
+    metrics: Mapping[str, MetricValue] = field(default_factory=dict)
+    committed_units: Mapping[str, int] = field(default_factory=dict)
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.optimizer_steps < 0:
+            raise ValueError("optimizer_steps must be non-negative")
+        if not self.committed and self.optimizer_steps:
+            raise ValueError("an aborted update cannot report optimizer steps")
+
+
+@runtime_checkable
+class TrainingTask(Protocol[BatchT]):
+    """Model/data/objective adapter used by a training engine."""
+
+    def train_batches(self, epoch: int) -> Iterable[BatchT]: ...
+
+    def validation_batches(self, epoch: int) -> Iterable[BatchT]: ...
+
+    def training_step(self, batch: BatchT, context: StepContext) -> StepOutput: ...
+
+    def validation_step(self, batch: BatchT, context: StepContext) -> StepOutput: ...
+
+    def state_dict(self) -> Mapping[str, Any]: ...
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None: ...
+
+
+@runtime_checkable
+class UpdateStrategy(Protocol[BatchT]):
+    """Parameter-update algorithm, independent of engine iteration."""
+
+    def begin_group(self, group_size: int) -> None: ...
+
+    def process_microbatch(
+        self,
+        task: TrainingTask[BatchT],
+        batch: BatchT,
+        context: StepContext,
+    ) -> StepOutput: ...
+
+    def commit_group(self) -> UpdateResult: ...
+
+    def abort_group(self, reason: str) -> UpdateResult: ...
+
+    def state_dict(self) -> Mapping[str, Any]: ...
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None: ...
+
+
+@dataclass(frozen=True)
+class EngineEvent:
+    """Stable callback payload that contains no model-specific assumptions."""
+
+    name: str
+    context: StepContext | None = None
+    metrics: Mapping[str, MetricValue] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class TrainingCallback(Protocol):
+    def on_event(self, event: EngineEvent) -> None: ...

--- a/tests/test_training_contracts.py
+++ b/tests/test_training_contracts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+import torch
+
+from src.training.contracts import (
+    TRAINING_CONTRACT_VERSION,
+    EngineEvent,
+    EngineState,
+    MetricValue,
+    StepContext,
+    StepOutput,
+    TrainingCallback,
+    TrainingCheckpoint,
+    TrainingPhase,
+    TrainingTask,
+    UpdateResult,
+    UpdateStrategy,
+)
+
+
+class SyntheticTask:
+    def train_batches(self, epoch):
+        return [torch.tensor([float(epoch + 1)])]
+
+    def validation_batches(self, epoch):
+        return [torch.tensor([float(epoch + 1)])]
+
+    def training_step(self, batch, context):
+        return StepOutput(batch.mean(), {"loss": MetricValue(float(batch.mean()))})
+
+    def validation_step(self, batch, context):
+        return self.training_step(batch, context)
+
+    def state_dict(self) -> Mapping[str, object]:
+        return {"kind": "synthetic"}
+
+    def load_state_dict(self, state):
+        assert state["kind"] == "synthetic"
+
+
+class MultiOptimizerStrategy:
+    """Contract fixture representing NoProp-style multiple optimizer updates."""
+
+    def __init__(self):
+        self.group_size = 0
+
+    def begin_group(self, group_size):
+        self.group_size = group_size
+
+    def process_microbatch(self, task, batch, context):
+        return task.training_step(batch, context)
+
+    def commit_group(self):
+        return UpdateResult(committed=True, optimizer_steps=3)
+
+    def abort_group(self, reason):
+        return UpdateResult(committed=False, optimizer_steps=0, reason=reason)
+
+    def state_dict(self):
+        return {"group_size": self.group_size, "optimizers": [{}, {}, {}]}
+
+    def load_state_dict(self, state):
+        self.group_size = state["group_size"]
+
+
+class EventRecorder:
+    def __init__(self):
+        self.events = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+
+def test_contracts_are_model_agnostic_and_runtime_checkable():
+    task = SyntheticTask()
+    strategy = MultiOptimizerStrategy()
+    callback = EventRecorder()
+
+    assert TRAINING_CONTRACT_VERSION == 1
+    assert isinstance(task, TrainingTask)
+    assert isinstance(strategy, UpdateStrategy)
+    assert isinstance(callback, TrainingCallback)
+
+    context = StepContext(
+        phase=TrainingPhase.TRAIN,
+        epoch=0,
+        microbatch=0,
+        optimizer_step=0,
+        device=torch.device("cpu"),
+        group_size=2,
+    )
+    strategy.begin_group(context.group_size)
+    output = strategy.process_microbatch(task, torch.tensor([2.0]), context)
+    output.validate()
+    assert strategy.commit_group().optimizer_steps == 3
+
+    callback.on_event(EngineEvent("group_committed", context, output.metrics))
+    assert callback.events[0].name == "group_committed"
+
+
+def test_step_output_rejects_non_scalar_loss_and_negative_units():
+    with pytest.raises(ValueError, match="scalar"):
+        StepOutput(torch.ones(2)).validate()
+    with pytest.raises(ValueError, match="non-negative"):
+        StepOutput(torch.tensor(1.0), committed_units={"tokens": -1}).validate()
+
+
+def test_context_and_update_result_validate_engine_invariants():
+    with pytest.raises(ValueError, match="group_size"):
+        StepContext(
+            TrainingPhase.TRAIN, 0, 0, 0, torch.device("cpu"), group_size=0
+        )
+    with pytest.raises(ValueError, match="aborted"):
+        UpdateResult(committed=False, optimizer_steps=1)
+
+
+def test_training_checkpoint_round_trip_keeps_state_namespaced():
+    checkpoint = TrainingCheckpoint(
+        engine=EngineState(1, 2, 3, 4),
+        task={"model": {"weight": torch.tensor([1.0])}},
+        strategy={"optimizers": [{"step": 4}]},
+        rng={"python": "state"},
+        metadata={"run_fingerprint": "abc"},
+    )
+
+    restored = TrainingCheckpoint.from_payload(checkpoint.to_payload())
+
+    assert restored.engine == checkpoint.engine
+    assert torch.equal(restored.task["model"]["weight"], torch.tensor([1.0]))
+    assert restored.strategy == checkpoint.strategy
+    assert restored.metadata["run_fingerprint"] == "abc"
+
+
+def test_training_checkpoint_rejects_legacy_or_unknown_layouts():
+    with pytest.raises(ValueError, match="contract version"):
+        TrainingCheckpoint.from_payload({"model_state_dict": {}})
+    with pytest.raises(ValueError, match="contract version"):
+        TrainingCheckpoint.from_payload({"training_contract_version": 999})


### PR DESCRIPTION
## Summary
- inventory every production trainer, ancillary optimizer entry point, and diagnostic harness
- define versioned TrainingTask, UpdateStrategy, callback, metric, and progress contracts without biological-model imports
- namespace future checkpoint state into engine, task, strategy, RNG, and metadata ownership
- document legacy checkpoint translation rules and existing behavior-characterization coverage
- complete Phase 0 of the model-agnostic engine track

## Scope
This defines interfaces and compatibility rules only. It does not replace a training loop or change model behavior.

## Verification
- ruff check on changed Python files
- focused lifecycle and accumulation suite: 29 passed
- pytest -q: 372 passed, 1 skipped, 1 xpassed