### PR TITLE
Fix legacy protein classifier leakage

### DIFF
--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1093,6 +1093,12 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     preserve the necessary semantics of causal LMs, bidirectional critics,
     contrastive EBMs, and NoProp. Fixed-seed parity and interruption/resume gates
     are required before each legacy loop can be removed.
+*   **Legacy Protein Classifier Correction (2026-08-06):** Removed direct target
+    leakage from conditional tokens, made BOS pooling bidirectional and padding-aware,
+    and bound validation labels to the training-fitted class vocabulary. Class maps
+    are now checkpointed and checked on resume. Historical results from this legacy
+    classifier require revalidation; the corrected multitask ProteinCritic remains a
+    separate model.
 
 ---
 *End of Log*

--- a/src/protein_lm/data.py
+++ b/src/protein_lm/data.py
@@ -60,6 +60,7 @@ def create_dataloader(
     shuffle=True,
     dataset_class=ProteinDataset,
     label_field=None,
+    label_map=None,
     generator=None,
 ):
     """
@@ -67,7 +68,13 @@ def create_dataloader(
     Can be used for both language modeling and classification.
     """
     if dataset_class == ProteinClassificationDataset:
-        dataset = dataset_class(split_path, tokenizer, block_size, label_field=label_field)
+        dataset = dataset_class(
+            split_path,
+            tokenizer,
+            block_size,
+            label_field=label_field,
+            label_map=label_map,
+        )
     else:
         dataset = dataset_class(split_path, tokenizer, block_size)
         
@@ -80,13 +87,33 @@ def create_dataloader(
     )
 
 class ProteinClassificationDataset(ProteinDataset):
-    def __init__(self, file_path: str, tokenizer: ProteinTokenizer, block_size: int, label_field: str):
+    def __init__(
+        self,
+        file_path: str,
+        tokenizer: ProteinTokenizer,
+        block_size: int,
+        label_field: str,
+        label_map: dict | None = None,
+    ):
         super().__init__(file_path, tokenizer, block_size)
         self.label_field = label_field
-        
-        # Build label map dynamically from the data
-        self.labels = sorted(list(set(s[self.label_field] for s in self.samples if self.label_field in s)))
-        self.label_map = {label: i for i, label in enumerate(self.labels)}
+
+        observed_labels = sorted(
+            {sample[self.label_field] for sample in self.samples if self.label_field in sample}
+        )
+        self.label_map = (
+            dict(label_map)
+            if label_map is not None
+            else {label: index for index, label in enumerate(observed_labels)}
+        )
+        unknown = sorted(set(observed_labels).difference(self.label_map))
+        if unknown:
+            raise ValueError(
+                f"{file_path} contains labels absent from the training label map: {unknown}"
+            )
+        self.labels = [
+            label for label, _ in sorted(self.label_map.items(), key=lambda item: item[1])
+        ]
         print(f"Found labels: {self.label_map}")
 
     def __getitem__(self, idx):
@@ -96,9 +123,9 @@ class ProteinClassificationDataset(ProteinDataset):
         sequence = sample['sequence']
 
         conditions = []
-        if 'func_label' in sample:
+        if 'func_label' in sample and self.label_field != 'func_label':
             conditions.append(f"<FUNC:{sample['func_label'].upper()}>")
-        if 'topo_label' in sample:
+        if 'topo_label' in sample and self.label_field != 'topo_label':
             conditions.append(f"<TOPO:{sample['topo_label'].upper()}>")
 
         condition_ids = self.tokenizer.encode_conditions(conditions)
@@ -116,7 +143,12 @@ class ProteinClassificationDataset(ProteinDataset):
         else:
             input_ids = input_ids[:self.block_size]
             
-        label = sample.get(self.label_field)
-        
-        return torch.tensor(input_ids, dtype=torch.long), torch.tensor(self.label_map.get(label, -1), dtype=torch.long)
+        if self.label_field not in sample:
+            raise ValueError(
+                f"sample {idx} has no required label field {self.label_field!r}"
+            )
+        label = sample[self.label_field]
 
+        return torch.tensor(input_ids, dtype=torch.long), torch.tensor(
+            self.label_map[label], dtype=torch.long
+        )

--- a/src/protein_lm/models.py
+++ b/src/protein_lm/models.py
@@ -80,7 +80,11 @@ class ProteinClassifier(nn.Module):
 
         self.classification_head = nn.Linear(config.n_embd, config.num_classes)
 
-    def forward(self, input_ids: torch.LongTensor) -> torch.Tensor:
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         """
         Forward pass for the classifier.
 
@@ -99,17 +103,16 @@ class ProteinClassifier(nn.Module):
         pos_embeds = self.backbone.position_embedding(torch.arange(seq_length, device=input_ids.device))
         x = self.backbone.dropout(token_embeds + pos_embeds)
 
-        # We don't need a causal mask for the classifier, as we want to use the whole sequence.
-        # However, to reuse the backbone, we are using the same forward pass.
-        # For classification, it is common to use a non-causal mask, but for simplicity
-        # and to reuse the code, we will use the causal mask.
-        causal_mask = nn.Transformer.generate_square_subsequent_mask(seq_length, device=input_ids.device)
+        if attention_mask is None:
+            attention_mask = input_ids.ne(0)
+        else:
+            attention_mask = attention_mask.to(device=input_ids.device, dtype=torch.bool)
+        padding_mask = ~attention_mask
 
         for block in self.backbone.transformer_blocks:
-            x = block(x, src_mask=causal_mask)
+            x = block(x, src_key_padding_mask=padding_mask)
 
-        # We pool the representation of the [BOS] token, which is at the first position.
-        # This is a common technique to get a fixed-size representation of the sequence.
+        # Bidirectional attention lets the BOS representation summarize the full protein.
         bos_representation = x[:, 0, :]
 
         logits = self.classification_head(bos_representation)

--- a/src/protein_lm/train_classifier.py
+++ b/src/protein_lm/train_classifier.py
@@ -73,13 +73,16 @@ def train_classifier(config_path: str, resume=None, run_id=None):
         block_size=classifier_config.block_size,
         shuffle=False,
         dataset_class=ProteinClassificationDataset,
-        label_field='func_label'
+        label_field='func_label',
+        label_map=train_loader.dataset.label_map,
     )
-    
-    # Dynamically set num_classes from the dataset if not in config
-    if not hasattr(classifier_config, 'num_classes') or classifier_config.num_classes is None:
-        classifier_config.num_classes = len(train_loader.dataset.label_map)
-        print(f"Number of classes detected from dataset: {classifier_config.num_classes}")
+
+    detected_classes = len(train_loader.dataset.label_map)
+    if classifier_config.num_classes != detected_classes:
+        raise ValueError(
+            f"Configured num_classes={classifier_config.num_classes}, but the training "
+            f"label map contains {detected_classes} classes"
+        )
 
 
     # --- 4. Model Initialization ---
@@ -97,6 +100,12 @@ def train_classifier(config_path: str, resume=None, run_id=None):
     resume_microbatch = 0
     if resume:
         checkpoint = torch.load(resume, map_location=device, weights_only=False)
+        checkpoint_label_map = checkpoint.get("label_map")
+        if (
+            checkpoint_label_map is not None
+            and checkpoint_label_map != train_loader.dataset.label_map
+        ):
+            raise ValueError("Resume checkpoint label map differs from the training data")
         model.load_state_dict(checkpoint["model_state_dict"])
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
@@ -118,6 +127,7 @@ def train_classifier(config_path: str, resume=None, run_id=None):
             'optimizer_step': optimizer_step,
             'checkpoint_reason': reason,
             'cfg': config_data,
+            'label_map': dict(train_loader.dataset.label_map),
             'epoch_complete': complete,
             'microbatch_idx': 0 if complete else current_microbatch,
             'run_fingerprint': run_fingerprint,

--- a/tests/test_protein_classifier_data.py
+++ b/tests/test_protein_classifier_data.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+from src.protein_lm.data import ProteinClassificationDataset
+from src.protein_lm.tokenizer import ProteinTokenizer
+
+
+def _write_jsonl(path, records):
+    path.write_text("".join(json.dumps(record) + "\n" for record in records))
+
+
+def test_validation_reuses_training_label_ids(tmp_path):
+    train_path = tmp_path / "train.jsonl"
+    val_path = tmp_path / "val.jsonl"
+    _write_jsonl(
+        train_path,
+        [
+            {"sequence": "ACD", "func_label": "alpha"},
+            {"sequence": "EFG", "func_label": "beta"},
+        ],
+    )
+    _write_jsonl(val_path, [{"sequence": "HIK", "func_label": "beta"}])
+    tokenizer = ProteinTokenizer()
+
+    train = ProteinClassificationDataset(
+        str(train_path), tokenizer, block_size=8, label_field="func_label"
+    )
+    validation = ProteinClassificationDataset(
+        str(val_path),
+        tokenizer,
+        block_size=8,
+        label_field="func_label",
+        label_map=train.label_map,
+    )
+
+    assert train.label_map == {"alpha": 0, "beta": 1}
+    assert validation[0][1].item() == 1
+    assert validation[0][0][1].item() == tokenizer.token_to_id["H"]
+
+
+def test_validation_rejects_labels_unseen_during_training(tmp_path):
+    path = tmp_path / "validation.jsonl"
+    _write_jsonl(path, [{"sequence": "ACD", "func_label": "unknown"}])
+
+    with pytest.raises(ValueError, match="absent from the training label map"):
+        ProteinClassificationDataset(
+            str(path),
+            ProteinTokenizer(),
+            block_size=8,
+            label_field="func_label",
+            label_map={"known": 0},
+        )

--- a/tests/test_protein_models.py
+++ b/tests/test_protein_models.py
@@ -32,6 +32,51 @@ def test_classifier_forward_pass():
 
     assert logits.shape == (4, config.num_classes)
 
+
+def test_classifier_bos_representation_depends_on_later_residues():
+    torch.manual_seed(7)
+    config = ProteinClassifierConfig(
+        vocab_size=30,
+        n_layer=1,
+        n_head=2,
+        n_embd=16,
+        block_size=8,
+        dropout=0.0,
+        num_classes=2,
+    )
+    model = ProteinClassifier(config).eval()
+    first = torch.tensor([[1, 3, 4, 5, 0, 0]])
+    second = torch.tensor([[1, 8, 9, 10, 0, 0]])
+
+    with torch.no_grad():
+        first_logits = model(first)
+        second_logits = model(second)
+
+    assert not torch.allclose(first_logits, second_logits)
+
+
+def test_classifier_ignores_explicitly_masked_padding_tokens():
+    torch.manual_seed(11)
+    config = ProteinClassifierConfig(
+        vocab_size=30,
+        n_layer=1,
+        n_head=2,
+        n_embd=16,
+        block_size=8,
+        dropout=0.0,
+        num_classes=2,
+    )
+    model = ProteinClassifier(config).eval()
+    attention_mask = torch.tensor([[1, 1, 1, 0, 0]])
+    first = torch.tensor([[1, 3, 4, 0, 0]])
+    second = torch.tensor([[1, 3, 4, 8, 9]])
+
+    with torch.no_grad():
+        first_logits = model(first, attention_mask)
+        second_logits = model(second, attention_mask)
+
+    assert torch.allclose(first_logits, second_logits, atol=1e-6)
+
 def test_causal_mask():
     """
     Tests the causal masking of the language model.


### PR DESCRIPTION
## Summary
- remove the predicted label from classifier condition tokens
- replace causal BOS pooling with bidirectional, padding-aware sequence encoding
- fit label IDs on training data and reuse the exact mapping for validation
- persist the class map in checkpoints and validate it during resume
- mark historical legacy-classifier results for revalidation

## Why
The previous classifier exposed func_label in its input and classified the causally masked BOS state, which could not attend to protein residues. Validation also generated an independent class-to-ID mapping.

## Scope
This corrects only the standalone legacy ProteinClassifier. It does not change the corrected multitask ProteinCritic.

## Verification
- focused classifier/lifecycle suite: 9 passed
- pytest -q: 376 passed, 1 skipped, 1 xpassed
- ruff check and git diff --check