### PR TITLE
Add model-agnostic training engine

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -16,11 +16,11 @@ branches, and tests capture the behavior that migrations must preserve.
 
 ## Phase 1: Minimal Shared Engine
 
-- [ ] Implement a model-agnostic `TrainingEngine` over `TrainingRun`.
-- [ ] Implement standard accumulated-backprop and optimizer/scheduler strategies.
-- [ ] Add shared device, precision, clipping, nonfinite, wall-time, validation,
+- [x] Implement a model-agnostic `TrainingEngine` over `TrainingRun`.
+- [x] Implement standard accumulated-backprop and optimizer/scheduler strategies.
+- [x] Add shared device, precision, clipping, nonfinite, wall-time, validation,
   metric aggregation, callback, and checkpoint policies.
-- [ ] Add engine contract tests with synthetic tasks and deterministic failures.
+- [x] Add engine contract tests with synthetic tasks and deterministic failures.
 
 Exit gate: synthetic tasks prove exact fresh, partial-group, interrupted, resumed,
 and completed behavior without importing a biological model.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1099,6 +1099,12 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     are now checkpointed and checked on resume. Historical results from this legacy
     classifier require revalidation; the corrected multitask ProteinCritic remains a
     separate model.
+*   **Model-Agnostic Engine Phase 1 (2026-08-06):** Added the shared synthetic-task
+    engine, actual-size accumulated-backprop strategy, optimizer/scheduler state,
+    precision policy, clipping and nonfinite recovery, weighted metrics, callbacks,
+    validation selection, wall-time interruption, and namespaced checkpoint resume.
+    Biological trainers remain on their existing loops until individual parity gates
+    pass.
 
 ---
 *End of Log*

--- a/src/training/contracts.py
+++ b/src/training/contracts.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Iterable, Mapping, Protocol, TypeVar, runtime_checkable
+from typing import Any, Iterator, Mapping, Protocol, TypeVar, runtime_checkable
 
 import torch
 
@@ -16,6 +16,14 @@ import torch
 TRAINING_CONTRACT_VERSION = 1
 
 BatchT = TypeVar("BatchT")
+
+
+class BatchStream(Protocol[BatchT]):
+    """Re-iterable or single-pass batch source with a declared finite length."""
+
+    def __iter__(self) -> Iterator[BatchT]: ...
+
+    def __len__(self) -> int: ...
 
 
 class TrainingPhase(str, Enum):
@@ -165,9 +173,11 @@ class UpdateResult:
 class TrainingTask(Protocol[BatchT]):
     """Model/data/objective adapter used by a training engine."""
 
-    def train_batches(self, epoch: int) -> Iterable[BatchT]: ...
+    def begin_phase(self, phase: TrainingPhase, epoch: int) -> None: ...
 
-    def validation_batches(self, epoch: int) -> Iterable[BatchT]: ...
+    def train_batches(self, epoch: int) -> BatchStream[BatchT]: ...
+
+    def validation_batches(self, epoch: int) -> BatchStream[BatchT]: ...
 
     def training_step(self, batch: BatchT, context: StepContext) -> StepOutput: ...
 

--- a/src/training/engine.py
+++ b/src/training/engine.py
@@ -1,0 +1,275 @@
+"""Model-agnostic training orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from numbers import Integral
+from pathlib import Path
+from typing import Generic
+
+import torch
+
+from src.training.contracts import (
+    BatchT,
+    EngineEvent,
+    EngineState,
+    MetricValue,
+    StepContext,
+    TrainingCallback,
+    TrainingCheckpoint,
+    TrainingPhase,
+    TrainingTask,
+    UpdateStrategy,
+)
+from src.training.run_lifecycle import TrainingRun, capture_rng_state, restore_rng_state
+from src.training.runtime import (
+    PeriodicCheckpointPolicy,
+    WallTimer,
+    save_checkpoint_atomic,
+)
+from src.training.strategies import NonFiniteStepError
+
+
+@dataclass(frozen=True)
+class EngineConfig:
+    epochs: int
+    grad_accum_steps: int = 1
+    validate_every_epochs: int = 1
+    monitor: str = "loss"
+    minimize_monitor: bool = True
+    last_checkpoint_name: str = "last.pt"
+    best_checkpoint_name: str = "best.pt"
+
+    def __post_init__(self) -> None:
+        for name in ("epochs", "grad_accum_steps", "validate_every_epochs"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, Integral):
+                raise TypeError(f"{name} must be an integer")
+            if value < 1:
+                raise ValueError(f"{name} must be positive")
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    state: EngineState
+    status: str
+    best_metric: float | None
+    aborted_groups: int = 0
+
+
+@dataclass
+class _MetricAccumulator:
+    totals: dict[str, float] = field(default_factory=dict)
+    weights: dict[str, float] = field(default_factory=dict)
+
+    def add(self, metrics) -> None:
+        for name, value in metrics.items():
+            self.totals[name] = self.totals.get(name, 0.0) + float(value.total)
+            self.weights[name] = self.weights.get(name, 0.0) + float(value.weight)
+
+    def averages(self) -> dict[str, MetricValue]:
+        return {
+            name: MetricValue(total / self.weights[name], 1.0)
+            for name, total in self.totals.items()
+            if self.weights.get(name, 0.0) > 0
+        }
+
+
+class TrainingEngine(Generic[BatchT]):
+    def __init__(
+        self,
+        *,
+        task: TrainingTask[BatchT],
+        strategy: UpdateStrategy[BatchT],
+        run: TrainingRun,
+        config: EngineConfig,
+        device: torch.device,
+        callbacks: list[TrainingCallback] | None = None,
+        wall_timer: WallTimer | None = None,
+        checkpoint_policy: PeriodicCheckpointPolicy | None = None,
+        run_fingerprint: str | None = None,
+    ) -> None:
+        self.task = task
+        self.strategy = strategy
+        self.run = run
+        self.config = config
+        self.device = device
+        self.callbacks = list(callbacks or [])
+        self.wall_timer = wall_timer or WallTimer()
+        self.checkpoint_policy = checkpoint_policy or PeriodicCheckpointPolicy()
+        self.run_fingerprint = run_fingerprint
+        self.state = EngineState()
+        self.best_metric: float | None = None
+        self.aborted_groups = 0
+
+    def fit(self) -> EngineResult:
+        if self.run.resume_checkpoint is not None:
+            self._restore(self.run.resume_checkpoint)
+
+        for epoch in range(self.state.current_epoch, self.config.epochs):
+            self.task.begin_phase(TrainingPhase.TRAIN, epoch)
+            batches = self.task.train_batches(epoch)
+            total_batches = len(batches)
+            batch_iterator = iter(batches)
+            resume_microbatch = self.state.microbatch if epoch == self.state.current_epoch else 0
+            for _ in range(resume_microbatch):
+                next(batch_iterator)
+
+            microbatch = resume_microbatch
+            while microbatch < total_batches:
+                group_size = min(
+                    self.config.grad_accum_steps, total_batches - microbatch
+                )
+                self.strategy.begin_group(group_size)
+                group_metrics = _MetricAccumulator()
+                group_units: dict[str, int] = {}
+                group_failed = False
+                for offset in range(group_size):
+                    batch = next(batch_iterator)
+                    context = StepContext(
+                        TrainingPhase.TRAIN,
+                        epoch,
+                        microbatch + offset,
+                        self.state.optimizer_step,
+                        self.device,
+                        group_size,
+                    )
+                    try:
+                        output = self.strategy.process_microbatch(
+                            self.task, batch, context
+                        )
+                    except NonFiniteStepError as exc:
+                        self.strategy.abort_group(str(exc))
+                        self.aborted_groups += 1
+                        group_failed = True
+                        for _ in range(offset + 1, group_size):
+                            next(batch_iterator)
+                        break
+                    group_metrics.add(output.metrics)
+                    for name, count in output.committed_units.items():
+                        group_units[name] = group_units.get(name, 0) + int(count)
+
+                microbatch += group_size
+                if not group_failed:
+                    update = self.strategy.commit_group()
+                    if not update.committed:
+                        self.aborted_groups += 1
+                    else:
+                        self.state = EngineState(
+                            completed_epochs=epoch,
+                            current_epoch=epoch,
+                            microbatch=microbatch,
+                            optimizer_step=(
+                                self.state.optimizer_step + update.optimizer_steps
+                            ),
+                        )
+                        self._emit(
+                            "group_committed",
+                            context,
+                            group_metrics.averages(),
+                            {"committed_units": group_units},
+                        )
+                        if self.checkpoint_policy.should_save(
+                            self.state.optimizer_step
+                        ):
+                            self._save(self.config.last_checkpoint_name, "periodic")
+                            self.checkpoint_policy.mark_saved(
+                                self.state.optimizer_step
+                            )
+                if self.wall_timer.expired():
+                    self.state = EngineState(
+                        completed_epochs=epoch,
+                        current_epoch=epoch,
+                        microbatch=microbatch,
+                        optimizer_step=self.state.optimizer_step,
+                    )
+                    self._save(self.config.last_checkpoint_name, "wall_time")
+                    return EngineResult(
+                        self.state, "interrupted", self.best_metric, self.aborted_groups
+                    )
+
+            validation_metrics = {}
+            if (epoch + 1) % self.config.validate_every_epochs == 0:
+                validation_metrics = self._validate(epoch)
+            self.state = EngineState(
+                completed_epochs=epoch + 1,
+                current_epoch=epoch + 1,
+                microbatch=0,
+                optimizer_step=self.state.optimizer_step,
+            )
+            monitored = validation_metrics.get(self.config.monitor)
+            improved = monitored is not None and self._is_better(monitored.total)
+            if improved:
+                self.best_metric = monitored.total
+            self._save(self.config.last_checkpoint_name, "epoch")
+            if improved:
+                self._save(self.config.best_checkpoint_name, "best")
+            self._emit("epoch_completed", None, validation_metrics)
+
+        self.run.mark_complete(
+            {
+                "completed_epochs": self.state.completed_epochs,
+                "optimizer_step": self.state.optimizer_step,
+                "best_metric": self.best_metric,
+            }
+        )
+        return EngineResult(self.state, "complete", self.best_metric, self.aborted_groups)
+
+    def _validate(self, epoch: int) -> dict[str, MetricValue]:
+        self.task.begin_phase(TrainingPhase.VALIDATION, epoch)
+        accumulator = _MetricAccumulator()
+        for microbatch, batch in enumerate(self.task.validation_batches(epoch)):
+            context = StepContext(
+                TrainingPhase.VALIDATION,
+                epoch,
+                microbatch,
+                self.state.optimizer_step,
+                self.device,
+            )
+            with torch.no_grad():
+                output = self.task.validation_step(batch, context)
+            output.validate()
+            accumulator.add(output.metrics)
+        metrics = accumulator.averages()
+        self._emit("validation_completed", None, metrics)
+        return metrics
+
+    def _is_better(self, value: float) -> bool:
+        if self.best_metric is None:
+            return True
+        return value < self.best_metric if self.config.minimize_monitor else value > self.best_metric
+
+    def _save(self, filename: str, reason: str) -> None:
+        checkpoint = TrainingCheckpoint(
+            engine=self.state,
+            task=self.task.state_dict(),
+            strategy=self.strategy.state_dict(),
+            rng=capture_rng_state(),
+            metadata={"reason": reason, "best_metric": self.best_metric},
+        )
+        payload = checkpoint.to_payload()
+        payload["run_progress"] = {
+            "completed_epochs": self.state.completed_epochs,
+            "current_epoch": self.state.current_epoch,
+            "microbatch": self.state.microbatch,
+            "optimizer_step": self.state.optimizer_step,
+        }
+        if self.run_fingerprint is not None:
+            payload["run_fingerprint"] = self.run_fingerprint
+        save_checkpoint_atomic(payload, self.run.checkpoints / filename)
+        self._emit("checkpoint_saved", None, metadata={"reason": reason, "filename": filename})
+
+    def _restore(self, path: Path) -> None:
+        payload = torch.load(path, map_location="cpu", weights_only=False)
+        checkpoint = TrainingCheckpoint.from_payload(payload)
+        self.task.load_state_dict(checkpoint.task)
+        self.strategy.load_state_dict(checkpoint.strategy)
+        restore_rng_state(dict(checkpoint.rng))
+        self.state = checkpoint.engine
+        best = checkpoint.metadata.get("best_metric")
+        self.best_metric = None if best is None else float(best)
+
+    def _emit(self, name, context=None, metrics=None, metadata=None) -> None:
+        event = EngineEvent(name, context, metrics or {}, metadata or {})
+        for callback in self.callbacks:
+            callback.on_event(event)

--- a/src/training/strategies.py
+++ b/src/training/strategies.py
@@ -1,0 +1,168 @@
+"""Model-agnostic parameter update strategies."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from contextlib import nullcontext
+from typing import Any, Generic
+
+import torch
+
+from src.training.contracts import (
+    BatchT,
+    StepContext,
+    StepOutput,
+    TrainingTask,
+    UpdateResult,
+)
+
+
+class NonFiniteStepError(RuntimeError):
+    """Raised when a loss or accumulated gradient is not finite."""
+
+
+class PrecisionPolicy:
+    """Autocast and optional gradient scaling independent of model code."""
+
+    def __init__(
+        self,
+        *,
+        device_type: str = "cpu",
+        dtype: torch.dtype | None = None,
+        enabled: bool = False,
+        scale_gradients: bool = False,
+    ) -> None:
+        self.device_type = device_type
+        self.dtype = dtype
+        self.enabled = bool(enabled)
+        self.scaler = torch.amp.GradScaler(
+            device_type, enabled=self.enabled and scale_gradients
+        )
+
+    def forward_context(self):
+        if not self.enabled:
+            return nullcontext()
+        return torch.amp.autocast(
+            device_type=self.device_type, dtype=self.dtype, enabled=True
+        )
+
+    def backward(self, loss: torch.Tensor) -> None:
+        self.scaler.scale(loss).backward()
+
+    def unscale_(self, optimizer: torch.optim.Optimizer) -> None:
+        self.scaler.unscale_(optimizer)
+
+    def step(self, optimizer: torch.optim.Optimizer) -> None:
+        self.scaler.step(optimizer)
+        self.scaler.update()
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return self.scaler.state_dict()
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        self.scaler.load_state_dict(dict(state))
+
+
+class AccumulatedBackpropStrategy(Generic[BatchT]):
+    """Standard backpropagation with actual-size gradient averaging."""
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        *,
+        scheduler: Any | None = None,
+        parameters=None,
+        grad_clip_norm: float | None = None,
+        precision: PrecisionPolicy | None = None,
+    ) -> None:
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.parameters = list(parameters) if parameters is not None else [
+            parameter
+            for group in optimizer.param_groups
+            for parameter in group["params"]
+        ]
+        self.grad_clip_norm = grad_clip_norm
+        self.precision = precision or PrecisionPolicy()
+        self._expected_group_size = 0
+        self._processed = 0
+
+    def begin_group(self, group_size: int) -> None:
+        if group_size < 1:
+            raise ValueError("group_size must be positive")
+        if self._processed:
+            raise RuntimeError("cannot begin a group while another group is active")
+        self._expected_group_size = int(group_size)
+        self.optimizer.zero_grad(set_to_none=True)
+
+    def process_microbatch(
+        self,
+        task: TrainingTask[BatchT],
+        batch: BatchT,
+        context: StepContext,
+    ) -> StepOutput:
+        if self._expected_group_size < 1:
+            raise RuntimeError("begin_group must be called before process_microbatch")
+        with self.precision.forward_context():
+            output = task.training_step(batch, context)
+        output.validate()
+        if not bool(torch.isfinite(output.loss.detach()).item()):
+            raise NonFiniteStepError("nonfinite microbatch loss")
+        self.precision.backward(output.loss)
+        self._processed += 1
+        return output
+
+    def commit_group(self) -> UpdateResult:
+        if self._processed != self._expected_group_size:
+            raise RuntimeError(
+                f"cannot commit {self._processed} microbatches; "
+                f"expected {self._expected_group_size}"
+            )
+        self.precision.unscale_(self.optimizer)
+        scale = 1.0 / self._processed
+        for parameter in self.parameters:
+            if parameter.grad is not None:
+                parameter.grad.mul_(scale)
+        finite = all(
+            parameter.grad is None
+            or bool(torch.isfinite(parameter.grad).all().item())
+            for parameter in self.parameters
+        )
+        if not finite:
+            return self.abort_group("nonfinite accumulated gradient")
+        if self.grad_clip_norm is not None:
+            norm = torch.nn.utils.clip_grad_norm_(self.parameters, self.grad_clip_norm)
+            if not math.isfinite(float(norm)):
+                return self.abort_group("nonfinite clipped gradient norm")
+        self.precision.step(self.optimizer)
+        if self.scheduler is not None:
+            self.scheduler.step()
+        self.optimizer.zero_grad(set_to_none=True)
+        self._reset_group()
+        return UpdateResult(committed=True, optimizer_steps=1)
+
+    def abort_group(self, reason: str) -> UpdateResult:
+        self.optimizer.zero_grad(set_to_none=True)
+        self._reset_group()
+        return UpdateResult(committed=False, optimizer_steps=0, reason=reason)
+
+    def _reset_group(self) -> None:
+        self._expected_group_size = 0
+        self._processed = 0
+
+    def state_dict(self) -> Mapping[str, Any]:
+        state: dict[str, Any] = {"optimizer": self.optimizer.state_dict()}
+        state["precision"] = dict(self.precision.state_dict())
+        if self.scheduler is not None:
+            state["scheduler"] = self.scheduler.state_dict()
+        return state
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        self.optimizer.load_state_dict(state["optimizer"])
+        self.precision.load_state_dict(state.get("precision", {}))
+        if self.scheduler is not None:
+            if "scheduler" not in state:
+                raise ValueError("checkpoint has no scheduler state")
+            self.scheduler.load_state_dict(state["scheduler"])
+        self._reset_group()

--- a/tests/test_training_contracts.py
+++ b/tests/test_training_contracts.py
@@ -22,6 +22,9 @@ from src.training.contracts import (
 
 
 class SyntheticTask:
+    def begin_phase(self, phase, epoch):
+        self.phase = phase
+
     def train_batches(self, epoch):
         return [torch.tensor([float(epoch + 1)])]
 

--- a/tests/test_training_engine.py
+++ b/tests/test_training_engine.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.training.contracts import MetricValue, StepContext, StepOutput, TrainingPhase
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.run_lifecycle import TrainingRun
+from src.training.strategies import AccumulatedBackpropStrategy, PrecisionPolicy
+
+
+class LinearTask:
+    def __init__(self, values, *, nonfinite_value=None):
+        self.model = torch.nn.Linear(1, 1, bias=False)
+        self.values = [float(value) for value in values]
+        self.nonfinite_value = nonfinite_value
+        self.phase = None
+
+    def begin_phase(self, phase, epoch):
+        self.phase = phase
+        self.model.train(phase == TrainingPhase.TRAIN)
+
+    def train_batches(self, epoch):
+        return [torch.tensor([[value]]) for value in self.values]
+
+    def validation_batches(self, epoch):
+        return [torch.tensor([[1.0]])]
+
+    def training_step(self, batch, context):
+        prediction = self.model(batch)
+        loss = prediction.square().mean()
+        if self.nonfinite_value is not None and batch.item() == self.nonfinite_value:
+            loss = loss * torch.tensor(float("nan"))
+        return StepOutput(
+            loss,
+            {"loss": MetricValue(float(loss.detach()), 1.0)},
+            {"examples": len(batch)},
+        )
+
+    def validation_step(self, batch, context):
+        loss = self.model(batch).square().mean()
+        return StepOutput(loss, {"loss": MetricValue(float(loss), 1.0)})
+
+    def state_dict(self):
+        return {"model": self.model.state_dict()}
+
+    def load_state_dict(self, state):
+        self.model.load_state_dict(state["model"])
+
+
+class ExpireAfterFirstGroup:
+    def __init__(self):
+        self.calls = 0
+
+    def expired(self):
+        self.calls += 1
+        return self.calls == 1
+
+
+class EventRecorder:
+    def __init__(self):
+        self.events = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+
+class WeightedValidationTask(LinearTask):
+    def validation_batches(self, epoch):
+        return [torch.tensor([[2.0]]), torch.tensor([[4.0]])]
+
+    def validation_step(self, batch, context):
+        weight = 100.0 if batch.item() == 2.0 else 10.0
+        value = float(batch.item())
+        return StepOutput(
+            self.model(batch).square().mean(),
+            {"score": MetricValue(value * weight, weight)},
+        )
+
+
+def _build_engine(tmp_path, run, task, *, epochs=1, timer=None):
+    optimizer = torch.optim.SGD(task.model.parameters(), lr=0.1)
+    scheduler = torch.optim.lr_scheduler.LambdaLR(
+        optimizer, lr_lambda=lambda step: 1.0
+    )
+    strategy = AccumulatedBackpropStrategy(
+        optimizer, scheduler=scheduler, parameters=task.model.parameters()
+    )
+    engine = TrainingEngine(
+        task=task,
+        strategy=strategy,
+        run=run,
+        config=EngineConfig(epochs=epochs, grad_accum_steps=2),
+        device=torch.device("cpu"),
+        wall_timer=timer,
+    )
+    return engine, optimizer, scheduler
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("epochs", 1.5),
+        ("grad_accum_steps", 2.0),
+        ("validate_every_epochs", True),
+    ],
+)
+def test_engine_config_rejects_non_integer_counts(field, value):
+    values = {
+        "epochs": 1,
+        "grad_accum_steps": 1,
+        "validate_every_epochs": 1,
+    }
+    values[field] = value
+
+    with pytest.raises(TypeError, match=f"{field} must be an integer"):
+        EngineConfig(**values)
+
+
+def test_remainder_group_uses_actual_size_and_scheduler_steps_per_update(tmp_path):
+    task = LinearTask([1.0, 2.0, 3.0])
+    task.model.weight.data.fill_(1.0)
+    run = TrainingRun.open(tmp_path, "remainder")
+    engine, optimizer, scheduler = _build_engine(tmp_path, run, task)
+
+    result = engine.fit()
+
+    reference = torch.nn.Linear(1, 1, bias=False)
+    reference.weight.data.fill_(1.0)
+    reference_optimizer = torch.optim.SGD(reference.parameters(), lr=0.1)
+    for values in ([1.0, 2.0], [3.0]):
+        reference_optimizer.zero_grad()
+        losses = [reference(torch.tensor([[value]])).square().mean() for value in values]
+        torch.stack(losses).mean().backward()
+        reference_optimizer.step()
+
+    assert result.state.optimizer_step == 2
+    assert scheduler.last_epoch == 2
+    assert optimizer.param_groups[0]["lr"] == 0.1
+    assert torch.allclose(task.model.weight, reference.weight)
+    assert (run.checkpoints / "last.pt").exists()
+    assert (run.checkpoints / "best.pt").exists()
+    run.close()
+
+
+def test_nonfinite_microbatch_aborts_the_entire_group(tmp_path):
+    task = LinearTask([1.0, 2.0, 3.0], nonfinite_value=2.0)
+    task.model.weight.data.fill_(1.0)
+    run = TrainingRun.open(tmp_path, "nonfinite")
+    engine, _, _ = _build_engine(tmp_path, run, task)
+
+    result = engine.fit()
+
+    assert result.aborted_groups == 1
+    assert result.state.optimizer_step == 1
+    assert task.model.weight.item() == torch.tensor(-0.8).item()
+    run.close()
+
+
+def test_interrupted_resume_matches_uninterrupted_parameters(tmp_path):
+    reference_task = LinearTask([1.0, 2.0, 3.0, 4.0])
+    reference_task.model.weight.data.fill_(1.0)
+    reference_run = TrainingRun.open(tmp_path, "reference")
+    reference_engine, _, _ = _build_engine(tmp_path, reference_run, reference_task)
+    reference_result = reference_engine.fit()
+    reference_weight = reference_task.model.weight.detach().clone()
+    reference_run.close()
+
+    interrupted_task = LinearTask([1.0, 2.0, 3.0, 4.0])
+    interrupted_task.model.weight.data.fill_(1.0)
+    interrupted_run = TrainingRun.open(tmp_path, "resumable")
+    interrupted_engine, _, _ = _build_engine(
+        tmp_path, interrupted_run, interrupted_task, timer=ExpireAfterFirstGroup()
+    )
+    interrupted_result = interrupted_engine.fit()
+    checkpoint = interrupted_run.checkpoints / "last.pt"
+    interrupted_run.close()
+
+    assert interrupted_result.status == "interrupted"
+    assert interrupted_result.state.microbatch == 2
+
+    resumed_run = TrainingRun.open(
+        tmp_path, "resumable", resume=checkpoint, target_epochs=1
+    )
+    resumed_task = LinearTask([1.0, 2.0, 3.0, 4.0])
+    resumed_engine, _, resumed_scheduler = _build_engine(
+        tmp_path, resumed_run, resumed_task
+    )
+    resumed_result = resumed_engine.fit()
+
+    assert reference_result.state.optimizer_step == resumed_result.state.optimizer_step == 2
+    assert resumed_scheduler.last_epoch == 2
+    assert torch.allclose(resumed_task.model.weight, reference_weight)
+    resumed_run.close()
+
+
+def test_precision_policy_applies_autocast_without_task_changes():
+    task = LinearTask([1.0])
+    optimizer = torch.optim.SGD(task.model.parameters(), lr=0.1)
+    strategy = AccumulatedBackpropStrategy(
+        optimizer,
+        precision=PrecisionPolicy(
+            device_type="cpu", dtype=torch.bfloat16, enabled=True
+        ),
+    )
+    context = StepContext(
+        TrainingPhase.TRAIN, 0, 0, 0, torch.device("cpu")
+    )
+
+    strategy.begin_group(1)
+    output = strategy.process_microbatch(task, torch.tensor([[1.0]]), context)
+    result = strategy.commit_group()
+
+    assert output.loss.dtype == torch.bfloat16
+    assert result.committed
+
+
+def test_validation_metrics_are_weighted_and_emitted_to_callbacks(tmp_path):
+    task = WeightedValidationTask([1.0])
+    run = TrainingRun.open(tmp_path, "weighted-metrics")
+    optimizer = torch.optim.SGD(task.model.parameters(), lr=0.0)
+    recorder = EventRecorder()
+    engine = TrainingEngine(
+        task=task,
+        strategy=AccumulatedBackpropStrategy(optimizer),
+        run=run,
+        config=EngineConfig(epochs=1, monitor="score"),
+        device=torch.device("cpu"),
+        callbacks=[recorder],
+    )
+
+    result = engine.fit()
+
+    expected = (2.0 * 100.0 + 4.0 * 10.0) / 110.0
+    validation = next(
+        event for event in recorder.events if event.name == "validation_completed"
+    )
+    assert validation.metrics["score"].total == expected
+    assert result.best_metric == expected
+    run.close()


### PR DESCRIPTION
## Summary
- add a model-neutral TrainingEngine over the shared TrainingRun lifecycle
- add actual-size accumulated backprop with optimizer/scheduler ownership, clipping, and nonfinite-group aborts
- add shared autocast and optional gradient-scaling precision policy
- add weighted metric aggregation, callbacks, validation selection, periodic/epoch/best checkpoints, wall-time interruption, and namespaced resume
- require sized batch streams so remainder scaling and resume positions are exact
- complete Phase 1 using synthetic tasks only

## Scope
No biological trainer uses this engine yet. CodonLM, ProteinLM, ProteinCritic, ProteinEBM, and NoProp behavior is unchanged. Trainer migrations remain gated on individual parity tests.

## Verification
- focused engine/lifecycle suite: 32 passed
- pytest -q: 381 passed, 1 skipped, 1 xpassed
- ruff check and git diff --check