### PR TITLE
Migrate ProteinCritic to the shared training engine

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -48,6 +48,9 @@ configuration, task, strategy, and engine assembly.
 - [ ] Verify frozen-backbone state for the EBM and classifier migrations.
 - [x] Verify ProteinCritic class/regression metric aggregation, validation
   selection, legacy checkpoint compatibility, and optimizer-boundary resume parity.
+- [ ] Add validated per-task loss weights in a separate scientific-feature PR,
+  preserving the present objective as the default and selecting weights using
+  training/validation diagnostics rather than the test split.
 
 Exit gate: protein trainers share orchestration without changing their architectures,
 decoy distributions, losses, or scientific metrics.

--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -40,13 +40,14 @@ configuration, task, strategy, and engine assembly.
 
 - [x] Add an end-of-phase metric hook so non-decomposable supervised metrics such
   as F1 are computed over the complete prediction set rather than averaged per batch.
-- [ ] Implement the bidirectional multitask `ProteinCriticTask`.
+- [x] Implement the bidirectional multitask `ProteinCriticTask`.
 - [ ] Implement the protein classifier task or consolidate it with a generic
   supervised-sequence task when the contracts genuinely match.
 - [ ] Implement `ProteinEBMTask`, keeping positive/negative construction and energy
   metrics task-owned while using the shared optimization strategy.
-- [ ] Verify class/regression metric aggregation, frozen-backbone state, validation
-  selection, and resume parity.
+- [ ] Verify frozen-backbone state for the EBM and classifier migrations.
+- [x] Verify ProteinCritic class/regression metric aggregation, validation
+  selection, legacy checkpoint compatibility, and optimizer-boundary resume parity.
 
 Exit gate: protein trainers share orchestration without changing their architectures,
 decoy distributions, losses, or scientific metrics.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1116,6 +1116,13 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     end-of-phase metric hook required by supervised protein migrations. Metrics such
     as F1 can now be computed once from the complete validation prediction set rather
     than incorrectly averaging independent batch F1 values.
+*   **Model-Agnostic ProteinCritic Migration (2026-08-09):** Moved the corrected
+    bidirectional multitask critic onto the shared engine while preserving dynamic
+    length buckets, mixed classification/regression/multilabel loss semantics,
+    class weighting, wall-time interruption, and evaluator-compatible checkpoint
+    fields. The task now reports whole-phase accuracy and regression MAE, the engine
+    exposes train-phase summaries to callbacks, and improved checkpoints retain both
+    stable and numbered names. Legacy critic checkpoints remain resumable.
 
 ---
 *End of Log*

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1122,7 +1122,10 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     class weighting, wall-time interruption, and evaluator-compatible checkpoint
     fields. The task now reports whole-phase accuracy and regression MAE, the engine
     exposes train-phase summaries to callbacks, and improved checkpoints retain both
-    stable and numbered names. Legacy critic checkpoints remain resumable.
+    stable and numbered names. Legacy critic checkpoints remain resumable. The
+    hand-written motif-attention regularizer was retired: existing zero-valued
+    configuration remains valid, while nonzero legacy use now fails explicitly
+    instead of imposing four unvalidated motifs on corrected training.
 
 ---
 *End of Log*

--- a/src/protein_lm/critic_task.py
+++ b/src/protein_lm/critic_task.py
@@ -1,0 +1,284 @@
+"""Shared-engine adapter for the bidirectional multitask protein critic."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from src.training.contracts import (
+    EngineState,
+    MetricValue,
+    StepContext,
+    StepOutput,
+    TrainingCheckpoint,
+    TrainingPhase,
+)
+
+
+def task_losses(
+    logits_dict: dict,
+    batch: dict,
+    classification_tasks: tuple[str, ...],
+    regression_tasks: tuple[str, ...],
+    criterion: nn.Module | dict[str, nn.Module],
+) -> dict[str, torch.Tensor]:
+    """Calculate available single-label and regression objectives."""
+    losses = {}
+    for task in classification_tasks:
+        targets = batch[task]
+        valid = targets != -1
+        if bool(valid.any()):
+            task_criterion = criterion[task] if isinstance(criterion, dict) else criterion
+            losses[task] = task_criterion(logits_dict[task][valid], targets[valid])
+    for task in regression_tasks:
+        targets = batch[task].float()
+        valid = torch.isfinite(targets)
+        if bool(valid.any()):
+            predictions = logits_dict[task].squeeze(-1)
+            losses[task] = nn.functional.smooth_l1_loss(
+                predictions[valid], targets[valid]
+            )
+    return losses
+
+
+class ProteinCriticTask:
+    """Protein classification/regression objectives behind a generic task contract."""
+
+    MOTIFS = ("GDSGG", "HIGH", "KMSKS", "DXD")
+
+    def __init__(
+        self,
+        *,
+        model: nn.Module,
+        train_loader,
+        validation_loader,
+        device: torch.device,
+        classification_tasks: Sequence[str],
+        regression_tasks: Sequence[str],
+        multi_label_tasks: Sequence[str],
+        train_classification_criteria: Mapping[str, nn.Module],
+        validation_classification_criterion: nn.Module,
+        multi_label_criteria: Mapping[str, nn.Module],
+        saliency_regularizer_weight: float = 0.0,
+    ) -> None:
+        self.model = model
+        self.train_loader = train_loader
+        self.validation_loader = validation_loader
+        self.device = device
+        self.classification_tasks = tuple(classification_tasks)
+        self.regression_tasks = tuple(regression_tasks)
+        self.multi_label_tasks = tuple(multi_label_tasks)
+        self.train_classification_criteria = dict(train_classification_criteria)
+        self.validation_classification_criterion = validation_classification_criterion
+        self.multi_label_criteria = dict(multi_label_criteria)
+        self.saliency_regularizer_weight = float(saliency_regularizer_weight)
+        self._phase_totals: dict[str, float] = {}
+        self._phase_weights: dict[str, float] = {}
+
+    def begin_phase(self, phase: TrainingPhase, epoch: int) -> None:
+        self._phase_totals = {}
+        self._phase_weights = {}
+        if phase == TrainingPhase.TRAIN:
+            sampler = getattr(self.train_loader, "batch_sampler", None)
+            if hasattr(sampler, "set_epoch"):
+                sampler.set_epoch(epoch)
+            self.model.train()
+        else:
+            self.model.eval()
+
+    def end_phase(self, phase: TrainingPhase, epoch: int):
+        metrics = {
+            name: MetricValue(total / self._phase_weights[name])
+            for name, total in self._phase_totals.items()
+            if self._phase_weights.get(name, 0.0) > 0
+        }
+        if self.device.type == "mps":
+            torch.mps.empty_cache()
+        return metrics
+
+    def train_batches(self, epoch: int):
+        return self.train_loader
+
+    def validation_batches(self, epoch: int):
+        return self.validation_loader
+
+    def training_step(self, batch, context: StepContext) -> StepOutput:
+        return self._step(batch, training=True)
+
+    def validation_step(self, batch, context: StepContext) -> StepOutput:
+        return self._step(batch, training=False)
+
+    def _step(self, batch, *, training: bool) -> StepOutput:
+        input_ids = batch["input_ids"].to(self.device)
+        attention_mask = batch.get("attention_mask")
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(self.device)
+        logits = self.model(input_ids, attention_mask=attention_mask)
+        criteria = (
+            self.train_classification_criteria
+            if training
+            else self.validation_classification_criterion
+        )
+        supervised = task_losses(
+            logits,
+            {
+                task: batch[task].to(self.device)
+                for task in (*self.classification_tasks, *self.regression_tasks)
+            },
+            self.classification_tasks,
+            self.regression_tasks,
+            criteria,
+        )
+        components: list[torch.Tensor] = []
+        metrics: dict[str, MetricValue] = {}
+        if supervised:
+            components.append(torch.stack(list(supervised.values())).mean())
+            for name, value in supervised.items():
+                metrics[f"{name}_loss"] = MetricValue(float(value.detach()))
+        for task in self.classification_tasks:
+            targets = batch[task].to(self.device)
+            valid = targets != -1
+            if bool(valid.any()):
+                correct = int((logits[task][valid].argmax(dim=-1) == targets[valid]).sum().item())
+                self._record(f"{task}_accuracy", correct, int(valid.sum().item()))
+        for task in self.regression_tasks:
+            targets = batch[task].to(self.device).float()
+            valid = torch.isfinite(targets)
+            if bool(valid.any()):
+                error = (logits[task].squeeze(-1)[valid] - targets[valid]).abs().sum()
+                self._record(f"{task}_mae", float(error.detach()), int(valid.sum().item()))
+
+        for task in self.multi_label_tasks:
+            targets = batch[task].to(self.device)
+            if targets.numel() and bool((targets >= 0).any()):
+                value = self.multi_label_criteria[task](logits[task], targets)
+                components.append(value)
+                metrics[f"{task}_loss"] = MetricValue(float(value.detach()))
+                valid = targets >= 0
+                predictions = logits[task] >= 0
+                correct = (predictions[valid] == targets[valid].bool()).sum()
+                self._record(
+                    f"{task}_accuracy", float(correct.detach()), int(valid.sum().item())
+                )
+
+        if components:
+            loss = torch.stack(components).sum()
+            if training and self.saliency_regularizer_weight > 0:
+                loss = loss + self._saliency_loss(logits, batch)
+        else:
+            # Keep accumulation boundaries deterministic even for an unlabeled batch.
+            loss = sum((value.sum() * 0.0 for value in logits.values()))
+
+        loss_value = float(loss.detach())
+        loss_weight = 1.0 if training or components else 0.0
+        metrics["loss"] = MetricValue(loss_value, loss_weight)
+        sequences = int(input_ids.shape[0])
+        residues = int(attention_mask.sum().item()) if attention_mask is not None else int(input_ids.numel())
+        for name, value in metrics.items():
+            self._phase_totals[name] = self._phase_totals.get(name, 0.0) + value.total
+            self._phase_weights[name] = self._phase_weights.get(name, 0.0) + value.weight
+        return StepOutput(
+            loss=loss,
+            metrics=metrics,
+            committed_units={"sequences": sequences, "residues": residues},
+        )
+
+    def _record(self, name: str, total: float, weight: float) -> None:
+        self._phase_totals[name] = self._phase_totals.get(name, 0.0) + float(total)
+        self._phase_weights[name] = self._phase_weights.get(name, 0.0) + float(weight)
+
+    def _saliency_loss(self, logits: Mapping[str, torch.Tensor], batch) -> torch.Tensor:
+        attention = logits.get("attention_weights")
+        if attention is None:
+            return next(iter(logits.values())).sum() * 0.0
+        values = []
+        for index, sequence in enumerate(batch["sequence"]):
+            active = []
+            for motif in self.MOTIFS:
+                start = sequence.find(motif)
+                if start >= 0:
+                    active.extend(
+                        position
+                        for position in range(start + 1, start + 1 + len(motif))
+                        if position < attention.shape[1]
+                    )
+            if active:
+                values.append(-torch.log(attention[index, active].sum() + 1e-8))
+        if not values:
+            return attention.sum() * 0.0
+        return self.saliency_regularizer_weight * torch.stack(values).mean()
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return {"model": self.model.state_dict()}
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        self.model.load_state_dict(state["model"])
+
+
+def decode_protein_critic_checkpoint(payload: Mapping[str, Any]) -> TrainingCheckpoint:
+    """Read current engine checkpoints or the legacy critic schema."""
+    if "training_contract_version" in payload:
+        return TrainingCheckpoint.from_payload(payload)
+    required = {"model_state_dict", "optimizer_state_dict", "epoch"}
+    missing = required.difference(payload)
+    if missing:
+        raise ValueError(f"legacy protein critic checkpoint is missing: {sorted(missing)}")
+    epoch = int(payload["epoch"])
+    complete = bool(payload.get("epoch_complete", True))
+    completed = epoch + 1 if complete else epoch
+    return TrainingCheckpoint(
+        engine=EngineState(
+            completed_epochs=completed,
+            current_epoch=completed if complete else epoch,
+            microbatch=0 if complete else int(payload.get("microbatch_idx", 0)),
+            optimizer_step=int(payload.get("optimizer_step", 0)),
+        ),
+        task={"model": payload["model_state_dict"]},
+        strategy={"optimizer": payload["optimizer_state_dict"]},
+        rng=payload.get("rng_state", {}),
+        metadata={
+            "best_metric": payload.get("best_val_loss"),
+            "legacy": True,
+        },
+    )
+
+
+def adapt_protein_critic_checkpoint(
+    payload: dict[str, Any],
+    *,
+    config: Mapping[str, Any],
+    dataset_provenance: Mapping[str, Any],
+    task_vocabs: Mapping[str, Any],
+    model_spec: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add evaluator-compatible legacy aliases to an engine checkpoint."""
+    engine = payload["engine"]
+    reason = payload["metadata"]["reason"]
+    complete = reason in {"epoch", "epoch_archive", "best", "best_archive"}
+    best_metric = payload["metadata"].get("best_metric")
+    payload.update(
+        {
+            "epoch": int(engine["completed_epochs"]) - 1 if complete else int(engine["current_epoch"]),
+            "epoch_complete": complete,
+            "microbatch_idx": 0 if complete else int(engine["microbatch"]),
+            "optimizer_step": int(engine["optimizer_step"]),
+            "model_state_dict": payload["task"]["model"],
+            "optimizer_state_dict": payload["strategy"]["optimizer"],
+            "best_val_loss": float("inf") if best_metric is None else best_metric,
+            "checkpoint_reason": "best_epoch" if reason in {"best", "best_archive"} else reason,
+            "cfg": dict(config),
+            "dataset_provenance": dict(dataset_provenance),
+            "task_vocabs": dict(task_vocabs),
+            "model_spec": dict(model_spec),
+            "rng_state": payload["rng"],
+        }
+    )
+    return payload
+
+
+def make_protein_critic_checkpoint_adapter(**kwargs):
+    return partial(adapt_protein_critic_checkpoint, **kwargs)

--- a/src/protein_lm/critic_task.py
+++ b/src/protein_lm/critic_task.py
@@ -48,8 +48,6 @@ def task_losses(
 class ProteinCriticTask:
     """Protein classification/regression objectives behind a generic task contract."""
 
-    MOTIFS = ("GDSGG", "HIGH", "KMSKS", "DXD")
-
     def __init__(
         self,
         *,
@@ -63,7 +61,6 @@ class ProteinCriticTask:
         train_classification_criteria: Mapping[str, nn.Module],
         validation_classification_criterion: nn.Module,
         multi_label_criteria: Mapping[str, nn.Module],
-        saliency_regularizer_weight: float = 0.0,
     ) -> None:
         self.model = model
         self.train_loader = train_loader
@@ -75,7 +72,6 @@ class ProteinCriticTask:
         self.train_classification_criteria = dict(train_classification_criteria)
         self.validation_classification_criterion = validation_classification_criterion
         self.multi_label_criteria = dict(multi_label_criteria)
-        self.saliency_regularizer_weight = float(saliency_regularizer_weight)
         self._phase_totals: dict[str, float] = {}
         self._phase_weights: dict[str, float] = {}
 
@@ -167,8 +163,6 @@ class ProteinCriticTask:
 
         if components:
             loss = torch.stack(components).sum()
-            if training and self.saliency_regularizer_weight > 0:
-                loss = loss + self._saliency_loss(logits, batch)
         else:
             # Keep accumulation boundaries deterministic even for an unlabeled batch.
             loss = sum((value.sum() * 0.0 for value in logits.values()))
@@ -190,27 +184,6 @@ class ProteinCriticTask:
     def _record(self, name: str, total: float, weight: float) -> None:
         self._phase_totals[name] = self._phase_totals.get(name, 0.0) + float(total)
         self._phase_weights[name] = self._phase_weights.get(name, 0.0) + float(weight)
-
-    def _saliency_loss(self, logits: Mapping[str, torch.Tensor], batch) -> torch.Tensor:
-        attention = logits.get("attention_weights")
-        if attention is None:
-            return next(iter(logits.values())).sum() * 0.0
-        values = []
-        for index, sequence in enumerate(batch["sequence"]):
-            active = []
-            for motif in self.MOTIFS:
-                start = sequence.find(motif)
-                if start >= 0:
-                    active.extend(
-                        position
-                        for position in range(start + 1, start + 1 + len(motif))
-                        if position < attention.shape[1]
-                    )
-            if active:
-                values.append(-torch.log(attention[index, active].sum() + 1e-8))
-        if not values:
-            return attention.sum() * 0.0
-        return self.saliency_regularizer_weight * torch.stack(values).mean()
 
     def state_dict(self) -> Mapping[str, Any]:
         return {"model": self.model.state_dict()}

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -217,6 +217,18 @@ def mps_memory_summary():
     return " | " + " | ".join(parts) if parts else ""
 
 
+def validate_retired_saliency_regularizer(cfg: dict) -> None:
+    """Accept legacy disabled settings but reject the removed motif objective."""
+    value = cfg.get("saliency_regularizer_weight", 0.0)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("saliency_regularizer_weight must be numeric")
+    if float(value) != 0.0:
+        raise ValueError(
+            "saliency_regularizer_weight is no longer supported; set it to 0. "
+            "Known and learned motifs must be evaluated outside the training loss."
+        )
+
+
 def train_multi_task(
     config_path,
     resume_path=None,
@@ -228,6 +240,7 @@ def train_multi_task(
         cfg = yaml.safe_load(f)
     if max_time_minutes is not None:
         cfg["max_time_minutes"] = float(max_time_minutes)
+    validate_retired_saliency_regularizer(cfg)
 
     device_name = cfg.get(
         "device", "mps" if torch.backends.mps.is_available() else "cpu"
@@ -552,7 +565,6 @@ def train_multi_task(
         train_classification_criteria=train_classification_criteria,
         validation_classification_criterion=validation_classification_criterion,
         multi_label_criteria=multi_label_criteria,
-        saliency_regularizer_weight=cfg.get("saliency_regularizer_weight", 0.0),
     )
     strategy = AccumulatedBackpropStrategy(optimizer, parameters=model.parameters())
     try:

--- a/src/protein_lm/train_multi_task.py
+++ b/src/protein_lm/train_multi_task.py
@@ -7,6 +7,8 @@ import argparse
 import yaml
 import hashlib
 import random
+import csv
+import sys
 from pathlib import Path
 from src.protein_lm.tokenizer import ProteinTokenizer
 from src.protein_lm.models_multi import MultiTaskProteinClassifier
@@ -16,16 +18,18 @@ from src.protein_lm.dataset import (
     LengthBucketBatchSampler,
     collate_protein_batch,
 )
-from src.training.runtime import (
-    PeriodicCheckpointPolicy,
-    WallTimer,
-    save_checkpoint_atomic,
-)
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.optimizers import build_optimizer
+from src.training.runtime import PeriodicCheckpointPolicy, WallTimer
 from src.training.run_lifecycle import (
     TrainingRun,
-    capture_rng_state,
     configuration_fingerprint,
-    restore_rng_state,
+)
+from src.training.strategies import AccumulatedBackpropStrategy
+from src.protein_lm.critic_task import (
+    ProteinCriticTask,
+    decode_protein_critic_checkpoint,
+    make_protein_critic_checkpoint_adapter,
 )
 
 
@@ -367,7 +371,7 @@ def train_multi_task(
         flush=True,
     )
 
-    optimizer = torch.optim.AdamW(model.parameters(), lr=float(cfg.get("lr", 1e-4)))
+    optimizer = build_optimizer(model.parameters(), cfg)
 
     # Class weights are derived only from the training split. Validation remains
     # unweighted so its loss describes the frozen held-out distribution.
@@ -439,32 +443,8 @@ def train_multi_task(
     run_id = training_run.run_dir.name
     cfg["run_id"] = run_id
 
-    best_val_loss = float("inf")
-    start_epoch = 0
-    optimizer_step = 0
-    resume_microbatch_idx = 0
-    if resume_path and Path(resume_path).exists():
-        print(f"[*] Resuming from checkpoint: {resume_path}", flush=True)
-        checkpoint = torch.load(resume_path, map_location=device)
-        model.load_state_dict(checkpoint["model_state_dict"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        epoch_complete = bool(checkpoint.get("epoch_complete", True))
-        start_epoch = checkpoint["epoch"] + (1 if epoch_complete else 0)
-        resume_microbatch_idx = (
-            0 if epoch_complete else int(checkpoint.get("microbatch_idx", 0))
-        )
-        best_val_loss = checkpoint.get("best_val_loss", float("inf"))
-        optimizer_step = int(checkpoint.get("optimizer_step", 0))
-        restore_rng_state(checkpoint.get("rng_state"))
-        print(
-            f"[*] Resumed checkpoint. Next epoch: {start_epoch + 1}, "
-            f"microbatch: {resume_microbatch_idx} "
-            f"with best val loss: {best_val_loss:.4f}",
-            flush=True,
-        )
-
     print("[*] Starting Multi-Task Training...", flush=True)
-    grad_accum_steps = cfg.get("grad_accum_steps", 1)
+    grad_accum_steps = int(cfg.get("grad_accum_steps", 1))
     print(f"[*] Gradient accumulation steps: {grad_accum_steps}", flush=True)
     log_every_steps = cfg.get("log_every_steps", 100)
     checkpoint_every_steps = cfg.get("checkpoint_every_steps", 0)
@@ -478,318 +458,135 @@ def train_multi_task(
     if max_time_minutes:
         print(f"[*] Wall-time limit configured: {max_time_minutes} minutes", flush=True)
 
-    out_dir = training_run.checkpoints
-    scores_dir = training_run.scores
     run_logger = training_run.logger()
     run_logger.__enter__()
-
-    log_csv = scores_dir / "curves.csv"
-    import csv
-
+    log_csv = training_run.scores / "curves.csv"
     if not log_csv.exists():
         with open(log_csv, "w", newline="") as f:
             csv.writer(f).writerow(["epoch", "train_loss", "val_loss"])
+    model_spec = {
+        "vocab_size": model_cfg.vocab_size,
+        "block_size": model_cfg.block_size,
+        "n_layer": model_cfg.n_layer,
+        "n_head": model_cfg.n_head,
+        "n_embd": model_cfg.n_embd,
+        "dropout": model_cfg.dropout,
+        "pooling": model_cfg.pooling,
+        "bidirectional": model_cfg.bidirectional,
+        "task_dims": task_dims,
+        "regression_tasks": list(regression_tasks),
+    }
 
-    time_limit_reached = False
-    start_time = time.perf_counter()
-    wall_timer = WallTimer(max_time_minutes)
-    checkpoint_policy = PeriodicCheckpointPolicy(
-        every_steps=int(cfg.get("checkpoint_every_steps", 0) or 0),
-        every_minutes=float(cfg.get("checkpoint_every_minutes", 0.0) or 0.0),
+    class CriticLogger:
+        def __init__(self):
+            self.started = time.perf_counter()
+            self.interval_started = self.started
+            self.units = {"sequences": 0, "residues": 0}
+            self.train_metrics = {}
+            self.epoch_started = self.started
+            self.current_epoch = None
+
+        def on_event(self, event):
+            if event.name == "group_committed":
+                if event.context.epoch != self.current_epoch:
+                    self.current_epoch = event.context.epoch
+                    self.epoch_started = time.perf_counter()
+                for name, value in event.metadata.get("committed_units", {}).items():
+                    self.units[name] = self.units.get(name, 0) + value
+                microbatch = event.context.microbatch + 1
+                crossed_log_boundary = (
+                    log_every_steps
+                    and microbatch % log_every_steps < event.context.group_size
+                )
+                if crossed_log_boundary:
+                    elapsed = max(time.perf_counter() - self.interval_started, 1e-9)
+                    loss = event.metrics.get("loss")
+                    print(
+                        f"[progress] epoch={event.context.epoch + 1}/{epochs} "
+                        f"step={event.context.microbatch + 1}/{len(train_loader)} "
+                        f"optimizer_step={event.context.optimizer_step + 1} "
+                        f"recent_loss={loss.total if loss else float('nan'):.4f} "
+                        f"lr={optimizer.param_groups[0]['lr']:.2e} "
+                        f"seq_per_sec={self.units['sequences'] / elapsed:.2f} "
+                        f"residues_per_sec={self.units['residues'] / elapsed:.0f}"
+                        f"{mps_memory_summary() if device.type == 'mps' else ''}",
+                        flush=True,
+                    )
+                    self.interval_started = time.perf_counter()
+                    self.units = {"sequences": 0, "residues": 0}
+            elif event.name == "training_completed":
+                self.train_metrics = dict(event.metrics)
+            elif event.name == "epoch_completed":
+                train_loss = self.train_metrics.get("loss")
+                val_loss = event.metrics.get("loss")
+                epoch = int(event.metadata["epoch"])
+                with open(log_csv, "a", newline="") as handle:
+                    csv.writer(handle).writerow(
+                        [epoch, f"{train_loss.total:.4f}", f"{val_loss.total:.4f}"]
+                    )
+                print(
+                    f"Epoch {epoch}/{epochs} | Train Loss: {train_loss.total:.4f} | "
+                    f"Val Loss: {val_loss.total:.4f}",
+                    flush=True,
+                )
+                print(
+                    f"[timing] epoch={epoch} "
+                    f"wall_sec={time.perf_counter() - self.epoch_started:.2f}",
+                    flush=True,
+                )
+            elif event.name == "checkpoint_saved":
+                print(
+                    f"[checkpoint] saved {event.metadata['filename']} "
+                    f"reason={event.metadata['reason']}",
+                    flush=True,
+                )
+
+    task = ProteinCriticTask(
+        model=model,
+        train_loader=train_loader,
+        validation_loader=val_loader,
+        device=device,
+        classification_tasks=classification_tasks,
+        regression_tasks=regression_tasks,
+        multi_label_tasks=multi_label_tasks,
+        train_classification_criteria=train_classification_criteria,
+        validation_classification_criterion=validation_classification_criterion,
+        multi_label_criteria=multi_label_criteria,
+        saliency_regularizer_weight=cfg.get("saliency_regularizer_weight", 0.0),
     )
-    current_microbatch_idx = 0
-
-    def checkpoint_payload(epoch_idx: int, *, epoch_complete: bool = False) -> dict:
-        return {
-            "epoch": epoch_idx,
-            "model_state_dict": model.state_dict(),
-            "optimizer_state_dict": optimizer.state_dict(),
-            "best_val_loss": best_val_loss,
-            "optimizer_step": optimizer_step,
-            "microbatch_idx": current_microbatch_idx,
-            "epoch_complete": epoch_complete,
-            "run_progress": {
-                "completed_epochs": epoch_idx + 1 if epoch_complete else epoch_idx,
-                "current_epoch": epoch_idx + 1,
-                "microbatch": 0 if epoch_complete else current_microbatch_idx,
-                "optimizer_step": optimizer_step,
-            },
-            "rng_state": capture_rng_state(),
-            "run_fingerprint": run_fingerprint,
-            "cfg": cfg,
-            "dataset_provenance": dataset_provenance,
-            "task_vocabs": vocabs,
-            "model_spec": {
-                "vocab_size": model_cfg.vocab_size,
-                "block_size": model_cfg.block_size,
-                "n_layer": model_cfg.n_layer,
-                "n_head": model_cfg.n_head,
-                "n_embd": model_cfg.n_embd,
-                "dropout": model_cfg.dropout,
-                "pooling": model_cfg.pooling,
-                "bidirectional": model_cfg.bidirectional,
-                "task_dims": task_dims,
-                "regression_tasks": list(regression_tasks),
-            },
-        }
-
-    def save_last(epoch_idx: int, reason: str) -> None:
-        epoch_complete = reason == "epoch"
-        payload = checkpoint_payload(epoch_idx, epoch_complete=epoch_complete)
-        payload["checkpoint_reason"] = reason
-        payload["epoch_complete"] = epoch_complete
-        if payload["epoch_complete"]:
-            payload["microbatch_idx"] = 0
-        save_checkpoint_atomic(payload, out_dir / "last_critic.pt")
-        checkpoint_policy.mark_saved(optimizer_step)
-        print(
-            f"[checkpoint] saved {out_dir / 'last_critic.pt'} reason={reason} step={optimizer_step}"
+    strategy = AccumulatedBackpropStrategy(optimizer, parameters=model.parameters())
+    try:
+        engine = TrainingEngine(
+            task=task,
+            strategy=strategy,
+            run=training_run,
+            config=EngineConfig(
+                epochs=epochs,
+                grad_accum_steps=grad_accum_steps,
+                last_checkpoint_name="last_critic.pt",
+                best_checkpoint_name="best_critic.pt",
+                best_checkpoint_pattern="best_critic_epoch_{epoch:03d}.pt",
+            ),
+            device=device,
+            callbacks=[CriticLogger()],
+            wall_timer=WallTimer(max_time_minutes),
+            checkpoint_policy=PeriodicCheckpointPolicy(
+                every_steps=int(cfg.get("checkpoint_every_steps", 0) or 0),
+                every_minutes=float(cfg.get("checkpoint_every_minutes", 0.0) or 0.0),
+            ),
+            run_fingerprint=run_fingerprint,
+            checkpoint_decoder=decode_protein_critic_checkpoint,
+            checkpoint_payload_adapter=make_protein_critic_checkpoint_adapter(
+                config=cfg,
+                dataset_provenance=dataset_provenance,
+                task_vocabs=vocabs,
+                model_spec=model_spec,
+            ),
         )
-
-    for epoch in range(start_epoch, epochs):
-        if time_limit_reached:
-            break
-        epoch_started = time.perf_counter()
-        if dynamic_padding:
-            train_loader.batch_sampler.set_epoch(epoch)
-        model.train()
-        train_loss = 0.0
-        recent_loss = 0.0
-        recent_steps = 0
-        recent_sequences = 0
-        recent_residues = 0
-        recent_task_sums = {}
-        recent_task_counts = {}
-        recent_started = time.perf_counter()
-        optimizer.zero_grad()
-
-        for step, batch in enumerate(train_loader):
-            if epoch == start_epoch and step < resume_microbatch_idx:
-                continue
-            current_microbatch_idx = step + 1
-            input_ids = batch["input_ids"].to(device)
-            attention_mask = batch.get("attention_mask")
-            if attention_mask is not None:
-                attention_mask = attention_mask.to(device)
-
-            logits_dict = model(input_ids, attention_mask=attention_mask)
-
-            loss = 0
-            tasks_added = 0
-
-            # Legacy motif supervision is opt-in and disabled for corrected critics.
-            saliency_regularizer_weight = float(
-                cfg.get("saliency_regularizer_weight", 0.0)
-            )
-            if saliency_regularizer_weight > 0.0 and "attention_weights" in logits_dict:
-                attn_weights = logits_dict["attention_weights"]  # (B, T)
-                saliency_loss = 0.0
-                saliency_count = 0
-                MOTIFS = ["GDSGG", "HIGH", "KMSKS", "DXD"]
-                for i, seq in enumerate(batch["sequence"]):
-                    active_indices = []
-                    for motif in MOTIFS:
-                        start_idx = seq.find(motif)
-                        if start_idx != -1:
-                            for offset in range(len(motif)):
-                                idx = start_idx + 1 + offset
-                                if idx < attn_weights.shape[1]:
-                                    active_indices.append(idx)
-                    if active_indices:
-                        active_mass = attn_weights[i, active_indices].sum()
-                        saliency_loss += -torch.log(active_mass + 1e-8)
-                        saliency_count += 1
-                if saliency_count > 0:
-                    loss += saliency_regularizer_weight * (
-                        saliency_loss / saliency_count
-                    )
-            supervised_losses = task_losses(
-                logits_dict,
-                {
-                    task: batch[task].to(device)
-                    for task in (*classification_tasks, *regression_tasks)
-                },
-                classification_tasks,
-                regression_tasks,
-                train_classification_criteria,
-            )
-            if supervised_losses:
-                loss += torch.stack(list(supervised_losses.values())).mean()
-                tasks_added += 1
-                for task, task_loss in supervised_losses.items():
-                    recent_task_sums[task] = (
-                        recent_task_sums.get(task, torch.zeros((), device=device))
-                        + task_loss.detach()
-                    )
-                    recent_task_counts[task] = recent_task_counts.get(task, 0) + 1
-            for task in multi_label_tasks:
-                targets = batch[task].to(device)
-                if targets.numel() and (targets >= 0).any():
-                    loss += multi_label_criteria[task](logits_dict[task], targets)
-                    tasks_added += 1
-
-            if tasks_added > 0:
-                group_size = accumulation_group_size(
-                    step, len(train_loader), grad_accum_steps
-                )
-                loss = loss / group_size
-                loss.backward()
-                train_loss += loss.item() * group_size
-                recent_loss += loss.item() * group_size
-                recent_steps += 1
-                recent_sequences += input_ids.shape[0]
-                recent_residues += int(attention_mask.sum().item())
-
-            if (step + 1) % grad_accum_steps == 0 or (step + 1) == len(train_loader):
-                optimizer.step()
-                optimizer.zero_grad()
-                optimizer_step += 1
-
-                if checkpoint_policy.should_save(optimizer_step):
-                    save_last(epoch, reason="periodic")
-
-            if log_every_steps and (step + 1) % log_every_steps == 0:
-                elapsed = time.perf_counter() - start_time
-                interval_elapsed = time.perf_counter() - recent_started
-                avg_recent_loss = recent_loss / max(recent_steps, 1)
-                task_text = " ".join(
-                    f"{task}_loss={float(total.cpu()) / recent_task_counts[task]:.4f}"
-                    for task, total in sorted(recent_task_sums.items())
-                )
-                task_suffix = f" {task_text}" if task_text else ""
-                memory_suffix = mps_memory_summary() if device.type == "mps" else ""
-                print(
-                    f"[progress] epoch={epoch + 1}/{epochs} "
-                    f"step={step + 1}/{len(train_loader)} "
-                    f"elapsed_min={elapsed / 60:.1f} "
-                    f"recent_loss={avg_recent_loss:.4f} "
-                    f"optimizer_step={optimizer_step} "
-                    f"lr={optimizer.param_groups[0]['lr']:.2e} "
-                    f"seq_per_sec={recent_sequences / max(interval_elapsed, 1e-9):.2f} "
-                    f"residues_per_sec={recent_residues / max(interval_elapsed, 1e-9):.0f} "
-                    f"batch_seq_len={input_ids.shape[1]}"
-                    f"{task_suffix}{memory_suffix}",
-                    flush=True,
-                )
-                recent_loss = 0.0
-                recent_steps = 0
-                recent_sequences = 0
-                recent_residues = 0
-                recent_task_sums = {}
-                recent_task_counts = {}
-                recent_started = time.perf_counter()
-
-            # Check wall-time limit at the end of every step
-            if wall_timer.expired():
-                print(
-                    f"\n[info] Wall-time limit of {max_time_minutes} minutes reached mid-epoch.",
-                    flush=True,
-                )
-                optimizer_boundary = (step + 1) % grad_accum_steps == 0 or (
-                    step + 1
-                ) == len(train_loader)
-                if not optimizer_boundary:
-                    optimizer.zero_grad(set_to_none=True)
-                    current_microbatch_idx = (
-                        step // grad_accum_steps
-                    ) * grad_accum_steps
-                save_last(epoch, reason="wall_time")
-                print(
-                    f"[success] Gracefully saved checkpoint to {out_dir / 'last_critic.pt'}. Exiting.",
-                    flush=True,
-                )
-                time_limit_reached = True
-                break
-
-        if time_limit_reached:
-            break
-        resume_microbatch_idx = 0
-        train_loss /= len(train_loader)
-        if device.type == "mps":
-            torch.mps.empty_cache()
-
-        model.eval()
-        val_loss = 0.0
-        val_tasks_total = 0
-        with torch.no_grad():
-            for batch in val_loader:
-                input_ids = batch["input_ids"].to(device)
-                attention_mask = batch.get("attention_mask")
-                if attention_mask is not None:
-                    attention_mask = attention_mask.to(device)
-                logits_dict = model(input_ids, attention_mask=attention_mask)
-
-                batch_loss = 0
-                batch_tasks = 0
-                supervised_losses = task_losses(
-                    logits_dict,
-                    {
-                        task: batch[task].to(device)
-                        for task in (*classification_tasks, *regression_tasks)
-                    },
-                    classification_tasks,
-                    regression_tasks,
-                    validation_classification_criterion,
-                )
-                if supervised_losses:
-                    batch_loss += torch.stack(list(supervised_losses.values())).mean()
-                    batch_tasks += 1
-                for task in multi_label_tasks:
-                    targets = batch[task].to(device)
-                    if targets.numel() and (targets >= 0).any():
-                        batch_loss += multi_label_criteria[task](
-                            logits_dict[task], targets
-                        )
-                        batch_tasks += 1
-
-                if batch_tasks > 0:
-                    val_loss += batch_loss.item()
-                    val_tasks_total += 1
-
-        if val_tasks_total > 0:
-            val_loss /= val_tasks_total
-        if device.type == "mps":
-            torch.mps.empty_cache()
-        print(
-            f"Epoch {epoch + 1}/{epochs} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}",
-            flush=True,
-        )
-        print(
-            f"[timing] epoch={epoch + 1} wall_sec={time.perf_counter() - epoch_started:.2f}",
-            flush=True,
-        )
-
-        with open(log_csv, "a", newline="") as f:
-            csv.writer(f).writerow([epoch + 1, f"{train_loss:.4f}", f"{val_loss:.4f}"])
-
-        improved = False
-        if val_loss < best_val_loss:
-            best_val_loss = val_loss
-            improved = True
-
-        # Save last checkpoint for resilience
-        save_last(epoch, reason="epoch")
-
-        if improved:
-            best_payload = checkpoint_payload(epoch, epoch_complete=True)
-            best_payload["checkpoint_reason"] = "best_epoch"
-            best_payload["epoch_complete"] = True
-            best_payload["microbatch_idx"] = 0
-            save_checkpoint_atomic(best_payload, out_dir / "best_critic.pt")
-            save_checkpoint_atomic(
-                best_payload, out_dir / f"best_critic_epoch_{epoch + 1:03d}.pt"
-            )
-            print("  -> Saved new best model.", flush=True)
-
-    if not time_limit_reached:
-        training_run.mark_complete(
-            {
-                "run_id": run_id,
-                "completed_epochs": epochs,
-                "best_validation_loss": best_val_loss,
-            }
-        )
-    training_run.close()
+        return engine.fit()
+    finally:
+        training_run.close()
+        run_logger.__exit__(*sys.exc_info())
 
 
 if __name__ == "__main__":

--- a/src/training/engine.py
+++ b/src/training/engine.py
@@ -39,6 +39,7 @@ class EngineConfig:
     minimize_monitor: bool = True
     last_checkpoint_name: str = "last.pt"
     best_checkpoint_name: str = "best.pt"
+    best_checkpoint_pattern: str | None = None
     epoch_checkpoint_pattern: str | None = None
 
     def __post_init__(self) -> None:
@@ -195,7 +196,8 @@ class TrainingEngine(Generic[BatchT]):
                         self.state, "interrupted", self.best_metric, self.aborted_groups
                     )
 
-            self.task.end_phase(TrainingPhase.TRAIN, epoch)
+            training_metrics = dict(self.task.end_phase(TrainingPhase.TRAIN, epoch))
+            self._emit("training_completed", None, training_metrics)
             validation_metrics = {}
             if (epoch + 1) % self.config.validate_every_epochs == 0:
                 validation_metrics = self._validate(epoch)
@@ -218,7 +220,21 @@ class TrainingEngine(Generic[BatchT]):
                 )
             if improved:
                 self._save(self.config.best_checkpoint_name, "best")
-            self._emit("epoch_completed", None, validation_metrics)
+                if self.config.best_checkpoint_pattern is not None:
+                    self._save(
+                        self.config.best_checkpoint_pattern.format(epoch=epoch + 1),
+                        "best_archive",
+                    )
+            self._emit(
+                "epoch_completed",
+                None,
+                validation_metrics,
+                {
+                    "epoch": epoch + 1,
+                    "training_metrics": training_metrics,
+                    "improved": improved,
+                },
+            )
 
         self.run.mark_complete(
             {

--- a/src/training/run_lifecycle.py
+++ b/src/training/run_lifecycle.py
@@ -116,12 +116,12 @@ def restore_rng_state(state: dict[str, Any] | None) -> None:
             numpy_state["cached_gaussian"],
         )
     )
-    torch.set_rng_state(state["torch_cpu"])
+    torch.set_rng_state(state["torch_cpu"].cpu())
     if "torch_cuda" in state and torch.cuda.is_available():
         torch.cuda.set_rng_state_all(state["torch_cuda"])
     set_mps_state = getattr(torch.mps, "set_rng_state", None)
     if "torch_mps" in state and callable(set_mps_state):
-        set_mps_state(state["torch_mps"])
+        set_mps_state(state["torch_mps"].cpu())
 
 
 class TrainingRun:

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -32,6 +32,12 @@ from src.protein_lm.train_multi_task import (
     load_compatible_model_weights,
     task_losses,
 )
+from src.protein_lm.critic_task import (
+    ProteinCriticTask,
+    adapt_protein_critic_checkpoint,
+    decode_protein_critic_checkpoint,
+)
+from src.training.contracts import StepContext, TrainingPhase
 
 
 def test_protein_type_label_extraction():
@@ -346,3 +352,82 @@ def test_partial_accumulation_group_uses_actual_size():
     assert accumulation_group_size(0, loader_length=10, grad_accum_steps=4) == 4
     assert accumulation_group_size(8, loader_length=10, grad_accum_steps=4) == 2
     assert accumulation_group_size(9, loader_length=10, grad_accum_steps=4) == 2
+
+
+def test_critic_task_combines_objectives_and_reports_complete_phase_metrics():
+    class FixedCritic(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.scale = torch.nn.Parameter(torch.tensor(1.0))
+
+        def forward(self, input_ids, attention_mask=None):
+            batch = input_ids.shape[0]
+            family = torch.tensor([[4.0, 0.0], [0.0, 4.0]])[:batch] * self.scale
+            stability = torch.tensor([[1.0], [3.0]])[:batch] * self.scale
+            protein_type = torch.tensor([[2.0, -2.0], [-2.0, 2.0]])[:batch] * self.scale
+            return {"family": family, "stability": stability, "protein_type": protein_type}
+
+    model = FixedCritic()
+    batch = {
+        "input_ids": torch.ones((2, 4), dtype=torch.long),
+        "attention_mask": torch.ones((2, 4), dtype=torch.long),
+        "sequence": ["AAAA", "BBBB"],
+        "family": torch.tensor([0, 1]),
+        "stability": torch.tensor([1.0, 2.0]),
+        "protein_type": torch.tensor([[1.0, 0.0], [0.0, 1.0]]),
+    }
+    task = ProteinCriticTask(
+        model=model,
+        train_loader=[batch],
+        validation_loader=[batch],
+        device=torch.device("cpu"),
+        classification_tasks=("family",),
+        regression_tasks=("stability",),
+        multi_label_tasks=("protein_type",),
+        train_classification_criteria={"family": torch.nn.CrossEntropyLoss()},
+        validation_classification_criterion=torch.nn.CrossEntropyLoss(),
+        multi_label_criteria={"protein_type": torch.nn.BCEWithLogitsLoss()},
+    )
+    task.begin_phase(TrainingPhase.VALIDATION, 0)
+    output = task.validation_step(
+        batch, StepContext(TrainingPhase.VALIDATION, 0, 0, 0, torch.device("cpu"))
+    )
+    metrics = task.end_phase(TrainingPhase.VALIDATION, 0)
+
+    assert output.loss.requires_grad
+    assert set(output.metrics) >= {"loss", "family_loss", "stability_loss", "protein_type_loss"}
+    assert metrics["family_accuracy"].total == 1.0
+    assert metrics["stability_mae"].total == 0.5
+    assert metrics["protein_type_accuracy"].total == 1.0
+
+
+def test_critic_checkpoint_legacy_round_trip():
+    model = torch.nn.Linear(2, 2)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    legacy = {
+        "epoch": 2,
+        "epoch_complete": False,
+        "microbatch_idx": 7,
+        "optimizer_step": 4,
+        "best_val_loss": 0.75,
+        "model_state_dict": model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "rng_state": {},
+    }
+    decoded = decode_protein_critic_checkpoint(legacy)
+    assert decoded.engine.current_epoch == 2
+    assert decoded.engine.microbatch == 7
+    assert decoded.metadata["best_metric"] == 0.75
+
+    payload = decoded.to_payload()
+    payload["metadata"] = {"reason": "best", "best_metric": 0.5}
+    adapted = adapt_protein_critic_checkpoint(
+        payload,
+        config={"epochs": 3},
+        dataset_provenance={"status": "test"},
+        task_vocabs={"pfam": {}},
+        model_spec={"task_dims": {"family": 2}},
+    )
+    assert adapted["checkpoint_reason"] == "best_epoch"
+    assert adapted["best_val_loss"] == 0.5
+    assert adapted["model_state_dict"] is payload["task"]["model"]

--- a/tests/test_structural_aware_protein_critic.py
+++ b/tests/test_structural_aware_protein_critic.py
@@ -31,6 +31,7 @@ from src.protein_lm.train_multi_task import (
     compute_multi_label_pos_weight,
     load_compatible_model_weights,
     task_losses,
+    validate_retired_saliency_regularizer,
 )
 from src.protein_lm.critic_task import (
     ProteinCriticTask,
@@ -352,6 +353,22 @@ def test_partial_accumulation_group_uses_actual_size():
     assert accumulation_group_size(0, loader_length=10, grad_accum_steps=4) == 4
     assert accumulation_group_size(8, loader_length=10, grad_accum_steps=4) == 2
     assert accumulation_group_size(9, loader_length=10, grad_accum_steps=4) == 2
+
+
+@pytest.mark.parametrize("config", [{}, {"saliency_regularizer_weight": 0}, {"saliency_regularizer_weight": 0.0}])
+def test_retired_saliency_regularizer_accepts_compatible_disabled_config(config):
+    validate_retired_saliency_regularizer(config)
+
+
+def test_retired_saliency_regularizer_rejects_nonzero_legacy_objective():
+    with pytest.raises(ValueError, match="no longer supported"):
+        validate_retired_saliency_regularizer({"saliency_regularizer_weight": 0.1})
+
+
+@pytest.mark.parametrize("value", [True, "0"])
+def test_retired_saliency_regularizer_rejects_invalid_type(value):
+    with pytest.raises(TypeError, match="must be numeric"):
+        validate_retired_saliency_regularizer({"saliency_regularizer_weight": value})
 
 
 def test_critic_task_combines_objectives_and_reports_complete_phase_metrics():

--- a/tests/test_training_engine.py
+++ b/tests/test_training_engine.py
@@ -86,6 +86,13 @@ class WeightedValidationTask(LinearTask):
         return {}
 
 
+class PhaseMetricTask(LinearTask):
+    def end_phase(self, phase, epoch):
+        if phase == TrainingPhase.TRAIN:
+            return {"epoch_loss": MetricValue(1.25)}
+        return {}
+
+
 def _build_engine(tmp_path, run, task, *, epochs=1, timer=None):
     optimizer = torch.optim.SGD(task.model.parameters(), lr=0.1)
     scheduler = torch.optim.lr_scheduler.LambdaLR(
@@ -246,6 +253,34 @@ def test_validation_metrics_are_weighted_and_emitted_to_callbacks(tmp_path):
     assert validation.metrics["score"].total == expected
     assert validation.metrics["weighted_f1"].total == 0.75
     assert result.best_metric == expected
+    run.close()
+
+
+def test_training_metrics_and_numbered_best_are_emitted(tmp_path):
+    task = PhaseMetricTask([1.0])
+    run = TrainingRun.open(tmp_path, "phase-metrics")
+    optimizer = torch.optim.SGD(task.model.parameters(), lr=0.0)
+    recorder = EventRecorder()
+    engine = TrainingEngine(
+        task=task,
+        strategy=AccumulatedBackpropStrategy(optimizer),
+        run=run,
+        config=EngineConfig(
+            epochs=1,
+            best_checkpoint_pattern="best_epoch_{epoch:03d}.pt",
+        ),
+        device=torch.device("cpu"),
+        callbacks=[recorder],
+    )
+
+    engine.fit()
+
+    training = next(event for event in recorder.events if event.name == "training_completed")
+    completed = next(event for event in recorder.events if event.name == "epoch_completed")
+    assert training.metrics["epoch_loss"].total == 1.25
+    assert completed.metadata["training_metrics"]["epoch_loss"].total == 1.25
+    assert completed.metadata["improved"] is True
+    assert (run.checkpoints / "best_epoch_001.pt").exists()
     run.close()
 
 


### PR DESCRIPTION
## Summary
- add a bidirectional multitask ProteinCritic task adapter for classification, regression, and multilabel objectives
- replace critic-owned accumulation, validation, checkpoint, interruption, and resume orchestration with the shared training engine
- preserve legacy checkpoint aliases, dynamic bucket batching, class weighting, evaluator provenance, progress logs, and numbered best checkpoints
- retire the hard-coded motif-attention regularizer while accepting existing absent/zero configuration and rejecting nonzero legacy use explicitly
- record configurable per-task loss weighting as a future scientific feature outside this PR
- expose train-phase metrics and numbered best archives as generic engine capabilities
- normalize restored RNG tensors to CPU so MPS-mapped checkpoints remain resumable
- update the conductor track and development log

## Validation
- focused Ruff checks passed
- `pytest -q` (413 passed, 1 skipped, 1 xpassed)

## Scope
This migrates only the corrected multitask ProteinCritic. The standalone protein classifier, ProteinEBM, learned-motif analysis, and configurable task-loss weighting remain separate follow-ups.