### PR TITLE
Migrate protein classifier to the shared training engine

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -41,13 +41,16 @@ configuration, task, strategy, and engine assembly.
 - [x] Add an end-of-phase metric hook so non-decomposable supervised metrics such
   as F1 are computed over the complete prediction set rather than averaged per batch.
 - [x] Implement the bidirectional multitask `ProteinCriticTask`.
-- [ ] Implement the protein classifier task or consolidate it with a generic
-  supervised-sequence task when the contracts genuinely match.
+- [x] Implement the corrected single-label `ProteinClassifierTask`; retain its
+  train-fitted label vocabulary as task-owned state rather than over-generalizing
+  the multitask critic adapter.
 - [ ] Implement `ProteinEBMTask`, keeping positive/negative construction and energy
   metrics task-owned while using the shared optimization strategy.
-- [ ] Verify frozen-backbone state for the EBM and classifier migrations.
+- [ ] Verify frozen-backbone state for the EBM migration.
 - [x] Verify ProteinCritic class/regression metric aggregation, validation
   selection, legacy checkpoint compatibility, and optimizer-boundary resume parity.
+- [x] Verify ProteinClassifier complete-set accuracy/weighted-F1, label-map
+  compatibility, scheduler state, legacy aliases, and interrupted resume parity.
 - [ ] Add validated per-task loss weights in a separate scientific-feature PR,
   preserving the present objective as the default and selecting weights using
   training/validation diagnostics rather than the test split.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1126,6 +1126,13 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     hand-written motif-attention regularizer was retired: existing zero-valued
     configuration remains valid, while nonzero legacy use now fails explicitly
     instead of imposing four unvalidated motifs on corrected training.
+*   **Model-Agnostic Protein Classifier Migration (2026-08-09):** Moved the
+    corrected single-label bidirectional classifier onto the shared engine. The
+    task retains the training-fitted label map, complete-phase accuracy and
+    weighted-F1, deterministic epoch permutations, and padding-aware inputs while
+    the engine owns actual-size accumulation, cosine scheduling, nonfinite recovery,
+    wall-time interruption, and epoch archives. Versioned checkpoints retain the
+    legacy model, optimizer, scheduler, label-map, loss, and progress aliases.
 
 ---
 *End of Log*

--- a/docs/TRAINING_ENTRYPOINT_INVENTORY.md
+++ b/docs/TRAINING_ENTRYPOINT_INVENTORY.md
@@ -8,7 +8,7 @@ Diagnostic harnesses may execute optimizer steps but are not production trainers
 | --- | --- | --- | --- | --- |
 | `src/codonlm/train_codon_lm.py` / `src/codonlm/training/loop.py` | causal codon LM with optional auxiliary objectives | AdamW, accumulated backprop, scheduler per committed group | exact optimizer boundary | Phase 4 |
 | `src/protein_lm/train_lm.py` | causal amino-acid LM | AdamW, accumulated backprop, cosine scheduler | optimizer boundary | Phase 2 reference |
-| `src/protein_lm/train_classifier.py` | protein sequence classifier | AdamW, accumulated backprop, cosine scheduler | optimizer boundary | Phase 3 |
+| `src/protein_lm/train_classifier.py` | protein sequence classifier | shared engine: configurable optimizer, accumulated backprop, cosine scheduler | optimizer boundary | Phase 3 migrated |
 | `src/protein_lm/train_multi_task.py` | bidirectional multitask ProteinCritic | AdamW, accumulated backprop, mixed classification/regression loss | optimizer boundary | Phase 3 |
 | `src/protein_lm/train_ebm.py` | latent real-versus-corrupted ranking | AdamW on EBM head; frozen critic | epoch boundary | Phase 3 |
 | `src/codonlm/train_noprop.py` | layer-local NoProp codon model | embedding, per-block, and head optimizers | epoch boundary | Phase 5 |

--- a/src/protein_lm/classifier_task.py
+++ b/src/protein_lm/classifier_task.py
@@ -1,0 +1,202 @@
+"""Shared-engine adapter for single-label protein classification."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn as nn
+from sklearn.metrics import f1_score
+
+from src.training.contracts import (
+    EngineState,
+    MetricValue,
+    StepContext,
+    StepOutput,
+    TrainingCheckpoint,
+    TrainingPhase,
+)
+
+
+class ProteinClassifierTask:
+    """Single-label protein objective, metrics, data order, and model state."""
+
+    def __init__(
+        self,
+        *,
+        model: nn.Module,
+        train_loader,
+        validation_loader,
+        criterion: nn.Module,
+        device: torch.device,
+        train_generator: torch.Generator,
+        seed: int,
+        label_map: Mapping[str, int],
+        pad_token_id: int,
+        log_every_microbatches: int = 100,
+    ) -> None:
+        self.model = model
+        self.train_loader = train_loader
+        self.validation_loader = validation_loader
+        self.criterion = criterion
+        self.device = device
+        self.train_generator = train_generator
+        self.seed = int(seed)
+        self.label_map = dict(label_map)
+        self.pad_token_id = int(pad_token_id)
+        self.log_every_microbatches = int(log_every_microbatches)
+        self._predictions: list[int] = []
+        self._labels: list[int] = []
+
+    def begin_phase(self, phase: TrainingPhase, epoch: int) -> None:
+        self._predictions = []
+        self._labels = []
+        if phase == TrainingPhase.TRAIN:
+            self.train_generator.manual_seed(self.seed + epoch)
+            self.model.train()
+        else:
+            self.model.eval()
+
+    def end_phase(self, phase: TrainingPhase, epoch: int):
+        if not self._labels:
+            return {}
+        correct = sum(
+            prediction == label
+            for prediction, label in zip(self._predictions, self._labels)
+        )
+        return {
+            "accuracy": MetricValue(correct / len(self._labels)),
+            "weighted_f1": MetricValue(
+                f1_score(
+                    self._labels,
+                    self._predictions,
+                    average="weighted",
+                    zero_division=0,
+                )
+            ),
+        }
+
+    def train_batches(self, epoch: int):
+        return self.train_loader
+
+    def validation_batches(self, epoch: int):
+        return self.validation_loader
+
+    def training_step(self, batch, context: StepContext) -> StepOutput:
+        output = self._step(batch)
+        if (
+            self.log_every_microbatches > 0
+            and context.microbatch % self.log_every_microbatches == 0
+        ):
+            print(
+                f"Epoch {context.epoch + 1}, Step {context.microbatch}, "
+                f"Loss: {output.loss.item():.4f}",
+                flush=True,
+            )
+        return output
+
+    def validation_step(self, batch, context: StepContext) -> StepOutput:
+        return self._step(batch)
+
+    def _step(self, batch) -> StepOutput:
+        input_ids, labels = batch
+        input_ids = input_ids.to(self.device)
+        labels = labels.to(self.device)
+        attention_mask = input_ids.ne(self.pad_token_id)
+        logits = self.model(input_ids, attention_mask=attention_mask)
+        loss = self.criterion(logits, labels)
+        predictions = logits.argmax(dim=-1)
+        self._predictions.extend(predictions.detach().cpu().tolist())
+        self._labels.extend(labels.detach().cpu().tolist())
+        return StepOutput(
+            loss=loss,
+            metrics={"loss": MetricValue(float(loss.detach()))},
+            committed_units={
+                "sequences": int(input_ids.shape[0]),
+                "residues": int(attention_mask.sum().item()),
+            },
+        )
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return {"model": self.model.state_dict(), "label_map": self.label_map}
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        saved_label_map = state.get("label_map")
+        checkpoint_label_map = (
+            None if saved_label_map is None else dict(saved_label_map)
+        )
+        if checkpoint_label_map is not None and checkpoint_label_map != self.label_map:
+            raise ValueError("Resume checkpoint label map differs from the training data")
+        self.model.load_state_dict(state["model"])
+
+
+def decode_protein_classifier_checkpoint(
+    payload: Mapping[str, Any],
+) -> TrainingCheckpoint:
+    """Read a current engine checkpoint or the legacy classifier schema."""
+    if "training_contract_version" in payload:
+        return TrainingCheckpoint.from_payload(payload)
+    required = {
+        "model_state_dict",
+        "optimizer_state_dict",
+        "scheduler_state_dict",
+        "epoch",
+    }
+    missing = required.difference(payload)
+    if missing:
+        raise ValueError(f"legacy protein classifier checkpoint is missing: {sorted(missing)}")
+    epoch = int(payload["epoch"])
+    complete = bool(payload.get("epoch_complete", True))
+    completed = epoch + 1 if complete else epoch
+    return TrainingCheckpoint(
+        engine=EngineState(
+            completed_epochs=completed,
+            current_epoch=completed if complete else epoch,
+            microbatch=0 if complete else int(payload.get("microbatch_idx", 0)),
+            optimizer_step=int(payload.get("optimizer_step", 0)),
+        ),
+        task={
+            "model": payload["model_state_dict"],
+            "label_map": payload.get("label_map"),
+        },
+        strategy={
+            "optimizer": payload["optimizer_state_dict"],
+            "scheduler": payload["scheduler_state_dict"],
+        },
+        rng=payload.get("rng_state", {}),
+        metadata={"best_metric": None, "legacy": True},
+    )
+
+
+def adapt_protein_classifier_checkpoint(
+    payload: dict[str, Any], *, config: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Add legacy classifier aliases to a versioned engine checkpoint."""
+    engine = payload["engine"]
+    reason = payload["metadata"]["reason"]
+    complete = reason in {"epoch", "epoch_archive", "best", "best_archive"}
+    payload.update(
+        {
+            "epoch": int(engine["completed_epochs"]) - 1 if complete else int(engine["current_epoch"]),
+            "epoch_complete": complete,
+            "microbatch_idx": 0 if complete else int(engine["microbatch"]),
+            "optimizer_step": int(engine["optimizer_step"]),
+            "model_state_dict": payload["task"]["model"],
+            "optimizer_state_dict": payload["strategy"]["optimizer"],
+            "scheduler_state_dict": payload["strategy"]["scheduler"],
+            "label_map": dict(payload["task"]["label_map"]),
+            "loss": payload["metadata"].get("metrics", {}).get(
+                "loss", float("inf")
+            ),
+            "checkpoint_reason": reason,
+            "cfg": dict(config),
+            "rng_state": payload["rng"],
+        }
+    )
+    return payload
+
+
+def make_protein_classifier_checkpoint_adapter(config: Mapping[str, Any]):
+    return partial(adapt_protein_classifier_checkpoint, config=config)

--- a/src/protein_lm/config.py
+++ b/src/protein_lm/config.py
@@ -108,6 +108,24 @@ class ProteinClassifierConfig:
     pooling: str = "mean"
     bidirectional: bool = True
 
+
+def validate_protein_classifier_config(config, model_config, tokenizer) -> None:
+    """Validate shared protein settings plus classifier-specific values."""
+    validate_protein_lm_config(config, model_config, tokenizer)
+    if isinstance(model_config.num_classes, bool) or not isinstance(
+        model_config.num_classes, Integral
+    ):
+        raise TypeError("model.num_classes must be an integer")
+    if model_config.num_classes < 2:
+        raise ValueError("model.num_classes must be at least 2")
+    if not isinstance(model_config.bidirectional, bool):
+        raise TypeError("model.bidirectional must be a boolean")
+    if not model_config.bidirectional:
+        raise ValueError("the corrected protein classifier must be bidirectional")
+    label_field = config.get("data", {}).get("label_field", "func_label")
+    if not isinstance(label_field, str) or not label_field:
+        raise ValueError("data.label_field must be a non-empty string")
+
 def load_config(path: str, config_class, overrides=None):
     """
     Loads a model configuration from a YAML file.

--- a/src/protein_lm/train_classifier.py
+++ b/src/protein_lm/train_classifier.py
@@ -164,8 +164,21 @@ def train_classifier(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a protein classifier.")
-    parser.add_argument("--config", required=True)
-    parser.add_argument("--resume")
-    parser.add_argument("--run-id")
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to the classifier YAML configuration.",
+    )
+    parser.add_argument(
+        "--resume",
+        type=str,
+        help="Path to a classifier checkpoint to resume.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        help="Run identifier; fresh collisions receive a serial suffix.",
+    )
     args = parser.parse_args()
     train_classifier(args.config, resume=args.resume, run_id=args.run_id)

--- a/src/protein_lm/train_classifier.py
+++ b/src/protein_lm/train_classifier.py
@@ -1,82 +1,99 @@
+"""Train the corrected standalone protein classifier with the shared engine."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
 import torch
 import torch.nn as nn
 import yaml
-import argparse
-from pathlib import Path
-import os
-from sklearn.metrics import accuracy_score, f1_score
 
-from src.protein_lm.config import ProteinClassifierConfig, load_config
-from src.protein_lm.tokenizer import ProteinTokenizer
-from src.protein_lm.models import ProteinClassifier
-from src.protein_lm.data import create_dataloader, ProteinClassificationDataset
-from src.training.runtime import WallTimer, save_checkpoint_atomic
-from src.training.run_lifecycle import (
-    TrainingRun,
-    capture_rng_state,
-    configuration_fingerprint,
-    restore_rng_state,
+from src.protein_lm.classifier_task import (
+    ProteinClassifierTask,
+    decode_protein_classifier_checkpoint,
+    make_protein_classifier_checkpoint_adapter,
 )
+from src.protein_lm.config import (
+    ProteinClassifierConfig,
+    load_config,
+    validate_protein_classifier_config,
+)
+from src.protein_lm.data import ProteinClassificationDataset, create_dataloader
+from src.protein_lm.models import ProteinClassifier
+from src.protein_lm.tokenizer import ProteinTokenizer
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.optimizers import build_optimizer
+from src.training.run_lifecycle import TrainingRun, configuration_fingerprint
+from src.training.runtime import PeriodicCheckpointPolicy, WallTimer, default_device
+from src.training.strategies import AccumulatedBackpropStrategy
 
-def train_classifier(config_path: str, resume=None, run_id=None):
-    """
-    Trains the protein classifier.
-    """
-    # --- 1. Load Configuration ---
-    with open(config_path, 'r') as f:
-        config_data = yaml.safe_load(f)
 
-    classifier_config = load_config(config_path, ProteinClassifierConfig)
-    training_config = config_data.get('training', {})
-    data_config = config_data.get('data', {})
+class _ClassifierConsole:
+    def on_event(self, event) -> None:
+        if event.name != "validation_completed":
+            return
+        print(
+            f"Validation Loss: {event.metrics['loss'].total:.4f}, "
+            f"Accuracy: {event.metrics['accuracy'].total:.4f}, "
+            f"F1: {event.metrics['weighted_f1'].total:.4f}",
+            flush=True,
+        )
 
-    # --- 2. Setup ---
-    epochs = int(training_config["epochs"])
-    run_id = run_id or config_data.get("run_id") or Path(config_path).stem
-    run_fingerprint = configuration_fingerprint(config_data)
-    training_run = TrainingRun.open(
-        Path("runs") / "protein_classifier",
-        run_id,
-        resume=resume,
-        target_epochs=epochs,
-        config_fingerprint=run_fingerprint,
-    )
-    run_logger = training_run.logger()
-    run_logger.__enter__()
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"Using device: {device}")
+def train_classifier(
+    config_path: str, resume: str | None = None, run_id: str | None = None
+):
+    with open(config_path) as handle:
+        config_data = yaml.safe_load(handle)
+    if not isinstance(config_data, Mapping):
+        raise TypeError("Protein classifier configuration must be a YAML mapping")
 
     tokenizer = ProteinTokenizer()
-    classifier_config.vocab_size = len(tokenizer.vocab)
-    seed = int(training_config.get("seed", 1337))
-    train_generator = torch.Generator()
+    classifier_config = load_config(
+        config_path,
+        ProteinClassifierConfig,
+        overrides={"vocab_size": len(tokenizer.vocab)},
+    )
+    training_config = config_data.get("training", {})
+    data_config = config_data.get("data", {})
+    validate_protein_classifier_config(config_data, classifier_config, tokenizer)
 
-    # --- 3. Data Loading ---
+    epochs = training_config["epochs"]
+    requested_run_id = run_id or config_data.get("run_id") or Path(config_path).stem
+    fingerprint = configuration_fingerprint(config_data)
+    device = default_device()
+    seed = training_config.get("seed", 1337)
+    torch.manual_seed(seed)
+    train_generator = torch.Generator()
+    label_field = data_config.get("label_field", "func_label")
     num_workers = int(training_config.get("num_workers", (os.cpu_count() or 2) // 2))
+
     train_loader = create_dataloader(
-        data_config['train_path'],
-        training_config['batch_size'],
+        data_config["train_path"],
+        training_config["batch_size"],
         num_workers=num_workers,
         tokenizer=tokenizer,
         block_size=classifier_config.block_size,
         shuffle=True,
         dataset_class=ProteinClassificationDataset,
-        label_field='func_label', # This assumes the label is in the 'func_label' field
+        label_field=label_field,
         generator=train_generator,
     )
     val_loader = create_dataloader(
-        data_config['val_path'],
-        training_config['batch_size'],
+        data_config["val_path"],
+        training_config["batch_size"],
         num_workers=num_workers,
         tokenizer=tokenizer,
         block_size=classifier_config.block_size,
         shuffle=False,
         dataset_class=ProteinClassificationDataset,
-        label_field='func_label',
+        label_field=label_field,
         label_map=train_loader.dataset.label_map,
     )
-
     detected_classes = len(train_loader.dataset.label_map)
     if classifier_config.num_classes != detected_classes:
         raise ValueError(
@@ -84,131 +101,70 @@ def train_classifier(config_path: str, resume=None, run_id=None):
             f"label map contains {detected_classes} classes"
         )
 
-
-    # --- 4. Model Initialization ---
     model = ProteinClassifier(classifier_config).to(device)
-    optimizer = torch.optim.AdamW(
-        model.parameters(),
-        lr=training_config['lr'],
-        weight_decay=training_config.get('weight_decay', 0.01)
-    )
-    criterion = nn.CrossEntropyLoss()
+    optimizer = build_optimizer(model.parameters(), training_config)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
-    wall_timer = WallTimer(training_config.get("max_time_minutes"))
-    optimizer_step = 0
-    start_epoch = 0
-    resume_microbatch = 0
-    if resume:
-        checkpoint = torch.load(resume, map_location=device, weights_only=False)
-        checkpoint_label_map = checkpoint.get("label_map")
-        if (
-            checkpoint_label_map is not None
-            and checkpoint_label_map != train_loader.dataset.label_map
-        ):
-            raise ValueError("Resume checkpoint label map differs from the training data")
-        model.load_state_dict(checkpoint["model_state_dict"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
-        optimizer_step = int(checkpoint.get("optimizer_step", 0))
-        complete = bool(checkpoint.get("epoch_complete", True))
-        start_epoch = int(checkpoint["epoch"]) + (1 if complete else 0)
-        resume_microbatch = 0 if complete else int(checkpoint.get("microbatch_idx", 0))
-        restore_rng_state(checkpoint.get("rng_state"))
-    current_microbatch = 0
-
-    def save_checkpoint(path: Path, epoch: int, loss: float, reason: str) -> None:
-        complete = reason == "epoch"
-        save_checkpoint_atomic({
-            'epoch': epoch,
-            'model_state_dict': model.state_dict(),
-            'optimizer_state_dict': optimizer.state_dict(),
-            'scheduler_state_dict': scheduler.state_dict(),
-            'loss': loss,
-            'optimizer_step': optimizer_step,
-            'checkpoint_reason': reason,
-            'cfg': config_data,
-            'label_map': dict(train_loader.dataset.label_map),
-            'epoch_complete': complete,
-            'microbatch_idx': 0 if complete else current_microbatch,
-            'run_fingerprint': run_fingerprint,
-            'rng_state': capture_rng_state(),
-            'run_progress': {
-                'completed_epochs': epoch + 1 if complete else epoch,
-                'current_epoch': epoch + 1,
-                'microbatch': 0 if complete else current_microbatch,
-                'optimizer_step': optimizer_step,
-            },
-        }, path)
-
-    # --- 5. Training Loop ---
-    grad_accum = int(training_config.get('grad_accum_steps', 1))
-    for epoch in range(start_epoch, epochs):
-        train_generator.manual_seed(seed + epoch)
-        model.train()
-        optimizer.zero_grad(set_to_none=True)
-        for i, (input_ids, labels) in enumerate(train_loader):
-            if epoch == start_epoch and i < resume_microbatch:
-                continue
-            current_microbatch = i + 1
-            input_ids, labels = input_ids.to(device), labels.to(device)
-
-            logits = model(input_ids)
-            loss = criterion(logits, labels)
-            
-            (loss / grad_accum).backward()
-
-            boundary = (i + 1) % grad_accum == 0 or (i + 1) == len(train_loader)
-            if boundary:
-                optimizer.step()
-                optimizer.zero_grad(set_to_none=True)
-                optimizer_step += 1
-                every_steps = int(training_config.get("checkpoint_every_steps", 0) or 0)
-                if every_steps > 0 and optimizer_step % every_steps == 0:
-                    save_checkpoint(training_run.checkpoints / "last.pt", epoch, float("inf"), "periodic")
-
-            if i % 100 == 0:
-                print(f"Epoch {epoch+1}/{training_config['epochs']}, Step {i}, Loss: {loss.item():.4f}")
-            if wall_timer.expired():
-                save_checkpoint(training_run.checkpoints / "last.pt", epoch, float("inf"), "wall_time")
-                print(f"[success] Wall-time reached; saved {training_run.checkpoints / 'last.pt'}.")
-                training_run.close()
-                return
-        
-        scheduler.step()
-
-        # --- 6. Validation ---
-        model.eval()
-        val_loss = 0
-        all_preds = []
-        all_labels = []
-        with torch.no_grad():
-            for input_ids, labels in val_loader:
-                input_ids, labels = input_ids.to(device), labels.to(device)
-                logits = model(input_ids)
-                loss = criterion(logits, labels)
-                val_loss += loss.item()
-
-                preds = torch.argmax(logits, dim=1)
-                all_preds.extend(preds.cpu().numpy())
-                all_labels.extend(labels.cpu().numpy())
-
-        val_loss /= len(val_loader)
-        accuracy = accuracy_score(all_labels, all_preds)
-        f1 = f1_score(all_labels, all_preds, average='weighted')
-
-        print(f"Epoch {epoch+1}, Val Loss: {val_loss:.4f}, Accuracy: {accuracy:.4f}, F1: {f1:.4f}")
-
-        # --- 7. Checkpointing ---
-        save_checkpoint(training_run.checkpoints / f"epoch_{epoch+1:03d}.pt", epoch, val_loss, "epoch")
-        save_checkpoint(training_run.checkpoints / "last.pt", epoch, val_loss, "epoch")
-
-    training_run.mark_complete({"completed_epochs": epochs})
-    training_run.close()
+    task = ProteinClassifierTask(
+        model=model,
+        train_loader=train_loader,
+        validation_loader=val_loader,
+        criterion=nn.CrossEntropyLoss(),
+        device=device,
+        train_generator=train_generator,
+        seed=seed,
+        label_map=train_loader.dataset.label_map,
+        pad_token_id=tokenizer.pad_token_id,
+        log_every_microbatches=training_config.get("log_every_steps", 100),
+    )
+    strategy = AccumulatedBackpropStrategy(
+        optimizer,
+        scheduler=scheduler,
+        parameters=model.parameters(),
+        grad_clip_norm=training_config.get("grad_clip_norm"),
+        scheduler_interval="epoch",
+    )
+    training_run = TrainingRun.open(
+        Path("runs") / "protein_classifier",
+        requested_run_id,
+        resume=resume,
+        target_epochs=epochs,
+        config_fingerprint=fingerprint,
+    )
+    logger = training_run.logger()
+    logger.__enter__()
+    try:
+        print(f"Using device: {device}")
+        engine = TrainingEngine(
+            task=task,
+            strategy=strategy,
+            run=training_run,
+            config=EngineConfig(
+                epochs=epochs,
+                grad_accum_steps=training_config.get("grad_accum_steps", 1),
+                epoch_checkpoint_pattern="epoch_{epoch:03d}.pt",
+            ),
+            device=device,
+            callbacks=[_ClassifierConsole()],
+            wall_timer=WallTimer(training_config.get("max_time_minutes")),
+            checkpoint_policy=PeriodicCheckpointPolicy(
+                every_steps=training_config.get("checkpoint_every_steps", 0),
+                every_minutes=training_config.get("checkpoint_every_minutes", 0.0),
+            ),
+            run_fingerprint=fingerprint,
+            checkpoint_decoder=decode_protein_classifier_checkpoint,
+            checkpoint_payload_adapter=make_protein_classifier_checkpoint_adapter(
+                config_data
+            ),
+        )
+        return engine.fit()
+    finally:
+        training_run.close()
+        logger.__exit__(*sys.exc_info())
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a protein classifier.")
-    parser.add_argument("--config", type=str, required=True, help="Path to the config YAML file.")
+    parser.add_argument("--config", required=True)
     parser.add_argument("--resume")
     parser.add_argument("--run-id")
     args = parser.parse_args()

--- a/src/training/engine.py
+++ b/src/training/engine.py
@@ -212,18 +212,20 @@ class TrainingEngine(Generic[BatchT]):
             improved = monitored is not None and self._is_better(monitored.total)
             if improved:
                 self.best_metric = monitored.total
-            self._save(self.config.last_checkpoint_name, "epoch")
+            self._save(self.config.last_checkpoint_name, "epoch", validation_metrics)
             if self.config.epoch_checkpoint_pattern is not None:
                 self._save(
                     self.config.epoch_checkpoint_pattern.format(epoch=epoch + 1),
                     "epoch_archive",
+                    validation_metrics,
                 )
             if improved:
-                self._save(self.config.best_checkpoint_name, "best")
+                self._save(self.config.best_checkpoint_name, "best", validation_metrics)
                 if self.config.best_checkpoint_pattern is not None:
                     self._save(
                         self.config.best_checkpoint_pattern.format(epoch=epoch + 1),
                         "best_archive",
+                        validation_metrics,
                     )
             self._emit(
                 "epoch_completed",
@@ -270,13 +272,24 @@ class TrainingEngine(Generic[BatchT]):
             return True
         return value < self.best_metric if self.config.minimize_monitor else value > self.best_metric
 
-    def _save(self, filename: str, reason: str) -> None:
+    def _save(
+        self,
+        filename: str,
+        reason: str,
+        metrics: Mapping[str, MetricValue] | None = None,
+    ) -> None:
         checkpoint = TrainingCheckpoint(
             engine=self.state,
             task=self.task.state_dict(),
             strategy=self.strategy.state_dict(),
             rng=capture_rng_state(),
-            metadata={"reason": reason, "best_metric": self.best_metric},
+            metadata={
+                "reason": reason,
+                "best_metric": self.best_metric,
+                "metrics": {
+                    name: value.total for name, value in (metrics or {}).items()
+                },
+            },
         )
         payload = checkpoint.to_payload()
         payload["run_progress"] = {

--- a/tests/test_protein_classifier_task.py
+++ b/tests/test_protein_classifier_task.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+
+from src.protein_lm.classifier_task import (
+    ProteinClassifierTask,
+    adapt_protein_classifier_checkpoint,
+    decode_protein_classifier_checkpoint,
+)
+from src.training.contracts import TrainingPhase
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.run_lifecycle import TrainingRun
+from src.training.strategies import AccumulatedBackpropStrategy
+
+
+class TinyClassifier(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(8, 4)
+        self.head = torch.nn.Linear(4, 2)
+
+    def forward(self, input_ids, attention_mask=None):
+        hidden = self.embedding(input_ids)
+        weights = attention_mask.unsqueeze(-1)
+        pooled = (hidden * weights).sum(1) / weights.sum(1).clamp_min(1)
+        return self.head(pooled)
+
+
+def _batches():
+    return [
+        (torch.tensor([[1, 2, 0]]), torch.tensor([0])),
+        (torch.tensor([[1, 3, 0]]), torch.tensor([1])),
+        (torch.tensor([[1, 4, 5]]), torch.tensor([1])),
+    ]
+
+
+def _task(model, *, batches=None, label_map=None):
+    batches = batches or _batches()
+    return ProteinClassifierTask(
+        model=model,
+        train_loader=batches,
+        validation_loader=batches,
+        criterion=torch.nn.CrossEntropyLoss(),
+        device=torch.device("cpu"),
+        train_generator=torch.Generator(),
+        seed=17,
+        label_map=label_map or {"a": 0, "b": 1},
+        pad_token_id=0,
+        log_every_microbatches=0,
+    )
+
+
+def test_classifier_task_matches_actual_size_accumulation_and_metrics(tmp_path):
+    torch.manual_seed(11)
+    model = TinyClassifier()
+    reference = copy.deepcopy(model)
+    batches = _batches()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=0.01)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=1)
+    task = _task(model, batches=batches)
+    run = TrainingRun.open(tmp_path, "classifier-parity")
+    engine = TrainingEngine(
+        task=task,
+        strategy=AccumulatedBackpropStrategy(
+            optimizer,
+            scheduler=scheduler,
+            parameters=model.parameters(),
+            scheduler_interval="epoch",
+        ),
+        run=run,
+        config=EngineConfig(epochs=1, grad_accum_steps=2),
+        device=torch.device("cpu"),
+    )
+    result = engine.fit()
+
+    reference_optimizer = torch.optim.AdamW(
+        reference.parameters(), lr=1e-3, weight_decay=0.01
+    )
+    for group in (batches[:2], batches[2:]):
+        reference_optimizer.zero_grad(set_to_none=True)
+        losses = []
+        for input_ids, labels in group:
+            logits = reference(input_ids, attention_mask=input_ids.ne(0))
+            losses.append(torch.nn.functional.cross_entropy(logits, labels))
+        torch.stack(losses).mean().backward()
+        reference_optimizer.step()
+
+    for actual, expected in zip(model.parameters(), reference.parameters()):
+        assert torch.allclose(actual, expected)
+    assert result.state.optimizer_step == 2
+    assert scheduler.last_epoch == 1
+    task.begin_phase(TrainingPhase.VALIDATION, 1)
+    for index, batch in enumerate(batches):
+        task.validation_step(batch, _context(index))
+    metrics = task.end_phase(TrainingPhase.VALIDATION, 1)
+    assert set(metrics) == {"accuracy", "weighted_f1"}
+    run.close()
+
+
+def _context(microbatch):
+    from src.training.contracts import StepContext
+
+    return StepContext(
+        TrainingPhase.VALIDATION,
+        epoch=0,
+        microbatch=microbatch,
+        optimizer_step=0,
+        device=torch.device("cpu"),
+    )
+
+
+def test_classifier_task_rejects_changed_checkpoint_label_map():
+    task = _task(TinyClassifier())
+    with pytest.raises(ValueError, match="label map differs"):
+        task.load_state_dict(
+            {"model": task.model.state_dict(), "label_map": {"different": 0}}
+        )
+
+
+def test_legacy_classifier_checkpoint_translation_and_aliases():
+    model = TinyClassifier()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=2)
+    legacy = {
+        "epoch": 1,
+        "epoch_complete": False,
+        "microbatch_idx": 3,
+        "optimizer_step": 2,
+        "model_state_dict": model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "scheduler_state_dict": scheduler.state_dict(),
+        "label_map": {"a": 0, "b": 1},
+        "rng_state": {},
+    }
+    decoded = decode_protein_classifier_checkpoint(legacy)
+    assert decoded.engine.current_epoch == 1
+    assert decoded.engine.microbatch == 3
+    assert decoded.task["label_map"] == legacy["label_map"]
+
+    payload = decoded.to_payload()
+    payload["metadata"] = {
+        "reason": "epoch",
+        "best_metric": 0.5,
+        "metrics": {"loss": 0.6},
+    }
+    adapted = adapt_protein_classifier_checkpoint(payload, config={"epochs": 2})
+    assert adapted["model_state_dict"] is payload["task"]["model"]
+    assert adapted["label_map"] == legacy["label_map"]
+    assert adapted["loss"] == 0.6
+
+
+class ExpireAfterFirstGroup:
+    def __init__(self):
+        self.calls = 0
+
+    def expired(self):
+        self.calls += 1
+        return self.calls == 1
+
+
+def test_classifier_interrupted_resume_matches_uninterrupted(tmp_path):
+    torch.manual_seed(23)
+    initial = TinyClassifier().state_dict()
+
+    def build(run, *, timer=None):
+        model = TinyClassifier()
+        model.load_state_dict(initial)
+        task = _task(model, batches=_batches() + _batches())
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=1)
+        return task, TrainingEngine(
+            task=task,
+            strategy=AccumulatedBackpropStrategy(
+                optimizer,
+                scheduler=scheduler,
+                scheduler_interval="epoch",
+            ),
+            run=run,
+            config=EngineConfig(epochs=1, grad_accum_steps=2),
+            device=torch.device("cpu"),
+            wall_timer=timer,
+        )
+
+    reference_run = TrainingRun.open(tmp_path, "reference")
+    reference_task, reference_engine = build(reference_run)
+    reference_engine.fit()
+    reference_state = copy.deepcopy(reference_task.model.state_dict())
+    reference_run.close()
+
+    interrupted_run = TrainingRun.open(tmp_path, "resumed")
+    _, interrupted_engine = build(interrupted_run, timer=ExpireAfterFirstGroup())
+    interrupted = interrupted_engine.fit()
+    checkpoint = interrupted_run.checkpoints / "last.pt"
+    interrupted_run.close()
+    assert interrupted.state.microbatch == 2
+
+    resumed_run = TrainingRun.open(
+        tmp_path, "resumed", resume=checkpoint, target_epochs=1
+    )
+    resumed_task, resumed_engine = build(resumed_run)
+    resumed_engine.fit()
+    for name, tensor in resumed_task.model.state_dict().items():
+        assert torch.allclose(tensor, reference_state[name])
+    resumed_run.close()

--- a/tests/test_protein_trainer_lifecycle.py
+++ b/tests/test_protein_trainer_lifecycle.py
@@ -5,6 +5,7 @@ import torch
 import yaml
 
 from src.protein_lm.train_lm import train
+from src.protein_lm.train_classifier import train_classifier
 
 
 def _write_config(tmp_path: Path, epochs: int) -> Path:
@@ -62,3 +63,62 @@ def test_protein_lm_serial_launch_and_completed_extension(tmp_path, monkeypatch)
     payload = torch.load(checkpoint, map_location="cpu", weights_only=False)
     assert payload["run_progress"]["completed_epochs"] == 2
     assert (first / "run_complete_epoch_001.json").exists()
+
+
+def test_protein_classifier_uses_engine_checkpoint_and_label_contract(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    train_path = tmp_path / "classifier_train.jsonl"
+    val_path = tmp_path / "classifier_validation.jsonl"
+    records = [
+        {"sequence": "MKTAA", "func_label": "enzyme"},
+        {"sequence": "MQQVV", "func_label": "other"},
+        {"sequence": "MKTAV", "func_label": "enzyme"},
+        {"sequence": "MQQVA", "func_label": "other"},
+    ]
+    text = "".join(json.dumps(record) + "\n" for record in records)
+    train_path.write_text(text)
+    val_path.write_text(text)
+    config = {
+        "run_id": "classifier-smoke",
+        "model": {
+            "n_layer": 1,
+            "n_head": 1,
+            "n_embd": 8,
+            "block_size": 8,
+            "dropout": 0.0,
+            "num_classes": 2,
+        },
+        "training": {
+            "batch_size": 2,
+            "lr": 1e-3,
+            "epochs": 1,
+            "grad_accum_steps": 1,
+            "num_workers": 0,
+            "seed": 7,
+            "log_every_steps": 0,
+        },
+        "data": {"train_path": str(train_path), "val_path": str(val_path)},
+    }
+    config_path = tmp_path / "classifier.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+
+    result = train_classifier(str(config_path))
+
+    run = tmp_path / "runs" / "protein_classifier" / "classifier-smoke"
+    payload = torch.load(
+        run / "checkpoints" / "last.pt",
+        map_location="cpu",
+        weights_only=False,
+    )
+    assert result.status == "complete"
+    assert payload["training_contract_version"] == 1
+    assert payload["run_progress"]["completed_epochs"] == 1
+    assert payload["label_map"] == {"enzyme": 0, "other": 1}
+    assert payload["task"]["label_map"] == payload["label_map"]
+    assert payload["model_state_dict"].keys() == payload["task"]["model"].keys()
+    assert payload["scheduler_state_dict"] == payload["strategy"]["scheduler"]
+    assert payload["loss"] == payload["metadata"]["metrics"]["loss"]
+    assert (run / "checkpoints" / "epoch_001.pt").exists()
+    assert (run / "run_complete.json").exists()


### PR DESCRIPTION
## Summary
- add a corrected single-label ProteinClassifierTask with complete-phase accuracy and weighted-F1
- migrate classifier accumulation, scheduling, validation, nonfinite recovery, wall-time interruption, checkpointing, and resume to TrainingEngine
- preserve train-fitted label maps and reject corrected checkpoint/data vocabulary mismatches
- translate legacy classifier checkpoints in both directions while retaining model, optimizer, scheduler, label-map, loss, RNG, and progress aliases
- use the shared validated optimizer factory and add classifier-specific configuration validation
- preserve epoch archives and deterministic epoch permutations while correcting final partial accumulation scaling
- record current validation metrics in generic checkpoint metadata
- update the conductor plan, trainer inventory, and development log

## Validation
- focused Ruff checks passed
- `pytest -q` (418 passed, 1 skipped, 1 xpassed)

## Scope
This changes trainer orchestration only. It does not change the classifier architecture, label objective, pooling correction, dataset split, or scientific results. ProteinEBM remains the next Phase 3 migration.