### PR TITLE
Migrate ProteinEBM to the shared training engine

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -44,17 +44,14 @@ configuration, task, strategy, and engine assembly.
 - [x] Implement the corrected single-label `ProteinClassifierTask`; retain its
   train-fitted label vocabulary as task-owned state rather than over-generalizing
   the multitask critic adapter.
-- [ ] Implement `ProteinEBMTask`, keeping positive/negative construction and energy
+- [x] Implement `ProteinEBMTask`, keeping positive/negative construction and energy
   metrics task-owned while using the shared optimization strategy.
-- [ ] Verify frozen-backbone state for the EBM migration.
+- [x] Verify the frozen-backbone invariant, head-only updates, validation selection,
+  versioned critic loading, legacy EBM aliases, and interrupted resume parity.
 - [x] Verify ProteinCritic class/regression metric aggregation, validation
   selection, legacy checkpoint compatibility, and optimizer-boundary resume parity.
 - [x] Verify ProteinClassifier complete-set accuracy/weighted-F1, label-map
   compatibility, scheduler state, legacy aliases, and interrupted resume parity.
-- [ ] Add validated per-task loss weights in a separate scientific-feature PR,
-  preserving the present objective as the default and selecting weights using
-  training/validation diagnostics rather than the test split.
-
 Exit gate: protein trainers share orchestration without changing their architectures,
 decoy distributions, losses, or scientific metrics.
 
@@ -94,6 +91,12 @@ update algorithm without model-specific branches.
 Exit gate: reusable mechanics have one maintained implementation, all supported
 trainers use it, and task-specific code contains only scientifically necessary
 behavior.
+
+## Future Scientific Features
+
+- [ ] Add validated per-task ProteinCritic loss weights in a separate PR,
+  preserving the present objective as the default and selecting weights using
+  training/validation diagnostics rather than the test split.
 
 ## Planned Pull Requests
 

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1133,6 +1133,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     the engine owns actual-size accumulation, cosine scheduling, nonfinite recovery,
     wall-time interruption, and epoch archives. Versioned checkpoints retain the
     legacy model, optimizer, scheduler, label-map, loss, and progress aliases.
+*   **Model-Agnostic Protein EBM Migration (2026-08-09):** Moved latent
+    real-versus-corrupted ranking onto the shared engine while keeping decoy
+    construction and softplus energy ranking task-owned. The critic is now checked
+    as completely frozen, only the EBM head reaches the optimizer, and validation
+    reports positive/negative energies and their gap. The loader accepts raw,
+    legacy, and versioned ProteinCritic weights, while EBM checkpoints retain their
+    one-based epoch, best-epoch, optimizer, validation-loss, and model aliases.
+    Phase 3 supervised and contrastive protein trainer migrations are complete.
 
 ---
 *End of Log*

--- a/docs/TRAINING_ENTRYPOINT_INVENTORY.md
+++ b/docs/TRAINING_ENTRYPOINT_INVENTORY.md
@@ -10,7 +10,7 @@ Diagnostic harnesses may execute optimizer steps but are not production trainers
 | `src/protein_lm/train_lm.py` | causal amino-acid LM | AdamW, accumulated backprop, cosine scheduler | optimizer boundary | Phase 2 reference |
 | `src/protein_lm/train_classifier.py` | protein sequence classifier | shared engine: configurable optimizer, accumulated backprop, cosine scheduler | optimizer boundary | Phase 3 migrated |
 | `src/protein_lm/train_multi_task.py` | bidirectional multitask ProteinCritic | AdamW, accumulated backprop, mixed classification/regression loss | optimizer boundary | Phase 3 |
-| `src/protein_lm/train_ebm.py` | latent real-versus-corrupted ranking | AdamW on EBM head; frozen critic | epoch boundary | Phase 3 |
+| `src/protein_lm/train_ebm.py` | latent real-versus-corrupted ranking | shared engine: AdamW on EBM head; frozen critic | optimizer boundary | Phase 3 migrated |
 | `src/codonlm/train_noprop.py` | layer-local NoProp codon model | embedding, per-block, and head optimizers | epoch boundary | Phase 5 |
 | `src/protein_lm/train_mlp_heads.py` | standalone heads over frozen features | one AdamW optimizer per head | none | ancillary; migrate or explicitly guard |
 | `scripts/train_biophysics_fusion.py` | nucleotide biophysics encoder pretraining/fusion assembly | AdamW encoder pretraining | none | ancillary; migrate or explicitly guard |

--- a/src/protein_lm/ebm_task.py
+++ b/src/protein_lm/ebm_task.py
@@ -1,0 +1,233 @@
+"""Shared-engine adapter for latent protein energy-model training."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from src.training.contracts import (
+    EngineState,
+    MetricValue,
+    StepContext,
+    StepOutput,
+    TrainingCheckpoint,
+    TrainingPhase,
+)
+
+
+AMINO_ACIDS = tuple("ARNDCQEGHILKMFPSTWYV")
+
+
+def corrupt_sequence(seq: str, mutation_rate: float = 0.20) -> str:
+    """Create a substitution decoy using the process-global restored RNG."""
+    if not seq:
+        raise ValueError("cannot corrupt an empty protein sequence")
+    if not 0.0 < mutation_rate <= 1.0:
+        raise ValueError("mutation_rate must be in (0, 1]")
+    residues = list(seq)
+    count = max(1, int(len(seq) * mutation_rate))
+    for index in random.sample(range(len(seq)), count):
+        residues[index] = random.choice(AMINO_ACIDS)
+    return "".join(residues)
+
+
+class ProteinEBMTask:
+    """Real-versus-corrupted latent ranking with a frozen critic backbone."""
+
+    def __init__(
+        self,
+        *,
+        model: nn.Module,
+        critic: nn.Module,
+        train_loader,
+        validation_loader,
+        tokenizer,
+        device: torch.device,
+        block_size: int,
+        mutation_rate: float = 0.20,
+        log_every_microbatches: int = 50,
+    ) -> None:
+        self.model = model
+        self.critic = critic
+        self.train_loader = train_loader
+        self.validation_loader = validation_loader
+        self.tokenizer = tokenizer
+        self.device = device
+        self.block_size = int(block_size)
+        self.mutation_rate = float(mutation_rate)
+        self.log_every_microbatches = int(log_every_microbatches)
+        if any(parameter.requires_grad for parameter in critic.parameters()):
+            raise ValueError("ProteinEBM critic parameters must be frozen")
+        self._phase_totals: dict[str, float] = {}
+        self._phase_weights: dict[str, float] = {}
+
+    def begin_phase(self, phase: TrainingPhase, epoch: int) -> None:
+        self._phase_totals = {}
+        self._phase_weights = {}
+        self.critic.eval()
+        self.model.train(phase == TrainingPhase.TRAIN)
+
+    def end_phase(self, phase: TrainingPhase, epoch: int):
+        return {
+            name: MetricValue(total / self._phase_weights[name])
+            for name, total in self._phase_totals.items()
+            if self._phase_weights.get(name, 0.0) > 0
+        }
+
+    def train_batches(self, epoch: int):
+        return self.train_loader
+
+    def validation_batches(self, epoch: int):
+        return self.validation_loader
+
+    def training_step(self, batch, context: StepContext) -> StepOutput:
+        output = self._step(batch)
+        if (
+            self.log_every_microbatches > 0
+            and context.microbatch % self.log_every_microbatches == 0
+        ):
+            print(
+                f"Epoch {context.epoch + 1} | Step {context.microbatch} | "
+                f"Loss: {output.loss.item():.4f} | "
+                f"E_pos: {output.metrics['energy_pos'].total:.3f} | "
+                f"E_neg: {output.metrics['energy_neg'].total:.3f}",
+                flush=True,
+            )
+        return output
+
+    def validation_step(self, batch, context: StepContext) -> StepOutput:
+        return self._step(batch)
+
+    def _step(self, batch) -> StepOutput:
+        pos_ids = batch["input_ids"].to(self.device)
+        pos_mask = batch["attention_mask"].to(self.device)
+        neg_ids, neg_mask = self._negative_batch(
+            batch["sequence"], target_length=pos_ids.shape[1]
+        )
+        with torch.no_grad():
+            positive_latent = self.critic.extract_latent(pos_ids, pos_mask)
+            negative_latent = self.critic.extract_latent(neg_ids, neg_mask)
+        energy_pos = self.model(positive_latent)
+        energy_neg = self.model(negative_latent)
+        loss = F.softplus(energy_pos - energy_neg).mean()
+        batch_size = int(pos_ids.shape[0])
+        metrics = {
+            "loss": MetricValue(float(loss.detach())),
+            "energy_pos": MetricValue(float(energy_pos.detach().mean())),
+            "energy_neg": MetricValue(float(energy_neg.detach().mean())),
+            "energy_gap": MetricValue(
+                float((energy_neg.detach() - energy_pos.detach()).mean())
+            ),
+        }
+        for name, value in metrics.items():
+            self._phase_totals[name] = self._phase_totals.get(name, 0.0) + value.total
+            self._phase_weights[name] = self._phase_weights.get(name, 0.0) + value.weight
+        return StepOutput(
+            loss=loss,
+            metrics=metrics,
+            committed_units={
+                "sequences": batch_size,
+                "residues": int(pos_mask.sum().item()),
+            },
+        )
+
+    def _negative_batch(self, sequences, *, target_length: int):
+        ids = []
+        masks = []
+        for sequence in sequences:
+            negative = corrupt_sequence(sequence, self.mutation_rate)
+            tokens = (
+                [self.tokenizer.bos_token_id]
+                + self.tokenizer.encode_sequence(negative)[: self.block_size - 2]
+                + [self.tokenizer.eos_token_id]
+            )
+            tokens = tokens[:target_length]
+            padding = max(0, target_length - len(tokens))
+            ids.append(tokens + [self.tokenizer.pad_token_id] * padding)
+            masks.append([1] * len(tokens) + [0] * padding)
+        return (
+            torch.tensor(ids, dtype=torch.long, device=self.device),
+            torch.tensor(masks, dtype=torch.long, device=self.device),
+        )
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return {"model": self.model.state_dict()}
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        self.model.load_state_dict(state["model"])
+
+
+def decode_protein_ebm_checkpoint(payload: Mapping[str, Any]) -> TrainingCheckpoint:
+    """Read a versioned checkpoint or the legacy one-based EBM schema."""
+    if "training_contract_version" in payload:
+        return TrainingCheckpoint.from_payload(payload)
+    required = {"model", "optimizer_state_dict", "epoch"}
+    missing = required.difference(payload)
+    if missing:
+        raise ValueError(f"legacy ProteinEBM checkpoint is missing: {sorted(missing)}")
+    epoch = int(payload["epoch"])
+    complete = bool(payload.get("epoch_complete", True))
+    progress = payload.get("run_progress", {})
+    return TrainingCheckpoint(
+        engine=EngineState(
+            completed_epochs=epoch if complete else max(0, epoch - 1),
+            current_epoch=epoch if complete else max(0, epoch - 1),
+            microbatch=0 if complete else int(payload.get("microbatch_idx", 0)),
+            optimizer_step=int(progress.get("optimizer_step", 0)),
+        ),
+        task={"model": payload["model"]},
+        strategy={"optimizer": payload["optimizer_state_dict"]},
+        rng=payload.get("rng_state", {}),
+        metadata={
+            "best_metric": payload.get("best_val_loss"),
+            "best_epoch": payload.get("best_epoch"),
+            "legacy": True,
+        },
+    )
+
+
+def adapt_protein_ebm_checkpoint(
+    payload: dict[str, Any],
+    *,
+    critic_checkpoint: str,
+    model_spec: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add the established EBM aliases to a versioned checkpoint."""
+    engine = payload["engine"]
+    metadata = payload["metadata"]
+    reason = metadata["reason"]
+    complete = reason in {"epoch", "epoch_archive", "best", "best_archive"}
+    epoch = (
+        int(engine["completed_epochs"])
+        if complete
+        else int(engine["current_epoch"]) + 1
+    )
+    current_loss = metadata.get("metrics", {}).get("loss", float("inf"))
+    best_metric = metadata.get("best_metric")
+    payload.update(
+        {
+            "model": payload["task"]["model"],
+            "epoch": epoch,
+            "val_loss": current_loss,
+            "optimizer_state_dict": payload["strategy"]["optimizer"],
+            "best_val_loss": float("inf") if best_metric is None else best_metric,
+            "best_epoch": metadata.get("best_epoch") or 0,
+            "epoch_complete": complete,
+            "microbatch_idx": 0 if complete else int(engine["microbatch"]),
+            "checkpoint_reason": reason,
+            "rng_state": payload["rng"],
+            "critic_checkpoint": critic_checkpoint,
+            "model_spec": dict(model_spec),
+        }
+    )
+    return payload
+
+
+def make_protein_ebm_checkpoint_adapter(**kwargs):
+    return partial(adapt_protein_ebm_checkpoint, **kwargs)

--- a/src/protein_lm/train_ebm.py
+++ b/src/protein_lm/train_ebm.py
@@ -1,82 +1,220 @@
 #!/usr/bin/env python3
-"""
-Train Protein Latent Energy-Based Model (EBM) via Noise Contrastive Estimation (NCE).
-"""
+"""Train the latent protein EBM through the model-agnostic engine."""
 
 from __future__ import annotations
 
 import argparse
 import random
-import yaml
-import torch
-import torch.nn.functional as F
-from torch.utils.data import DataLoader
+import shutil
+import sys
+from collections.abc import Mapping
 from pathlib import Path
 
-from src.protein_lm.tokenizer import ProteinTokenizer
-from src.protein_lm.dataset import MultiTaskProteinDataset, LengthBucketBatchSampler, collate_protein_batch
-from src.protein_lm.models_multi import MultiTaskProteinClassifier
+import torch
+import yaml
+from torch.utils.data import DataLoader
+
 from src.protein_lm.config import ProteinClassifierConfig
-from src.protein_lm.ebm import ProteinLatentEBM
-from src.training.run_lifecycle import (
-    TrainingRun,
-    capture_rng_state,
-    configuration_fingerprint,
-    restore_rng_state,
+from src.protein_lm.dataset import (
+    LengthBucketBatchSampler,
+    MultiTaskProteinDataset,
+    collate_protein_batch,
 )
-from src.training.runtime import save_checkpoint_atomic
-
-AMINO_ACIDS = ['A', 'R', 'N', 'D', 'C', 'Q', 'E', 'G', 'H', 'I', 'L', 'K', 'M', 'F', 'P', 'S', 'T', 'W', 'Y', 'V']
-
-def corrupt_sequence(seq: str, mutation_rate: float = 0.20) -> str:
-    """Generate negative noise sequence by substituting residues randomly."""
-    seq_list = list(seq)
-    n_mutations = max(1, int(len(seq) * mutation_rate))
-    indices = random.sample(range(len(seq)), n_mutations)
-    for idx in indices:
-        seq_list[idx] = random.choice(AMINO_ACIDS)
-    return "".join(seq_list)
+from src.protein_lm.ebm import ProteinLatentEBM
+from src.protein_lm.ebm_task import (
+    ProteinEBMTask,
+    corrupt_sequence as corrupt_sequence,
+    decode_protein_ebm_checkpoint,
+    make_protein_ebm_checkpoint_adapter,
+)
+from src.protein_lm.models_multi import MultiTaskProteinClassifier
+from src.protein_lm.tokenizer import ProteinTokenizer
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.optimizers import build_optimizer
+from src.training.run_lifecycle import TrainingRun, configuration_fingerprint
+from src.training.runtime import default_device
+from src.training.strategies import AccumulatedBackpropStrategy
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Train Protein Latent EBM.")
     parser.add_argument("--config", required=True, help="Path to critic config file")
-    parser.add_argument("--critic_ckpt", required=True, help="Path to pre-trained MultiTask critic checkpoint")
+    parser.add_argument(
+        "--critic_ckpt",
+        required=True,
+        help="Path to pre-trained MultiTask critic checkpoint",
+    )
     parser.add_argument("--epochs", type=int, default=5, help="Number of EBM training epochs")
     parser.add_argument("--lr", type=float, default=0.001, help="Learning rate for EBM")
-    parser.add_argument("--pooling", default="attention", help="Backbone pooling type (attention | mean)")
+    parser.add_argument(
+        "--pooling",
+        default="attention",
+        help="Backbone pooling type (attention | mean)",
+    )
     parser.add_argument("--family_dim", type=int, default=2000, help="Classifier family dimension")
     parser.add_argument("--function_dim", type=int, default=1000, help="Classifier function dimension")
     parser.add_argument("--hidden_dim", type=int, default=512, help="Hidden size of the EBM network")
-    parser.add_argument("--out_dir", default="runs/protein_ebm", help="Output directory for checkpoints")
-    parser.add_argument("--run_id", default=None)
-    parser.add_argument("--resume", default=None)
+    parser.add_argument(
+        "--out_dir",
+        default="runs/protein_ebm",
+        help="Output directory for checkpoints",
+    )
+    parser.add_argument("--run_id", default=None, help="Run identifier")
+    parser.add_argument("--resume", default=None, help="Checkpoint to resume")
     parser.add_argument("--seed", type=int, default=1337, help="RNG seed")
     return parser.parse_args()
 
 
-def main():
-    args = parse_args()
+def resolve_critic_checkpoint(path: str | Path):
+    """Return critic model weights and optional architecture metadata."""
+    payload = torch.load(path, map_location="cpu", weights_only=False)
+    if not isinstance(payload, Mapping):
+        raise TypeError("critic checkpoint must contain a state mapping")
+    spec = payload.get("model_spec")
+    if "training_contract_version" in payload:
+        state = payload.get("task", {}).get("model")
+    elif "model_state_dict" in payload:
+        state = payload["model_state_dict"]
+    elif "model" in payload:
+        state = payload["model"]
+    elif payload and all(torch.is_tensor(value) for value in payload.values()):
+        state = payload
+    else:
+        state = None
+    if not isinstance(state, Mapping):
+        raise ValueError("critic checkpoint has no recognized model state")
+    return state, dict(spec or {})
+
+
+class _EBMArtifacts:
+    def __init__(self, curves_path: Path, epochs: int) -> None:
+        self.curves_path = curves_path
+        self.epochs = epochs
+        self.training_metrics = {}
+
+    def on_event(self, event) -> None:
+        if event.name == "training_completed":
+            self.training_metrics = dict(event.metrics)
+        elif event.name == "epoch_completed":
+            epoch = int(event.metadata["epoch"])
+            train_loss = self.training_metrics["loss"].total
+            val_loss = event.metrics["loss"].total
+            with self.curves_path.open("a") as handle:
+                handle.write(f"{epoch},{train_loss:.6f},{val_loss:.6f}\n")
+            print(
+                f"--- Epoch {epoch}/{self.epochs} Complete | "
+                f"Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f} | "
+                f"Energy Gap: {event.metrics['energy_gap'].total:.4f} ---",
+                flush=True,
+            )
+        elif event.name == "checkpoint_saved":
+            print(
+                f"[saved] {event.metadata['filename']} "
+                f"({event.metadata['reason']})",
+                flush=True,
+            )
+
+
+def train_ebm(args):
     random.seed(args.seed)
     torch.manual_seed(args.seed)
-
-    device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"))
+    device = default_device()
     print(f"[ebm-train] using device: {device}")
+    with open(args.config) as handle:
+        cfg = yaml.safe_load(handle)
+    if not isinstance(cfg, Mapping):
+        raise TypeError("ProteinEBM configuration must be a YAML mapping")
+    if args.epochs < 1:
+        raise ValueError("epochs must be positive")
+    if args.hidden_dim < 1:
+        raise ValueError("hidden_dim must be positive")
 
-    # Load configuration
-    with open(args.config) as f:
-        cfg = yaml.safe_load(f)
+    critic_path = Path(args.critic_ckpt).resolve()
+    critic_state, critic_spec = resolve_critic_checkpoint(critic_path)
+    task_dims = critic_spec.get(
+        "task_dims",
+        {
+            "family": args.family_dim,
+            "function": args.function_dim,
+            "stability": 2,
+        },
+    )
+    tokenizer = ProteinTokenizer()
+    model_cfg = ProteinClassifierConfig(
+        vocab_size=int(critic_spec.get("vocab_size", len(tokenizer))),
+        n_layer=int(critic_spec.get("n_layer", cfg["n_layer"])),
+        n_head=int(critic_spec.get("n_head", cfg["n_head"])),
+        n_embd=int(critic_spec.get("n_embd", cfg["n_embd"])),
+        block_size=int(critic_spec.get("block_size", cfg["block_size"])),
+        dropout=float(critic_spec.get("dropout", cfg["dropout"])),
+        pooling=str(critic_spec.get("pooling", args.pooling)),
+        bidirectional=bool(critic_spec.get("bidirectional", True)),
+        num_classes=2,
+    )
+    critic = MultiTaskProteinClassifier(model_cfg, task_dims)
+    critic.load_state_dict(critic_state)
+    critic.to(device)
+    for parameter in critic.parameters():
+        parameter.requires_grad = False
+    critic.eval()
+
+    print("[ebm-train] loading dataset paths from config")
+    train_dataset = MultiTaskProteinDataset(
+        cfg["train_data"], tokenizer, max_length=model_cfg.block_size
+    )
+    val_dataset = MultiTaskProteinDataset(
+        cfg["val_data"], tokenizer, max_length=model_cfg.block_size
+    )
+    batch_size = int(cfg.get("batch_size", 4))
+    train_loader = DataLoader(
+        train_dataset,
+        batch_sampler=LengthBucketBatchSampler(
+            train_dataset, batch_size=batch_size, shuffle=True
+        ),
+        collate_fn=lambda batch: collate_protein_batch(
+            batch, pad_token_id=tokenizer.pad_token_id
+        ),
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_sampler=LengthBucketBatchSampler(
+            val_dataset, batch_size=batch_size, shuffle=False
+        ),
+        collate_fn=lambda batch: collate_protein_batch(
+            batch, pad_token_id=tokenizer.pad_token_id
+        ),
+    )
+
+    model = ProteinLatentEBM(
+        n_embd=model_cfg.n_embd,
+        hidden_dim=args.hidden_dim,
+    ).to(device)
+    optimizer = build_optimizer(
+        model.parameters(),
+        {"lr": args.lr, "weight_decay": 0.01},
+    )
+    task = ProteinEBMTask(
+        model=model,
+        critic=critic,
+        train_loader=train_loader,
+        validation_loader=val_loader,
+        tokenizer=tokenizer,
+        device=device,
+        block_size=model_cfg.block_size,
+        mutation_rate=0.20,
+        log_every_microbatches=50,
+    )
+    strategy = AccumulatedBackpropStrategy(optimizer, parameters=model.parameters())
 
     requested_dir = Path(args.out_dir)
     run_id = args.run_id or requested_dir.name
     fingerprint = configuration_fingerprint(
         {
             **cfg,
-            "critic_ckpt": str(Path(args.critic_ckpt).resolve()),
+            "critic_ckpt": str(critic_path),
             "lr": args.lr,
-            "pooling": args.pooling,
-            "family_dim": args.family_dim,
-            "function_dim": args.function_dim,
+            "pooling": model_cfg.pooling,
+            "task_dims": task_dims,
             "hidden_dim": args.hidden_dim,
             "seed": args.seed,
         }
@@ -89,244 +227,71 @@ def main():
         target_epochs=args.epochs,
         config_fingerprint=fingerprint,
     )
-    run_logger = training_run.logger()
-    run_logger.__enter__()
-
-    # Initialize tokenizer and datasets
-    tokenizer = ProteinTokenizer()
-    print("[ebm-train] loading dataset paths from config")
-    train_dataset = MultiTaskProteinDataset(cfg["train_data"], tokenizer, max_length=cfg.get("block_size", 512))
-    val_dataset = MultiTaskProteinDataset(cfg["val_data"], tokenizer, max_length=cfg.get("block_size", 512))
-
-    batch_size = cfg.get("batch_size", 4)
-    train_sampler = LengthBucketBatchSampler(train_dataset, batch_size=batch_size, shuffle=True)
-    val_sampler = LengthBucketBatchSampler(val_dataset, batch_size=batch_size, shuffle=False)
-
-    def collate_fn(batch):
-        return collate_protein_batch(batch, pad_token_id=tokenizer.pad_token_id)
-    train_loader = DataLoader(train_dataset, batch_sampler=train_sampler, collate_fn=collate_fn)
-    val_loader = DataLoader(val_dataset, batch_sampler=val_sampler, collate_fn=collate_fn)
-
-    # Initialize frozen MultiTask backbone classifier
-    model_cfg = ProteinClassifierConfig(
-        vocab_size=len(tokenizer),
-        n_layer=cfg["n_layer"],
-        n_head=cfg["n_head"],
-        n_embd=cfg["n_embd"],
-        block_size=cfg["block_size"],
-        dropout=cfg["dropout"],
-        pooling=args.pooling,
-        num_classes=2,
-    )
-    
-    # Standard task dimensions used by MultiTask critic
-    task_dims = {"family": args.family_dim, "function": args.function_dim, "stability": 2}
-    print(f"[ebm-train] loading MultiTask critic from {args.critic_ckpt}")
-    critic = MultiTaskProteinClassifier(model_cfg, task_dims)
-    
-    state_dict = torch.load(args.critic_ckpt, map_location="cpu")
-    if "model" in state_dict:
-        state_dict = state_dict["model"]
-    critic.load_state_dict(state_dict)
-    critic.to(device)
-    
-    # Freeze critic parameters completely
-    for p in critic.parameters():
-        p.requires_grad = False
-    critic.eval()
-
-    # Initialize Energy-Based Model head
-    ebm = ProteinLatentEBM(n_embd=cfg["n_embd"], hidden_dim=args.hidden_dim)
-    ebm.to(device)
-
-    optimizer = torch.optim.AdamW(ebm.parameters(), lr=args.lr, weight_decay=0.01)
-
-    out_dir = training_run.run_dir
-    ckpt_dir = training_run.checkpoints
-    scores_dir = training_run.scores
-
-    # Copy config
-    import shutil
-    try:
-        shutil.copy(args.config, ckpt_dir / "config.yaml")
-    except Exception as e:
-        print(f"[ebm-train] warning: failed to copy config file: {e}")
-
-    # Initialize curves.csv
-    curves_path = scores_dir / "curves.csv"
+    logger = training_run.logger()
+    logger.__enter__()
+    curves_path = training_run.scores / "curves.csv"
     if not curves_path.exists():
-        with open(curves_path, "w") as f:
-            f.write("epoch,train_loss,val_loss\n")
-
-    print(f"[ebm-train] starting EBM training: epochs={args.epochs}, lr={args.lr}")
-    
-    best_val_loss = float("inf")
-    best_epoch = 0
-    start_epoch = 1
-    if args.resume:
-        checkpoint = torch.load(args.resume, map_location=device, weights_only=False)
-        ebm.load_state_dict(checkpoint["model"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        best_val_loss = float(checkpoint.get("best_val_loss", float("inf")))
-        best_epoch = int(checkpoint.get("best_epoch", 0))
-        start_epoch = int(checkpoint["epoch"]) + 1
-        restore_rng_state(checkpoint.get("rng_state"))
-
-    for epoch in range(start_epoch, args.epochs + 1):
-        ebm.train()
-        total_loss = 0.0
-        n_batches = 0
-
-        for step, batch in enumerate(train_loader):
-            optimizer.zero_grad()
-
-            # 1. Prepare positive and corrupted negative sequences
-            pos_seqs = batch["sequence"]
-            neg_seqs = [corrupt_sequence(seq, mutation_rate=0.20) for seq in pos_seqs]
-
-            # Tokenize negative batch
-            neg_batch_ids = []
-            neg_batch_mask = []
-            for seq in neg_seqs:
-                tokens = [tokenizer.bos_token_id] + tokenizer.encode_sequence(seq)[:cfg["block_size"] - 2] + [tokenizer.eos_token_id]
-                pad_len = batch["input_ids"].shape[1] - len(tokens)
-                if pad_len > 0:
-                    neg_batch_ids.append(tokens + [tokenizer.pad_token_id] * pad_len)
-                    neg_batch_mask.append([1] * len(tokens) + [0] * pad_len)
-                else:
-                    neg_batch_ids.append(tokens[:batch["input_ids"].shape[1]])
-                    neg_batch_mask.append([1] * batch["input_ids"].shape[1])
-
-            pos_ids = batch["input_ids"].to(device)
-            pos_mask = batch["attention_mask"].to(device)
-            neg_ids = torch.tensor(neg_batch_ids, dtype=torch.long, device=device)
-            neg_mask = torch.tensor(neg_batch_mask, dtype=torch.long, device=device)
-
-            # 2. Extract continuous latent representations from frozen critic backbone
-            with torch.no_grad():
-                z_pos = critic.extract_latent(pos_ids, pos_mask)
-                z_neg = critic.extract_latent(neg_ids, neg_mask)
-
-            # 3. Calculate energies
-            energy_pos = ebm(z_pos)
-            energy_neg = ebm(z_neg)
-
-            # 4. softplus ranking loss (minimize energy of real, maximize energy of mutated decoys)
-            loss = torch.mean(F.softplus(energy_pos - energy_neg))
-            
-            loss.backward()
-            optimizer.step()
-
-            total_loss += loss.item()
-            n_batches += 1
-
-            if step % 50 == 0:
-                print(f"Epoch {epoch} | Step {step} | Loss: {loss.item():.4f} | E_pos: {energy_pos.mean().item():.3f} | E_neg: {energy_neg.mean().item():.3f}")
-
-        # Validation phase
-        ebm.eval()
-        val_loss = 0.0
-        val_batches = 0
-        with torch.no_grad():
-            for batch in val_loader:
-                pos_seqs = batch["sequence"]
-                neg_seqs = [corrupt_sequence(seq, mutation_rate=0.20) for seq in pos_seqs]
-
-                neg_batch_ids = []
-                neg_batch_mask = []
-                for seq in neg_seqs:
-                    tokens = [tokenizer.bos_token_id] + tokenizer.encode_sequence(seq)[:cfg["block_size"] - 2] + [tokenizer.eos_token_id]
-                    pad_len = batch["input_ids"].shape[1] - len(tokens)
-                    if pad_len > 0:
-                        neg_batch_ids.append(tokens + [tokenizer.pad_token_id] * pad_len)
-                        neg_batch_mask.append([1] * len(tokens) + [0] * pad_len)
-                    else:
-                        neg_batch_ids.append(tokens[:batch["input_ids"].shape[1]])
-                        neg_batch_mask.append([1] * batch["input_ids"].shape[1])
-
-                pos_ids = batch["input_ids"].to(device)
-                pos_mask = batch["attention_mask"].to(device)
-                neg_ids = torch.tensor(neg_batch_ids, dtype=torch.long, device=device)
-                neg_mask = torch.tensor(neg_batch_mask, dtype=torch.long, device=device)
-
-                z_pos = critic.extract_latent(pos_ids, pos_mask)
-                z_neg = critic.extract_latent(neg_ids, neg_mask)
-
-                energy_pos = ebm(z_pos)
-                energy_neg = ebm(z_neg)
-                val_loss += torch.mean(F.softplus(energy_pos - energy_neg)).item()
-                val_batches += 1
-
-        avg_train = total_loss / n_batches
-        avg_val = val_loss / val_batches
-        print(f"--- Epoch {epoch} Complete | Train Loss: {avg_train:.4f} | Val Loss: {avg_val:.4f} ---")
-
-        # Append to curves.csv
-        with open(curves_path, "a") as f:
-            f.write(f"{epoch},{avg_train:.6f},{avg_val:.6f}\n")
-
-        # Save checkpoint
-        payload = {
-            "model": ebm.state_dict(),
-            "epoch": epoch,
-            "val_loss": avg_val,
-            "optimizer_state_dict": optimizer.state_dict(),
-            "best_val_loss": min(best_val_loss, avg_val),
-            "best_epoch": epoch if avg_val < best_val_loss else best_epoch,
-            "epoch_complete": True,
-            "run_fingerprint": fingerprint,
-            "rng_state": capture_rng_state(),
-            "run_progress": {
-                "completed_epochs": epoch,
-                "current_epoch": epoch,
-                "microbatch": 0,
-                "optimizer_step": epoch * len(train_loader),
-            },
+        curves_path.write_text("epoch,train_loss,val_loss\n")
+    try:
+        try:
+            shutil.copy(args.config, training_run.checkpoints / "config.yaml")
+        except OSError as exc:
+            print(f"[ebm-train] warning: failed to copy config file: {exc}")
+        model_spec = {
+            "n_embd": model_cfg.n_embd,
+            "hidden_dim": args.hidden_dim,
+            "mutation_rate": 0.20,
+            "critic_task_dims": dict(task_dims),
         }
-        
-        # Save epoch checkpoint
-        ckpt_path = ckpt_dir / f"ebm_epoch_{epoch}.pt"
-        save_checkpoint_atomic(payload, ckpt_path)
-        print(f"[saved] {ckpt_path}")
+        engine = TrainingEngine(
+            task=task,
+            strategy=strategy,
+            run=training_run,
+            config=EngineConfig(
+                epochs=args.epochs,
+                last_checkpoint_name="last_ebm.pt",
+                best_checkpoint_name="best_ebm.pt",
+                best_checkpoint_pattern="best_ebm_epoch_{epoch:03d}.pt",
+                epoch_checkpoint_pattern="ebm_epoch_{epoch}.pt",
+            ),
+            device=device,
+            callbacks=[_EBMArtifacts(curves_path, args.epochs)],
+            run_fingerprint=fingerprint,
+            checkpoint_decoder=decode_protein_ebm_checkpoint,
+            checkpoint_payload_adapter=make_protein_ebm_checkpoint_adapter(
+                critic_checkpoint=str(critic_path),
+                model_spec=model_spec,
+            ),
+        )
+        result = engine.fit()
+        if result.status == "complete":
+            summary_path = training_run.run_dir / "summary.md"
+            summary_path.write_text(
+                f"""# Run Summary: `{training_run.run_dir.name}`
 
-        # Save last checkpoint
-        last_path = ckpt_dir / "last_ebm.pt"
-        save_checkpoint_atomic(payload, last_path)
-        
-        # Save best checkpoint
-        if avg_val < best_val_loss:
-            best_val_loss = avg_val
-            best_epoch = epoch
-            best_path = ckpt_dir / "best_ebm.pt"
-            save_checkpoint_atomic(payload, best_path)
-            save_checkpoint_atomic(payload, ckpt_dir / f"best_ebm_epoch_{epoch:03d}.pt")
-            print(f"[saved] {best_path} (new best validation loss: {best_val_loss:.4f})")
-
-    # Generate summary.md
-    summary_path = out_dir / "summary.md"
-    summary_content = f"""# Run Summary: `{out_dir.name}`
-
-## 📊 Status & Key Performance Indicators (KPIs)
+## Status & Key Performance Indicators
 - **Status:** Completed
 - **Epochs Trained:** {args.epochs}
-- **Best Epoch:** {best_epoch}
-- **Best Validation Loss:** {best_val_loss:.4f}
+- **Best Epoch:** {engine.best_epoch}
+- **Best Validation Loss:** {engine.best_metric:.4f}
 
-## 🧠 Model Architecture & Settings
+## Model Architecture & Settings
 - **Type:** Protein Latent Energy-Based Model (EBM)
-- **Latent Dim:** {cfg["n_embd"]}
+- **Latent Dim:** {model_cfg.n_embd}
 - **EBM Hidden Dim:** {args.hidden_dim}
-- **Pooling:** {args.pooling}
-- **Backbone Critic Checkpoint:** `{args.critic_ckpt}`
+- **Pooling:** {model_cfg.pooling}
+- **Backbone Critic Checkpoint:** `{critic_path}`
 """
-    summary_path.write_text(summary_content)
-    training_run.mark_complete(
-        {"completed_epochs": args.epochs, "best_epoch": best_epoch,
-         "best_validation_loss": best_val_loss}
-    )
-    training_run.close()
-    print(f"[summary] Wrote run summary to {summary_path}")
-    print("[ebm-train] Done training!")
+            )
+            print(f"[summary] Wrote run summary to {summary_path}")
+        return result
+    finally:
+        training_run.close()
+        logger.__exit__(*sys.exc_info())
+
+
+def main():
+    return train_ebm(parse_args())
 
 
 if __name__ == "__main__":

--- a/src/training/engine.py
+++ b/src/training/engine.py
@@ -108,6 +108,7 @@ class TrainingEngine(Generic[BatchT]):
         self.checkpoint_payload_adapter = checkpoint_payload_adapter
         self.state = EngineState()
         self.best_metric: float | None = None
+        self.best_epoch: int | None = None
         self.aborted_groups = 0
 
     def fit(self) -> EngineResult:
@@ -212,6 +213,7 @@ class TrainingEngine(Generic[BatchT]):
             improved = monitored is not None and self._is_better(monitored.total)
             if improved:
                 self.best_metric = monitored.total
+                self.best_epoch = epoch + 1
             self._save(self.config.last_checkpoint_name, "epoch", validation_metrics)
             if self.config.epoch_checkpoint_pattern is not None:
                 self._save(
@@ -243,6 +245,7 @@ class TrainingEngine(Generic[BatchT]):
                 "completed_epochs": self.state.completed_epochs,
                 "optimizer_step": self.state.optimizer_step,
                 "best_metric": self.best_metric,
+                "best_epoch": self.best_epoch,
             }
         )
         return EngineResult(self.state, "complete", self.best_metric, self.aborted_groups)
@@ -286,6 +289,7 @@ class TrainingEngine(Generic[BatchT]):
             metadata={
                 "reason": reason,
                 "best_metric": self.best_metric,
+                "best_epoch": self.best_epoch,
                 "metrics": {
                     name: value.total for name, value in (metrics or {}).items()
                 },
@@ -314,6 +318,8 @@ class TrainingEngine(Generic[BatchT]):
         self.state = checkpoint.engine
         best = checkpoint.metadata.get("best_metric")
         self.best_metric = None if best is None else float(best)
+        best_epoch = checkpoint.metadata.get("best_epoch")
+        self.best_epoch = None if best_epoch is None else int(best_epoch)
 
     def _emit(self, name, context=None, metrics=None, metadata=None) -> None:
         event = EngineEvent(name, context, metrics or {}, metadata or {})

--- a/tests/test_protein_ebm.py
+++ b/tests/test_protein_ebm.py
@@ -1,6 +1,4 @@
 import torch
-import numpy as np
-from pathlib import Path
 
 from src.protein_lm.tokenizer import ProteinTokenizer
 from src.protein_lm.ebm import ProteinLatentEBM

--- a/tests/test_protein_ebm_task.py
+++ b/tests/test_protein_ebm_task.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import copy
+import json
+import random
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from src.protein_lm.ebm import ProteinLatentEBM
+from src.protein_lm.ebm_task import (
+    ProteinEBMTask,
+    adapt_protein_ebm_checkpoint,
+    decode_protein_ebm_checkpoint,
+)
+from src.protein_lm.tokenizer import ProteinTokenizer
+from src.protein_lm.config import ProteinClassifierConfig
+from src.protein_lm.models_multi import MultiTaskProteinClassifier
+from src.protein_lm.train_ebm import resolve_critic_checkpoint, train_ebm
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.run_lifecycle import TrainingRun
+from src.training.strategies import AccumulatedBackpropStrategy
+
+
+class FrozenCritic(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(32, 4)
+        for parameter in self.parameters():
+            parameter.requires_grad = False
+
+    def extract_latent(self, input_ids, attention_mask):
+        hidden = self.embedding(input_ids)
+        weights = attention_mask.unsqueeze(-1)
+        return (hidden * weights).sum(1) / weights.sum(1).clamp_min(1)
+
+
+def _batch(tokenizer, sequences=("MKTAA", "MQQVV")):
+    encoded = []
+    for sequence in sequences:
+        tokens = [tokenizer.bos_token_id] + tokenizer.encode_sequence(sequence)
+        encoded.append(tokens + [tokenizer.pad_token_id] * (8 - len(tokens)))
+    input_ids = torch.tensor(encoded)
+    return {
+        "input_ids": input_ids,
+        "attention_mask": input_ids.ne(tokenizer.pad_token_id).long(),
+        "sequence": list(sequences),
+    }
+
+
+def _task(model, critic, batches):
+    tokenizer = ProteinTokenizer()
+    return ProteinEBMTask(
+        model=model,
+        critic=critic,
+        train_loader=batches,
+        validation_loader=batches[:1],
+        tokenizer=tokenizer,
+        device=torch.device("cpu"),
+        block_size=8,
+        log_every_microbatches=0,
+    )
+
+
+def test_ebm_task_updates_only_head_and_reports_energy_metrics(tmp_path):
+    tokenizer = ProteinTokenizer()
+    batch = _batch(tokenizer)
+    torch.manual_seed(5)
+    critic = FrozenCritic()
+    critic_before = copy.deepcopy(critic.state_dict())
+    model = ProteinLatentEBM(n_embd=4, hidden_dim=8, dropout=0.0)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    task = _task(model, critic, [batch])
+    run = TrainingRun.open(tmp_path, "ebm-frozen")
+    engine = TrainingEngine(
+        task=task,
+        strategy=AccumulatedBackpropStrategy(optimizer),
+        run=run,
+        config=EngineConfig(epochs=1),
+        device=torch.device("cpu"),
+    )
+
+    random.seed(7)
+    result = engine.fit()
+
+    assert result.state.optimizer_step == 1
+    assert set(critic.state_dict()) == set(critic_before)
+    for name, tensor in critic.state_dict().items():
+        assert torch.equal(tensor, critic_before[name])
+        assert tensor.grad is None
+    payload = torch.load(
+        run.checkpoints / "last.pt", map_location="cpu", weights_only=False
+    )
+    assert set(payload["metadata"]["metrics"]) >= {
+        "loss",
+        "energy_pos",
+        "energy_neg",
+        "energy_gap",
+    }
+    run.close()
+
+
+def test_ebm_task_rejects_trainable_critic():
+    critic = FrozenCritic()
+    next(critic.parameters()).requires_grad = True
+    with pytest.raises(ValueError, match="must be frozen"):
+        _task(
+            ProteinLatentEBM(n_embd=4, hidden_dim=8, dropout=0.0),
+            critic,
+            [_batch(ProteinTokenizer())],
+        )
+
+
+def test_legacy_ebm_checkpoint_translation_preserves_one_based_epoch():
+    model = ProteinLatentEBM(n_embd=4, hidden_dim=8)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    legacy = {
+        "model": model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "epoch": 3,
+        "epoch_complete": True,
+        "best_val_loss": 0.4,
+        "best_epoch": 2,
+        "rng_state": {},
+        "run_progress": {"optimizer_step": 12},
+    }
+    decoded = decode_protein_ebm_checkpoint(legacy)
+    assert decoded.engine.completed_epochs == 3
+    assert decoded.engine.current_epoch == 3
+    assert decoded.engine.optimizer_step == 12
+    assert decoded.metadata["best_epoch"] == 2
+
+    payload = decoded.to_payload()
+    payload["metadata"] = {
+        "reason": "epoch",
+        "best_metric": 0.3,
+        "best_epoch": 3,
+        "metrics": {"loss": 0.35},
+    }
+    adapted = adapt_protein_ebm_checkpoint(
+        payload,
+        critic_checkpoint="critic.pt",
+        model_spec={"n_embd": 4},
+    )
+    assert adapted["epoch"] == 3
+    assert adapted["val_loss"] == 0.35
+    assert adapted["best_val_loss"] == 0.3
+    assert adapted["best_epoch"] == 3
+
+
+class ExpireOnce:
+    def __init__(self):
+        self.done = False
+
+    def expired(self):
+        if self.done:
+            return False
+        self.done = True
+        return True
+
+
+def test_ebm_interrupted_resume_matches_uninterrupted(tmp_path):
+    tokenizer = ProteinTokenizer()
+    batches = [_batch(tokenizer, (sequence,)) for sequence in ("MKTAA", "MQQVV")]
+    torch.manual_seed(13)
+    critic_state = FrozenCritic().state_dict()
+    initial_model = ProteinLatentEBM(n_embd=4, hidden_dim=8, dropout=0.0).state_dict()
+
+    def build(run, timer=None):
+        critic = FrozenCritic()
+        critic.load_state_dict(critic_state)
+        model = ProteinLatentEBM(n_embd=4, hidden_dim=8, dropout=0.0)
+        model.load_state_dict(initial_model)
+        task = _task(model, critic, batches)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+        return task, TrainingEngine(
+            task=task,
+            strategy=AccumulatedBackpropStrategy(optimizer),
+            run=run,
+            config=EngineConfig(epochs=1),
+            device=torch.device("cpu"),
+            wall_timer=timer,
+        )
+
+    random.seed(19)
+    reference_run = TrainingRun.open(tmp_path, "reference")
+    reference_task, reference_engine = build(reference_run)
+    reference_engine.fit()
+    reference_state = copy.deepcopy(reference_task.model.state_dict())
+    reference_run.close()
+
+    random.seed(19)
+    interrupted_run = TrainingRun.open(tmp_path, "resumed")
+    _, interrupted_engine = build(interrupted_run, ExpireOnce())
+    interrupted = interrupted_engine.fit()
+    checkpoint = interrupted_run.checkpoints / "last.pt"
+    interrupted_run.close()
+    assert interrupted.state.microbatch == 1
+
+    resumed_run = TrainingRun.open(
+        tmp_path, "resumed", resume=checkpoint, target_epochs=1
+    )
+    resumed_task, resumed_engine = build(resumed_run)
+    resumed_engine.fit()
+    for name, tensor in resumed_task.model.state_dict().items():
+        assert torch.allclose(tensor, reference_state[name])
+    resumed_run.close()
+
+
+def test_ebm_trainer_accepts_versioned_critic_and_writes_legacy_aliases(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "src.protein_lm.train_ebm.default_device", lambda: torch.device("cpu")
+    )
+    tokenizer = ProteinTokenizer()
+    task_dims = {"family": 2, "function": 2, "stability": 1}
+    critic_config = ProteinClassifierConfig(
+        vocab_size=len(tokenizer),
+        n_layer=1,
+        n_head=1,
+        n_embd=8,
+        block_size=8,
+        dropout=0.0,
+        num_classes=2,
+        pooling="attention",
+    )
+    critic = MultiTaskProteinClassifier(critic_config, task_dims)
+    critic_path = tmp_path / "critic.pt"
+    torch.save(
+        {
+            "training_contract_version": 1,
+            "task": {"model": critic.state_dict()},
+            "model_spec": {
+                "vocab_size": len(tokenizer),
+                "n_layer": 1,
+                "n_head": 1,
+                "n_embd": 8,
+                "block_size": 8,
+                "dropout": 0.0,
+                "pooling": "attention",
+                "bidirectional": True,
+                "task_dims": task_dims,
+            },
+        },
+        critic_path,
+    )
+    state, spec = resolve_critic_checkpoint(critic_path)
+    assert state.keys() == critic.state_dict().keys()
+    assert spec["task_dims"] == task_dims
+
+    train_path = tmp_path / "train.jsonl"
+    val_path = tmp_path / "validation.jsonl"
+    records = [{"sequence": "MKTAA"}, {"sequence": "MQQVV"}]
+    text = "".join(json.dumps(record) + "\n" for record in records)
+    train_path.write_text(text)
+    val_path.write_text(text)
+    config_path = tmp_path / "ebm.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                f"train_data: {train_path}",
+                f"val_data: {val_path}",
+                "n_layer: 1",
+                "n_head: 1",
+                "n_embd: 8",
+                "block_size: 8",
+                "dropout: 0.0",
+                "batch_size: 2",
+            ]
+        )
+    )
+    args = SimpleNamespace(
+        config=str(config_path),
+        critic_ckpt=str(critic_path),
+        epochs=1,
+        lr=1e-3,
+        pooling="attention",
+        family_dim=2,
+        function_dim=2,
+        hidden_dim=8,
+        out_dir=str(tmp_path / "runs" / "protein_ebm"),
+        run_id="ebm-smoke",
+        resume=None,
+        seed=7,
+    )
+
+    result = train_ebm(args)
+
+    run = tmp_path / "runs" / "ebm-smoke"
+    payload = torch.load(
+        run / "checkpoints" / "last_ebm.pt",
+        map_location="cpu",
+        weights_only=False,
+    )
+    assert result.status == "complete"
+    assert payload["training_contract_version"] == 1
+    assert payload["epoch"] == 1
+    assert payload["best_epoch"] == 1
+    assert payload["model"].keys() == payload["task"]["model"].keys()
+    assert payload["critic_checkpoint"] == str(critic_path.resolve())
+    assert (run / "checkpoints" / "ebm_epoch_1.pt").exists()
+    assert (run / "checkpoints" / "best_ebm.pt").exists()
+    assert (run / "summary.md").exists()

--- a/tests/test_training_engine.py
+++ b/tests/test_training_engine.py
@@ -280,6 +280,7 @@ def test_training_metrics_and_numbered_best_are_emitted(tmp_path):
     assert training.metrics["epoch_loss"].total == 1.25
     assert completed.metadata["training_metrics"]["epoch_loss"].total == 1.25
     assert completed.metadata["improved"] is True
+    assert engine.best_epoch == 1
     assert (run.checkpoints / "best_epoch_001.pt").exists()
     run.close()
 


### PR DESCRIPTION
## Summary
- add ProteinEBMTask for task-owned substitution decoys, frozen-critic latent extraction, and softplus energy ranking
- migrate EBM iteration, optimization, validation, nonfinite handling, checkpoint selection, and resume to TrainingEngine
- enforce that every critic parameter is frozen and expose positive energy, negative energy, and energy-gap metrics
- load raw, legacy, and versioned ProteinCritic checkpoints, using checkpoint architecture/task metadata when available
- preserve one-based EBM epoch aliases, current/best validation loss, best epoch, optimizer state, curves, summaries, and established checkpoint filenames
- retain best-selection epoch as generic engine checkpoint metadata
- add fixed-seed head-only update, frozen-backbone, legacy translation, interrupted-resume, and end-to-end versioned-critic tests
- mark Phase 3 protein trainer migrations complete and update the inventory/development log

## Validation
- focused Ruff checks passed
- `pytest -q` (423 passed, 1 skipped, 1 xpassed)

## Scope
This preserves the existing 20% substitution-decoy distribution and softplus ranking objective. It does not redesign negative sampling, tune the EBM architecture, retrain the critic, or change downstream guidance.