### PR TITLE
Track directed ProteinEBM corruption research

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -4,6 +4,13 @@ This file tracks all major tracks for the project. Each track has its own detail
 
 ---
 
+- [ ] **Track: Directed ProteinEBM Corruption And Validation**
+*Link: [./tracks/ebm_directed_corruption_20260809/](./tracks/ebm_directed_corruption_20260809/)*
+*Summary: Replace uniform-only substitutions with a controlled, provenance-rich
+mixture of uniform, BLOSUM-conservative, Grantham-radical, and ProteinLM-contextual
+decoys; select on validation and externally test what EBM energy represents before
+using it as a biological quality score.*
+
 - [ ] **Track: Shared Training Run Lifecycle**
 *Link: [./tracks/shared_training_run_lifecycle_20260805/](./tracks/shared_training_run_lifecycle_20260805/)*
 *Summary: Centralize collision-safe run allocation, locking, resume lineage and

--- a/conductor/tracks/ebm_directed_corruption_20260809/plan.md
+++ b/conductor/tracks/ebm_directed_corruption_20260809/plan.md
@@ -1,0 +1,59 @@
+# Directed ProteinEBM Corruption Plan
+
+## Phase 0: Freeze The Baseline
+
+- [ ] Freeze the current uniform-20% implementation, dataset manifest, critic
+  checkpoint, EBM architecture, seed set, and compute budget.
+- [ ] Add strict standard-amino-acid validation at dataset/trainer boundaries.
+- [ ] Save per-decoy mutation provenance and establish uniform-only validation
+  metrics with confidence intervals.
+
+Exit gate: the present objective is exactly reproducible and invalid sequence
+symbols cannot silently become unknown tokens.
+
+## Phase 1: Corruption Strategy Contract
+
+- [ ] Define a registered corruption-strategy interface with a supplied RNG and a
+  structured decoy/provenance result.
+- [ ] Validate mixture weights, mutation rates/counts, and strategy-specific options.
+- [ ] Guarantee actual residue changes and exact interrupted/resumed reproduction.
+- [ ] Add unit/property tests for alphabet, length, mutation count, provenance, and
+  deterministic sampling.
+
+Exit gate: adding a strategy does not require editing the EBM task or engine.
+
+## Phase 2: Directed Negative Families
+
+- [ ] Implement BLOSUM-conservative hard negatives.
+- [ ] Implement Grantham-radical negatives with declared charge, polarity, and
+  volume severity bands.
+- [ ] Implement ProteinLM-low-likelihood contextual negatives without using EBM
+  validation/test outcomes to choose candidates.
+- [ ] Retain uniform substitutions as an independently selectable component.
+
+Exit gate: each family passes provenance and distribution audits and produces a
+nontrivial range of difficulty.
+
+## Phase 3: Controlled Ablation
+
+- [ ] Train uniform-only and each single-family strategy under matched conditions.
+- [ ] Train predeclared candidate mixtures, including the initial equal 25% mixture.
+- [ ] Report per-family ranking accuracy, energy gap, AUROC, calibration, and simple
+  composition/charge/hydrophobicity baselines.
+- [ ] Select one mixture using validation results and record the decision before
+  opening test results.
+
+Exit gate: the selected mixture improves hard-negative discrimination and is not
+explained by a trivial physicochemical shortcut.
+
+## Phase 4: External Validation And Promotion
+
+- [ ] Evaluate energy ordering on an external experimental mutation-effect or
+  stability dataset with family/scaffold-aware splits.
+- [ ] Measure whether EBM ranking improves generated-sequence selection over the
+  frozen ProteinCritic and ProteinLM likelihood controls.
+- [ ] Document supported and unsupported interpretations of the energy score.
+- [ ] Promote the mixture only if predefined validation gates pass; otherwise retain
+  uniform-only as a diagnostic baseline and do not use EBM energy as a quality claim.
+
+Exit gate: any promoted EBM has controlled synthetic and external evidence.

--- a/conductor/tracks/ebm_directed_corruption_20260809/spec.md
+++ b/conductor/tracks/ebm_directed_corruption_20260809/spec.md
@@ -1,0 +1,57 @@
+# Directed ProteinEBM Corruption Specification
+
+## Objective
+
+Replace uniform-only amino-acid substitution with an explicitly declared and
+measured mixture of negative distributions. The resulting ProteinEBM remains a
+natural-versus-defined-corruption ranker; energy must not be presented as
+experimental stability, function, or fitness without independent validation.
+
+## Requirements
+
+- Preserve the current 20% uniform substitution process as a frozen baseline.
+- Fail fast unless source and decoy sequences use the declared 20-residue alphabet.
+- Implement independently selectable corruption families:
+  - uniform substitutions;
+  - BLOSUM-conservative substitutions;
+  - Grantham-radical physicochemical substitutions;
+  - ProteinLM-low-likelihood contextual substitutions.
+- Record corruption family, mutated positions, source/replacement residues, and
+  severity for every generated decoy used in evaluation.
+- Prevent identity replacements from counting as mutations.
+- Keep corruption construction task-owned and deterministic under checkpoint resume.
+- Make mixture proportions and mutation-count/rate policies validated configuration.
+- Report loss, ranking accuracy, energy gap, and calibration separately for every
+  corruption family and severity band, plus the declared mixture aggregate.
+- Keep train, validation, and test corruption seeds and artifacts reproducible.
+
+## Scientific Controls
+
+- Hold the ProteinCritic checkpoint, natural-sequence split, EBM architecture,
+  optimizer budget, and seed set constant across corruption ablations.
+- Select a mixture using validation only and open the test split once after the
+  decision is recorded.
+- Compare against uniform-only, untrained-head, and simple physicochemical scoring
+  baselines.
+- Audit whether corruption families are trivially separable by amino-acid
+  composition, sequence length, charge, or hydrophobicity before attributing gains
+  to contextual protein understanding.
+- Treat structure-aware corruption as a later extension requiring trustworthy
+  residue annotations or structures; do not infer burial, interfaces, or active
+  sites from hand-written sequence rules.
+
+## Success Criteria
+
+1. Every decoy is reproducible and contains only the declared amino-acid alphabet.
+2. The selected mixture improves conservative/contextual held-out ranking without
+   losing broad uniform-negative discrimination.
+3. Performance is not explained solely by simple composition or charge baselines.
+4. Energy ordering is tested against an external mutation-effect or stability set
+   before energy is used as a biological quality claim.
+
+## Non-Goals
+
+- Changing ProteinCritic or CodonLM parameters.
+- Using the final test split to tune corruption proportions.
+- Claiming that every synthetic mutation is deleterious.
+- Combining this scientific objective change with training-engine migration.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1141,6 +1141,12 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     legacy, and versioned ProteinCritic weights, while EBM checkpoints retain their
     one-based epoch, best-epoch, optimizer, validation-loss, and model aliases.
     Phase 3 supervised and contrastive protein trainer migrations are complete.
+*   **Directed ProteinEBM Corruption Track (2026-08-09):** Opened a separate
+    scientific track to replace uniform-only substitution with controlled uniform,
+    BLOSUM-conservative, Grantham-radical, and ProteinLM-contextual negative
+    families. The track requires strict amino-acid validation, per-decoy provenance,
+    shortcut baselines, matched validation-only selection, and external mutation-
+    effect validation before interpreting EBM energy as biological quality.
 
 ---
 *End of Log*


### PR DESCRIPTION
## Summary
- add a dedicated conductor specification and phased plan for directed ProteinEBM negative sampling
- preserve uniform 20% substitution as the frozen baseline
- plan BLOSUM-conservative, Grantham-radical, and ProteinLM-contextual corruption strategies with structured provenance
- require strict amino-acid validation, deterministic resume, shortcut baselines, validation-only selection, and external mutation-effect validation
- explicitly constrain EBM interpretation to natural-versus-defined-corruption ranking until independently supported
- register the track and update the development log

## Scope
Documentation and research planning only. This PR does not change the current EBM objective, trainer, checkpoints, or generated-sequence guidance.