### PR TITLE
Migrate NoProp to shared training engine

### DIFF
--- a/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
+++ b/conductor/tracks/model_agnostic_training_engine_20260806/plan.md
@@ -69,11 +69,11 @@ changing their objective, update exposure, or checkpoint compatibility.
 
 ## Phase 5: Nonstandard Update Algorithms
 
-- [ ] Implement a layer-local `NoPropUpdateStrategy` with complete per-layer
+- [x] Implement a layer-local `NoPropUpdateStrategy` with complete per-layer
   optimizer state and resume parity.
-- [ ] Evaluate whether frozen-backbone and discriminative-learning-rate behavior
+- [x] Evaluate whether frozen-backbone and discriminative-learning-rate behavior
   require strategies, optimizer factories, or parameter-group configuration.
-- [ ] Document how future training algorithms register without editing the engine.
+- [x] Document how future training algorithms register without editing the engine.
 
 Exit gate: NoProp demonstrates that the engine supports a genuinely different
 update algorithm without model-specific branches.
@@ -105,4 +105,5 @@ behavior.
 3. ProteinLM reference migration.
 4. ProteinCritic, classifier, and EBM migrations.
 5. CodonLM migration and MPS parity gate.
-6. NoProp strategy, CI enforcement, documentation, and cleanup.
+6. NoProp strategy.
+7. CI enforcement, ancillary-trainer decisions, documentation, and cleanup.

--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1147,6 +1147,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     families. The track requires strict amino-acid validation, per-decoy provenance,
     shortcut baselines, matched validation-only selection, and external mutation-
     effect validation before interpreting EBM energy as biological quality.
+*   **Model-Agnostic NoProp Migration (2026-08-09):** Replaced NoProp's standalone
+    epoch loop with a task adapter and a layer-local update strategy. The strategy
+    preserves the embedding update through block zero, isolated per-block AdamW
+    steps, and detached output-head update; all optimizer states now participate in
+    exact optimizer-boundary interruption and resume. The shared engine owns
+    validation, best/last checkpoints, RNG restoration, run completion, and callback
+    reporting while legacy NoProp checkpoint aliases remain available. Fixed-seed
+    tests cover direct-update parity, legacy translation, and interrupted resume.
 
 ---
 *End of Log*

--- a/docs/TRAINING_ENTRYPOINT_INVENTORY.md
+++ b/docs/TRAINING_ENTRYPOINT_INVENTORY.md
@@ -11,7 +11,7 @@ Diagnostic harnesses may execute optimizer steps but are not production trainers
 | `src/protein_lm/train_classifier.py` | protein sequence classifier | shared engine: configurable optimizer, accumulated backprop, cosine scheduler | optimizer boundary | Phase 3 migrated |
 | `src/protein_lm/train_multi_task.py` | bidirectional multitask ProteinCritic | AdamW, accumulated backprop, mixed classification/regression loss | optimizer boundary | Phase 3 |
 | `src/protein_lm/train_ebm.py` | latent real-versus-corrupted ranking | shared engine: AdamW on EBM head; frozen critic | optimizer boundary | Phase 3 migrated |
-| `src/codonlm/train_noprop.py` | layer-local NoProp codon model | embedding, per-block, and head optimizers | epoch boundary | Phase 5 |
+| `src/codonlm/train_noprop.py` | layer-local NoProp codon model | shared engine: embedding, per-block, and head optimizers committed by `NoPropUpdateStrategy` | optimizer boundary | Phase 5 migrated |
 | `src/protein_lm/train_mlp_heads.py` | standalone heads over frozen features | one AdamW optimizer per head | none | ancillary; migrate or explicitly guard |
 | `scripts/train_biophysics_fusion.py` | nucleotide biophysics encoder pretraining/fusion assembly | AdamW encoder pretraining | none | ancillary; migrate or explicitly guard |
 
@@ -39,6 +39,16 @@ Diagnostic harnesses may execute optimizer steps but are not production trainers
 
 The migration parity suite will build on these tests and add fixed-seed parameter
 comparisons for each trainer before its existing orchestration loop is removed.
+
+## Registering Update Algorithms
+
+A trainer whose only differences are frozen parameters, optimizer type, or
+discriminative learning rates should use the standard accumulated-backprop strategy
+with appropriate optimizer parameter groups. A custom `UpdateStrategy` is reserved
+for algorithms that change update timing or gradient flow. NoProp is the reference:
+its strategy owns the embedding, per-block, and head optimizers, while its task owns
+the layer-local denoising objectives and explicit detach boundaries. The generic
+engine requires no model-name branch.
 
 ## Checkpoint Compatibility Rules
 

--- a/src/codonlm/noprop_task.py
+++ b/src/codonlm/noprop_task.py
@@ -1,0 +1,290 @@
+"""Shared-engine adapters for layer-local NoProp training."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from src.training.contracts import (
+    EngineState,
+    MetricValue,
+    StepContext,
+    StepOutput,
+    TrainingCheckpoint,
+    TrainingPhase,
+    UpdateResult,
+)
+from src.training.strategies import NonFiniteStepError
+
+
+class NoPropTask:
+    """Data, model, and local denoising objectives used by NoProp."""
+
+    def __init__(
+        self,
+        *,
+        model,
+        train_loader,
+        validation_loader,
+        device: torch.device,
+        noise_sigma: float,
+        train_generator: torch.Generator | None = None,
+        seed: int = 0,
+    ) -> None:
+        if noise_sigma < 0:
+            raise ValueError("noise_sigma must be non-negative")
+        self.model = model
+        self.train_loader = train_loader
+        self.validation_loader = validation_loader
+        self.device = device
+        self.noise_sigma = float(noise_sigma)
+        self.train_generator = train_generator
+        self.seed = int(seed)
+        self._train_totals: dict[str, float] = {}
+        self._train_steps = 0
+
+    def begin_phase(self, phase: TrainingPhase, epoch: int) -> None:
+        if phase == TrainingPhase.TRAIN:
+            self._train_totals = {}
+            self._train_steps = 0
+            if self.train_generator is not None:
+                self.train_generator.manual_seed(self.seed + epoch)
+            self.model.train()
+        else:
+            self.model.eval()
+
+    def end_phase(self, phase: TrainingPhase, epoch: int):
+        if phase == TrainingPhase.TRAIN and self._train_steps:
+            return {
+                name: MetricValue(total / self._train_steps)
+                for name, total in self._train_totals.items()
+            }
+        return {}
+
+    def train_batches(self, epoch: int):
+        return self.train_loader
+
+    def validation_batches(self, epoch: int):
+        return self.validation_loader
+
+    def training_step(self, batch, context: StepContext) -> StepOutput:
+        raise RuntimeError("NoProp training requires NoPropUpdateStrategy")
+
+    def local_training_step(
+        self,
+        batch,
+        *,
+        embedding_optimizer: torch.optim.Optimizer,
+        block_optimizers: Sequence[torch.optim.Optimizer],
+        head_optimizer: torch.optim.Optimizer,
+    ) -> StepOutput:
+        x, y = (tensor.to(self.device) for tensor in batch)
+        y_clean = self.model.tok_emb(y).detach()
+        y_noisy = y_clean + torch.randn_like(y_clean) * self.noise_sigma
+        non_pad_mask = y.ne(0).unsqueeze(-1).float()
+        h, attn_mask = self._initial_hidden(x)
+
+        embedding_optimizer.zero_grad(set_to_none=True)
+        block_losses: list[torch.Tensor] = []
+        for index, (block, optimizer) in enumerate(
+            zip(self.model.blocks, block_optimizers, strict=True)
+        ):
+            h_in = h if index == 0 else h.detach()
+            optimizer.zero_grad(set_to_none=True)
+            h, pred_y = block(h_in, noisy_targets=y_noisy, attn_mask=attn_mask)
+            loss = self._masked_mse(pred_y, y_clean, non_pad_mask)
+            self._require_finite(loss, f"block {index} loss")
+            loss.backward()
+            optimizer.step()
+            if index == 0:
+                embedding_optimizer.step()
+            block_losses.append(loss.detach())
+
+        head_optimizer.zero_grad(set_to_none=True)
+        logits = self.model.head(self.model.ln_f(h.detach()))
+        ce = F.cross_entropy(logits.view(-1, logits.size(-1)), y.view(-1), ignore_index=0)
+        self._require_finite(ce, "head loss")
+        ce.backward()
+        head_optimizer.step()
+        output = self._output(ce.detach(), block_losses, y)
+        for name, value in output.metrics.items():
+            self._train_totals[name] = self._train_totals.get(name, 0.0) + value.total
+        self._train_steps += 1
+        return output
+
+    def validation_step(self, batch, context: StepContext) -> StepOutput:
+        x, y = (tensor.to(self.device) for tensor in batch)
+        y_clean = self.model.tok_emb(y)
+        non_pad_mask = y.ne(0).unsqueeze(-1).float()
+        h, attn_mask = self._initial_hidden(x)
+        block_losses = []
+        for block in self.model.blocks:
+            h, pred_y = block(h, noisy_targets=y_clean, attn_mask=attn_mask)
+            block_losses.append(self._masked_mse(pred_y, y_clean, non_pad_mask))
+        logits = self.model.head(self.model.ln_f(h))
+        ce = F.cross_entropy(logits.view(-1, logits.size(-1)), y.view(-1), ignore_index=0)
+        return self._output(ce, block_losses, y)
+
+    def _initial_hidden(self, x: torch.Tensor):
+        positions = torch.arange(x.size(1), device=x.device).unsqueeze(0)
+        hidden = self.model.drop(self.model.tok_emb(x) + self.model.pos_emb(positions))
+        attn_mask = None
+        if self.model.sep_id is not None:
+            segments = torch.cumsum(x.eq(int(self.model.sep_id)), dim=1)
+            attn_mask = segments.unsqueeze(-1).eq(segments.unsqueeze(-2)).unsqueeze(1)
+        return hidden, attn_mask
+
+    @staticmethod
+    def _masked_mse(prediction, target, non_pad_mask):
+        elementwise = F.mse_loss(prediction, target, reduction="none")
+        denominator = non_pad_mask.sum() * prediction.size(-1) + 1e-8
+        return (elementwise * non_pad_mask).sum() / denominator
+
+    @staticmethod
+    def _require_finite(loss: torch.Tensor, name: str) -> None:
+        if not bool(torch.isfinite(loss.detach()).item()):
+            raise NonFiniteStepError(f"nonfinite NoProp {name}")
+
+    @staticmethod
+    def _output(ce, block_losses, targets):
+        metrics = {"loss": MetricValue(float(ce.detach()))}
+        metrics.update(
+            {
+                f"block_{index}_mse": MetricValue(float(loss.detach()))
+                for index, loss in enumerate(block_losses)
+            }
+        )
+        return StepOutput(
+            loss=ce,
+            metrics=metrics,
+            committed_units={
+                "tokens": int(targets.ne(0).sum().item()),
+                "sequences": int(targets.size(0)),
+            },
+        )
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return {"model": self.model.state_dict()}
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        self.model.load_state_dict(state["model"])
+
+
+class NoPropUpdateStrategy:
+    """Commit NoProp's embedding, block-local, and output-head updates."""
+
+    def __init__(self, embedding_optimizer, block_optimizers, head_optimizer):
+        self.embedding_optimizer = embedding_optimizer
+        self.block_optimizers = list(block_optimizers)
+        self.head_optimizer = head_optimizer
+        self._active = False
+        self._processed = 0
+
+    def begin_group(self, group_size: int) -> None:
+        if group_size != 1:
+            raise ValueError("NoProp requires grad_accum_steps=1")
+        if self._active:
+            raise RuntimeError("a NoProp update group is already active")
+        self._active = True
+        self._processed = 0
+
+    def process_microbatch(self, task, batch, context: StepContext) -> StepOutput:
+        if not self._active:
+            raise RuntimeError("begin_group must be called before process_microbatch")
+        if not isinstance(task, NoPropTask):
+            raise TypeError("NoPropUpdateStrategy requires NoPropTask")
+        output = task.local_training_step(
+            batch,
+            embedding_optimizer=self.embedding_optimizer,
+            block_optimizers=self.block_optimizers,
+            head_optimizer=self.head_optimizer,
+        )
+        output.validate()
+        self._processed = 1
+        return output
+
+    def commit_group(self) -> UpdateResult:
+        if not self._active or self._processed != 1:
+            raise RuntimeError("NoProp update group is incomplete")
+        self._reset()
+        return UpdateResult(committed=True, optimizer_steps=1)
+
+    def abort_group(self, reason: str) -> UpdateResult:
+        for optimizer in self._optimizers():
+            optimizer.zero_grad(set_to_none=True)
+        self._reset()
+        return UpdateResult(committed=False, optimizer_steps=0, reason=reason)
+
+    def end_epoch(self, metrics) -> None:
+        return None
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return {
+            "optimizers": {
+                "embedding": self.embedding_optimizer.state_dict(),
+                "blocks": [optimizer.state_dict() for optimizer in self.block_optimizers],
+                "head": self.head_optimizer.state_dict(),
+            }
+        }
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        optimizers = state["optimizers"]
+        block_states = optimizers["blocks"]
+        if len(block_states) != len(self.block_optimizers):
+            raise ValueError("checkpoint NoProp block optimizer count differs from model")
+        self.embedding_optimizer.load_state_dict(optimizers["embedding"])
+        for optimizer, saved in zip(self.block_optimizers, block_states, strict=True):
+            optimizer.load_state_dict(saved)
+        self.head_optimizer.load_state_dict(optimizers["head"])
+        self._reset()
+
+    def _optimizers(self):
+        return [self.embedding_optimizer, *self.block_optimizers, self.head_optimizer]
+
+    def _reset(self):
+        self._active = False
+        self._processed = 0
+
+
+def decode_noprop_checkpoint(payload: Mapping[str, Any]) -> TrainingCheckpoint:
+    """Read current engine checkpoints or the legacy NoProp schema."""
+    if "training_contract_version" in payload:
+        return TrainingCheckpoint.from_payload(payload)
+    required = {"model", "optimizers", "epoch"}
+    missing = required.difference(payload)
+    if missing:
+        raise ValueError(f"legacy NoProp checkpoint is missing: {sorted(missing)}")
+    epoch = int(payload["epoch"])
+    return TrainingCheckpoint(
+        engine=EngineState(
+            completed_epochs=epoch,
+            current_epoch=epoch,
+            microbatch=0,
+            optimizer_step=int(payload.get("run_progress", {}).get("optimizer_step", 0)),
+        ),
+        task={"model": payload["model"]},
+        strategy={"optimizers": payload["optimizers"]},
+        rng=payload.get("rng_state", {}),
+        metadata={"best_metric": payload.get("best_val_loss"), "legacy": True},
+    )
+
+
+def adapt_noprop_checkpoint(payload: dict[str, Any]) -> dict[str, Any]:
+    """Add legacy NoProp aliases to a versioned checkpoint payload."""
+    engine = payload["engine"]
+    metrics = payload["metadata"].get("metrics", {})
+    payload.update(
+        {
+            "model": payload["task"]["model"],
+            "optimizers": payload["strategy"]["optimizers"],
+            "epoch": int(engine["completed_epochs"]),
+            "epoch_complete": payload["metadata"]["reason"] in {"epoch", "best"},
+            "val_loss": metrics.get("loss"),
+            "best_val_loss": payload["metadata"].get("best_metric"),
+            "rng_state": payload["rng"],
+        }
+    )
+    return payload

--- a/src/codonlm/train_noprop.py
+++ b/src/codonlm/train_noprop.py
@@ -1,279 +1,193 @@
 #!/usr/bin/env python3
-"""
-Training script for NoPropTinyGPT using local layer-wise MSE denoising targets
-instead of global backpropagation.
-"""
+"""Train NoPropTinyGPT through the shared model-agnostic engine."""
+
+from __future__ import annotations
 
 import argparse
-import yaml
+import sys
 import torch
-import torch.nn.functional as F
+import yaml
 from torch.utils.data import DataLoader
 
-from .model_tiny_gpt import NoPropTinyGPT
+from src.training.contracts import EngineEvent
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.run_lifecycle import TrainingRun, configuration_fingerprint
+
 from .data_loading import PackedDataset, dynamic_lm_collate_fn
-from .train_codon_lm import _ensure_path_list, _normalize_run_id, _auto_run_id
-from src.training.runtime import save_checkpoint_atomic
-from src.training.run_lifecycle import (
-    TrainingRun,
-    capture_rng_state,
-    configuration_fingerprint,
-    restore_rng_state,
+from .model_tiny_gpt import NoPropTinyGPT
+from .noprop_task import (
+    NoPropTask,
+    NoPropUpdateStrategy,
+    adapt_noprop_checkpoint,
+    decode_noprop_checkpoint,
 )
+from .train_codon_lm import _auto_run_id, _ensure_path_list, _normalize_run_id
 from .training.vocabulary import (
     resolve_vocabulary_contract,
     snapshot_vocabulary,
     write_vocabulary_manifest,
 )
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--config", required=True)
-    ap.add_argument("--run_id", default=None)
-    ap.add_argument("--device", default=None)
-    ap.add_argument("--noise_sigma", type=float, default=0.1, help="Sigma of Gaussian noise added to targets")
-    ap.add_argument("--resume", default=None)
-    args = ap.parse_args()
 
-    with open(args.config, "r") as f:
-        cfg = yaml.safe_load(f)
+class _NoPropConsole:
+    def __init__(self, curves_path) -> None:
+        self.curves_path = curves_path
 
-    # Setup device
-    if args.device:
-        device = torch.device(args.device)
-    else:
-        device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
-    print(f"[noprop] using device: {device}")
+    def on_event(self, event: EngineEvent) -> None:
+        if event.name != "epoch_completed":
+            return
+        epoch = int(event.metadata["epoch"])
+        train = event.metadata["training_metrics"]
+        validation = event.metrics
+        with self.curves_path.open("a") as handle:
+            handle.write(
+                f"{epoch},{train['loss'].total:.6f},"
+                f"{validation['loss'].total:.6f}\n"
+            )
+        train_blocks = _format_blocks(train)
+        validation_blocks = _format_blocks(validation)
+        print(f"Epoch {epoch}:")
+        print(f"  Train Block MSEs: {train_blocks} | CE Loss: {train['loss'].total:.4f}")
+        print(
+            f"  Val Block MSEs:   {validation_blocks} | "
+            f"CE Loss: {validation['loss'].total:.4f}"
+        )
 
-    # Set run ID
-    run_id = _normalize_run_id(args.run_id) or _auto_run_id(cfg, args.config)
-    epochs = int(cfg.get("epochs", 5))
-    run_fingerprint = configuration_fingerprint(
-        {**cfg, "noise_sigma": args.noise_sigma}
+
+def _format_blocks(metrics) -> str:
+    names = sorted(name for name in metrics if name.startswith("block_") and name.endswith("_mse"))
+    return ", ".join(
+        f"B{name.removeprefix('block_').removesuffix('_mse')}:{metrics[name].total:.4f}"
+        for name in names
     )
+
+
+def train(config_path: str, *, run_id=None, device_name=None, noise_sigma=0.1, resume=None):
+    with open(config_path) as handle:
+        cfg = yaml.safe_load(handle)
+    epochs = int(cfg.get("epochs", 5))
+    device = (
+        torch.device(device_name)
+        if device_name
+        else torch.device("mps" if torch.backends.mps.is_available() else "cpu")
+    )
+    requested_run_id = _normalize_run_id(run_id) or _auto_run_id(cfg, config_path)
+    fingerprint = configuration_fingerprint({**cfg, "noise_sigma": noise_sigma})
     training_run = TrainingRun.open(
         "runs",
-        run_id,
-        resume=args.resume,
+        requested_run_id,
+        resume=resume,
         target_epochs=epochs,
-        config_fingerprint=run_fingerprint,
+        config_fingerprint=fingerprint,
     )
-    run_id = training_run.run_dir.name
-    ckpt_root, scores_root = training_run.checkpoints, training_run.scores
-    run_logger = training_run.logger()
-    run_logger.__enter__()
-    print(f"[noprop] run_id: {run_id}")
+    logger = training_run.logger()
+    logger.__enter__()
+    try:
+        print(f"[noprop] using device: {device}")
+        print(f"[noprop] run_id: {training_run.run_dir.name}")
+        train_paths = _ensure_path_list(None, cfg.get("train_npz"), "train_npz")
+        val_paths = _ensure_path_list(None, cfg.get("val_npz"), "val_npz")
+        contract = resolve_vocabulary_contract(
+            [*train_paths, *val_paths],
+            configured_path=cfg.get("itos_path"),
+            configured_size=cfg.get("vocab_size"),
+        )
+        cfg["vocab_size"] = contract.size
+        vocabulary_snapshot = snapshot_vocabulary(
+            contract, training_run.run_dir / "itos.txt"
+        )
+        cfg["itos_path"] = str(vocabulary_snapshot)
+        cfg["vocabulary"] = contract.provenance(vocabulary_snapshot)
+        write_vocabulary_manifest(
+            cfg["vocabulary"], training_run.run_dir / "vocabulary.json"
+        )
 
-    # Load datasets
-    train_paths = _ensure_path_list(None, cfg.get("train_npz"), "train_npz")
-    val_paths = _ensure_path_list(None, cfg.get("val_npz"), "val_npz")
-    contract = resolve_vocabulary_contract(
-        [*train_paths, *val_paths],
-        configured_path=cfg.get("itos_path"),
-        configured_size=cfg.get("vocab_size"),
+        train_ds = PackedDataset(train_paths)
+        val_ds = PackedDataset(val_paths)
+        collate_fn = dynamic_lm_collate_fn if train_ds.is_dynamic else None
+        seed = int(cfg.get("seed", 42))
+        train_generator = torch.Generator()
+        train_loader = DataLoader(
+            train_ds,
+            batch_size=int(cfg["batch_size"]),
+            shuffle=True,
+            collate_fn=collate_fn,
+            generator=train_generator,
+        )
+        val_loader = DataLoader(
+            val_ds,
+            batch_size=int(cfg["batch_size"]),
+            collate_fn=collate_fn,
+        )
+        model = NoPropTinyGPT(
+            vocab_size=cfg["vocab_size"],
+            block_size=cfg["block_size"],
+            n_layer=cfg["n_layer"],
+            n_head=cfg["n_head"],
+            n_embd=cfg["n_embd"],
+            dropout=cfg.get("dropout", 0.1),
+            sep_id=3 if cfg.get("sep_mask_enabled", True) else None,
+            n_kv_head=cfg.get("n_kv_head"),
+            use_sdpa=cfg.get("use_sdpa", False),
+        ).to(device)
+        lr = float(cfg.get("learning_rate", 5e-4))
+        opt_emb = torch.optim.AdamW(
+            [*model.tok_emb.parameters(), *model.pos_emb.parameters()], lr=lr
+        )
+        opts_blocks = [torch.optim.AdamW(block.parameters(), lr=lr) for block in model.blocks]
+        opt_head = torch.optim.AdamW(
+            [*model.ln_f.parameters(), *model.head.parameters()], lr=lr
+        )
+        task = NoPropTask(
+            model=model,
+            train_loader=train_loader,
+            validation_loader=val_loader,
+            device=device,
+            noise_sigma=noise_sigma,
+            train_generator=train_generator,
+            seed=seed,
+        )
+        curves_path = training_run.scores / "curves.csv"
+        if not curves_path.exists():
+            curves_path.write_text("epoch,train_ce,val_ce\n")
+        engine = TrainingEngine(
+            task=task,
+            strategy=NoPropUpdateStrategy(opt_emb, opts_blocks, opt_head),
+            run=training_run,
+            config=EngineConfig(
+                epochs=epochs,
+                grad_accum_steps=1,
+                monitor="loss",
+                best_checkpoint_pattern="best_epoch_{epoch:03d}.pt",
+            ),
+            device=device,
+            callbacks=[_NoPropConsole(curves_path)],
+            run_fingerprint=fingerprint,
+            checkpoint_decoder=decode_noprop_checkpoint,
+            checkpoint_payload_adapter=adapt_noprop_checkpoint,
+        )
+        return engine.fit()
+    finally:
+        training_run.close()
+        logger.__exit__(*sys.exc_info())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--run_id", default=None)
+    parser.add_argument("--device", default=None)
+    parser.add_argument("--noise_sigma", type=float, default=0.1)
+    parser.add_argument("--resume", default=None)
+    args = parser.parse_args()
+    train(
+        args.config,
+        run_id=args.run_id,
+        device_name=args.device,
+        noise_sigma=args.noise_sigma,
+        resume=args.resume,
     )
-    cfg["vocab_size"] = contract.size
-    vocabulary_snapshot = snapshot_vocabulary(contract, ckpt_root.parent / "itos.txt")
-    cfg["itos_path"] = str(vocabulary_snapshot)
-    cfg["vocabulary"] = contract.provenance(vocabulary_snapshot)
-    write_vocabulary_manifest(
-        cfg["vocabulary"], ckpt_root.parent / "vocabulary.json"
-    )
-    train_ds = PackedDataset(train_paths)
-    val_ds = PackedDataset(val_paths)
 
-    collate_fn = dynamic_lm_collate_fn if getattr(train_ds, "is_dynamic", False) else None
-
-    train_loader = DataLoader(train_ds, batch_size=cfg["batch_size"], shuffle=True, collate_fn=collate_fn)
-    val_loader = DataLoader(val_ds, batch_size=cfg["batch_size"], collate_fn=collate_fn)
-
-    # Initialize model
-    model = NoPropTinyGPT(
-        vocab_size=cfg["vocab_size"],
-        block_size=cfg["block_size"],
-        n_layer=cfg["n_layer"],
-        n_head=cfg["n_head"],
-        n_embd=cfg["n_embd"],
-        dropout=cfg.get("dropout", 0.1),
-        sep_id=(3 if cfg.get("sep_mask_enabled", True) else None),
-        n_kv_head=cfg.get("n_kv_head", None),
-        use_sdpa=cfg.get("use_sdpa", False)
-    ).to(device)
-
-    # Initialize layer-wise optimizers
-    lr = float(cfg.get("learning_rate", 5e-4))
-
-    # We create separate optimizers for:
-    # 1. Embedding layer
-    # 2. Each NoProp block
-    # 3. Output layer (LN_F and LM head)
-    opt_emb = torch.optim.AdamW(list(model.tok_emb.parameters()) + list(model.pos_emb.parameters()), lr=lr)
-    opts_blocks = [torch.optim.AdamW(block.parameters(), lr=lr) for block in model.blocks]
-    opt_head = torch.optim.AdamW(list(model.ln_f.parameters()) + list(model.head.parameters()), lr=lr)
-
-    noise_sigma = args.noise_sigma
-    start_epoch = 1
-    best_val_loss = float("inf")
-    if args.resume:
-        checkpoint = torch.load(args.resume, map_location=device, weights_only=False)
-        model.load_state_dict(checkpoint["model"])
-        opt_emb.load_state_dict(checkpoint["optimizers"]["embedding"])
-        for optimizer, state in zip(opts_blocks, checkpoint["optimizers"]["blocks"]):
-            optimizer.load_state_dict(state)
-        opt_head.load_state_dict(checkpoint["optimizers"]["head"])
-        best_val_loss = float(checkpoint.get("best_val_loss", float("inf")))
-        start_epoch = int(checkpoint["epoch"]) + 1
-        restore_rng_state(checkpoint.get("rng_state"))
-
-    print(f"[noprop] starting training for {epochs} epochs")
-    curves_path = scores_root / "curves.csv"
-    if not curves_path.exists():
-        curves_path.write_text("epoch,train_ce,val_ce\n")
-
-    for epoch in range(start_epoch, epochs + 1):
-        # Training loop
-        model.train()
-        train_loss_ce = 0.0
-        train_loss_blocks = [0.0] * len(model.blocks)
-        n_train = 0
-
-        for x, y in train_loader:
-            x, y = x.to(device), y.to(device)
-            B, T = x.shape
-            n_train += 1
-
-            # Get target embeddings
-            y_clean = model.tok_emb(y).detach()  # (B, T, C)
-            noise = torch.randn_like(y_clean) * noise_sigma
-            y_noisy = y_clean + noise
-            non_pad_mask = (y != 0).unsqueeze(-1).float()
-
-            # 1. Step embeddings
-            opt_emb.zero_grad()
-            pos = torch.arange(0, T, device=x.device).unsqueeze(0)
-            h = model.tok_emb(x) + model.pos_emb(pos)
-            h = model.drop(h)
-
-            attn_mask = None
-            if model.sep_id is not None:
-                sep = (x == int(model.sep_id))
-                seg = torch.cumsum(sep, dim=1)
-                attn_mask = (seg.unsqueeze(-1) == seg.unsqueeze(-2)).unsqueeze(1)
-
-            # Keep track of outputs without backpropagating between layers
-            h_prev = h
-
-            # Step-by-step block-wise training
-            for layer_index, block in enumerate(model.blocks):
-                # Detach context input from graph to stop gradient propagation
-                h_in = h_prev.detach() if layer_index > 0 else h_prev
-
-                opts_blocks[layer_index].zero_grad()
-                h_out, pred_y = block(h_in, noisy_targets=y_noisy, attn_mask=attn_mask)
-
-                loss_mse_elementwise = F.mse_loss(pred_y, y_clean, reduction="none")
-                loss_mse = (loss_mse_elementwise * non_pad_mask).sum() / (non_pad_mask.sum() * pred_y.size(-1) + 1e-8)
-                loss_mse.backward()
-
-                opts_blocks[layer_index].step()
-                if layer_index == 0:
-                    # Also update embeddings via block 0 output
-                    opt_emb.step()
-
-                train_loss_blocks[layer_index] += loss_mse.item()
-                h_prev = h_out
-
-            # 2. Step final head
-            opt_head.zero_grad()
-            h_final = model.ln_f(h_prev.detach())
-            logits = model.head(h_final)
-
-            loss_ce = F.cross_entropy(logits.view(-1, logits.size(-1)), y.view(-1), ignore_index=0)
-            loss_ce.backward()
-            opt_head.step()
-
-            train_loss_ce += loss_ce.item()
-
-        # Validation loop
-        model.eval()
-        val_loss_ce = 0.0
-        val_loss_blocks = [0.0] * len(model.blocks)
-        n_val = 0
-
-        with torch.no_grad():
-            for x, y in val_loader:
-                x, y = x.to(device), y.to(device)
-                B, T = x.shape
-                n_val += 1
-
-                y_clean = model.tok_emb(y)
-                non_pad_mask = (y != 0).unsqueeze(-1).float()
-                pos = torch.arange(0, T, device=x.device).unsqueeze(0)
-                h = model.tok_emb(x) + model.pos_emb(pos)
-                h = model.drop(h)
-
-                attn_mask = None
-                if model.sep_id is not None:
-                    sep = (x == int(model.sep_id))
-                    seg = torch.cumsum(sep, dim=1)
-                    attn_mask = (seg.unsqueeze(-1) == seg.unsqueeze(-2)).unsqueeze(1)
-
-                h_prev = h
-                for layer_index, block in enumerate(model.blocks):
-                    h_out, pred_y = block(h_prev, noisy_targets=y_clean, attn_mask=attn_mask)
-                    loss_mse_elementwise = F.mse_loss(pred_y, y_clean, reduction="none")
-                    loss_mse = (loss_mse_elementwise * non_pad_mask).sum() / (non_pad_mask.sum() * pred_y.size(-1) + 1e-8)
-                    val_loss_blocks[layer_index] += loss_mse.item()
-                    h_prev = h_out
-
-                h_final = model.ln_f(h_prev)
-                logits = model.head(h_final)
-                loss_ce = F.cross_entropy(logits.view(-1, logits.size(-1)), y.view(-1), ignore_index=0)
-                val_loss_ce += loss_ce.item()
-
-        # Print statistics
-        print(f"Epoch {epoch}/{epochs}:")
-        train_block_str = ", ".join([f"B{i}:{train_loss_blocks[i]/n_train:.4f}" for i in range(len(model.blocks))])
-        val_block_str = ", ".join([f"B{i}:{val_loss_blocks[i]/n_val:.4f}" for i in range(len(model.blocks))])
-        print(f"  Train Block MSEs: {train_block_str} | CE Loss: {train_loss_ce/n_train:.4f}")
-        print(f"  Val Block MSEs:   {val_block_str} | CE Loss: {val_loss_ce/n_val:.4f}")
-
-        # Save checkpoint
-        avg_val_loss = val_loss_ce / n_val
-        payload = {
-            "model": model.state_dict(),
-            "optimizers": {
-                "embedding": opt_emb.state_dict(),
-                "blocks": [optimizer.state_dict() for optimizer in opts_blocks],
-                "head": opt_head.state_dict(),
-            },
-            "epoch": epoch,
-            "epoch_complete": True,
-            "val_loss": avg_val_loss,
-            "best_val_loss": min(best_val_loss, avg_val_loss),
-            "run_fingerprint": run_fingerprint,
-            "rng_state": capture_rng_state(),
-            "run_progress": {
-                "completed_epochs": epoch,
-                "current_epoch": epoch,
-                "microbatch": 0,
-                "optimizer_step": epoch * len(train_loader),
-            },
-        }
-        save_checkpoint_atomic(payload, ckpt_root / "last.pt")
-        with curves_path.open("a") as handle:
-            handle.write(f"{epoch},{train_loss_ce / n_train:.6f},{avg_val_loss:.6f}\n")
-        if avg_val_loss < best_val_loss:
-            best_val_loss = avg_val_loss
-            ckpt_path = ckpt_root / "best.pt"
-            save_checkpoint_atomic(payload, ckpt_path)
-            save_checkpoint_atomic(payload, ckpt_root / f"best_epoch_{epoch:03d}.pt")
-            print(f"  [noprop] saved new best checkpoint to {ckpt_path}")
-
-    training_run.mark_complete(
-        {"completed_epochs": epochs, "best_validation_loss": best_val_loss}
-    )
-    training_run.close()
 
 if __name__ == "__main__":
     main()

--- a/tests/test_noprop.py
+++ b/tests/test_noprop.py
@@ -1,7 +1,18 @@
-import torch
+import copy
+
 import torch.nn.functional as F
-import pytest
+import torch
+
 from src.codonlm.model_tiny_gpt import NoPropTinyGPT, NoPropBlock
+from src.codonlm.noprop_task import (
+    NoPropTask,
+    NoPropUpdateStrategy,
+    adapt_noprop_checkpoint,
+    decode_noprop_checkpoint,
+)
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.contracts import TrainingPhase
+from src.training.run_lifecycle import TrainingRun
 
 def test_noprop_initialization():
     vocab_size = 64
@@ -88,3 +99,177 @@ def test_noprop_inference_forward():
     assert logits.shape == (2, block_size, vocab_size)
     assert len(preds) == 2
     assert preds[0].shape == (2, block_size, 16)
+
+
+def _small_model():
+    return NoPropTinyGPT(
+        vocab_size=16,
+        block_size=5,
+        n_layer=2,
+        n_head=1,
+        n_embd=8,
+        dropout=0.0,
+        sep_id=None,
+    )
+
+
+def _optimizers(model):
+    lr = 1e-3
+    embedding = torch.optim.AdamW(
+        [*model.tok_emb.parameters(), *model.pos_emb.parameters()], lr=lr
+    )
+    blocks = [torch.optim.AdamW(block.parameters(), lr=lr) for block in model.blocks]
+    head = torch.optim.AdamW(
+        [*model.ln_f.parameters(), *model.head.parameters()], lr=lr
+    )
+    return embedding, blocks, head
+
+
+def _task_and_strategy(model, batches, *, sigma=0.1):
+    embedding, blocks, head = _optimizers(model)
+    task = NoPropTask(
+        model=model,
+        train_loader=batches,
+        validation_loader=batches[:1],
+        device=torch.device("cpu"),
+        noise_sigma=sigma,
+        seed=17,
+    )
+    return task, NoPropUpdateStrategy(embedding, blocks, head)
+
+
+def _assert_nested_equal(actual, expected):
+    if torch.is_tensor(expected):
+        assert torch.equal(actual, expected)
+    elif isinstance(expected, dict):
+        assert actual.keys() == expected.keys()
+        for key in expected:
+            _assert_nested_equal(actual[key], expected[key])
+    elif isinstance(expected, list):
+        assert len(actual) == len(expected)
+        for actual_item, expected_item in zip(actual, expected, strict=True):
+            _assert_nested_equal(actual_item, expected_item)
+    else:
+        assert actual == expected
+
+
+def test_noprop_shared_engine_matches_direct_local_update(tmp_path):
+    batches = [(torch.tensor([[1, 2, 3, 4, 5]]), torch.tensor([[2, 3, 4, 5, 6]]))]
+    torch.manual_seed(7)
+    engine_model = _small_model()
+    direct_model = copy.deepcopy(engine_model)
+    engine_task, strategy = _task_and_strategy(engine_model, batches)
+    direct_task, direct_strategy = _task_and_strategy(direct_model, batches)
+
+    torch.manual_seed(29)
+    direct_strategy.begin_group(1)
+    direct_task.begin_phase(TrainingPhase.TRAIN, 0)
+    direct_strategy.process_microbatch(direct_task, batches[0], None)
+    direct_strategy.commit_group()
+
+    torch.manual_seed(29)
+    run = TrainingRun.open(tmp_path, "noprop-parity")
+    engine = TrainingEngine(
+        task=engine_task,
+        strategy=strategy,
+        run=run,
+        config=EngineConfig(epochs=1),
+        device=torch.device("cpu"),
+    )
+    result = engine.fit()
+    run.close()
+
+    assert result.state.optimizer_step == 1
+    for actual, expected in zip(engine_model.parameters(), direct_model.parameters()):
+        assert torch.allclose(actual, expected)
+
+
+class _ExpireOnce:
+    def __init__(self):
+        self.calls = 0
+
+    def expired(self):
+        self.calls += 1
+        return self.calls == 1
+
+
+def test_noprop_interrupted_resume_matches_uninterrupted(tmp_path):
+    batches = [
+        (torch.tensor([[1, 2, 3, 4, 5]]), torch.tensor([[2, 3, 4, 5, 6]])),
+        (torch.tensor([[6, 7, 8, 9, 10]]), torch.tensor([[7, 8, 9, 10, 11]])),
+    ]
+    torch.manual_seed(41)
+    initial = copy.deepcopy(_small_model().state_dict())
+
+    def build(run, timer=None):
+        model = _small_model()
+        model.load_state_dict(initial)
+        task, strategy = _task_and_strategy(model, batches)
+        return model, TrainingEngine(
+            task=task,
+            strategy=strategy,
+            run=run,
+            config=EngineConfig(epochs=1),
+            device=torch.device("cpu"),
+            wall_timer=timer,
+            checkpoint_decoder=decode_noprop_checkpoint,
+            checkpoint_payload_adapter=adapt_noprop_checkpoint,
+        )
+
+    torch.manual_seed(53)
+    reference_run = TrainingRun.open(tmp_path, "noprop-reference")
+    reference_model, reference_engine = build(reference_run)
+    reference_engine.fit()
+    expected = copy.deepcopy(reference_model.state_dict())
+    reference_checkpoint = torch.load(
+        reference_run.checkpoints / "last.pt", map_location="cpu", weights_only=False
+    )
+    reference_run.close()
+
+    torch.manual_seed(53)
+    interrupted_run = TrainingRun.open(tmp_path, "noprop-resume")
+    _, interrupted_engine = build(interrupted_run, _ExpireOnce())
+    result = interrupted_engine.fit()
+    assert result.status == "interrupted"
+    checkpoint = interrupted_run.checkpoints / "last.pt"
+    interrupted_run.close()
+
+    resumed_run = TrainingRun.open(
+        tmp_path, "noprop-resume", resume=checkpoint, target_epochs=1
+    )
+    resumed_model, resumed_engine = build(resumed_run)
+    resumed = resumed_engine.fit()
+    resumed_run.close()
+
+    assert resumed.status == "complete"
+    assert resumed.state.optimizer_step == 2
+    for name, tensor in resumed_model.state_dict().items():
+        assert torch.allclose(tensor, expected[name])
+    resumed_checkpoint = torch.load(
+        resumed_run.checkpoints / "last.pt", map_location="cpu", weights_only=False
+    )
+    _assert_nested_equal(
+        resumed_checkpoint["strategy"]["optimizers"],
+        reference_checkpoint["strategy"]["optimizers"],
+    )
+
+
+def test_noprop_legacy_checkpoint_translation_preserves_optimizer_groups():
+    model = _small_model()
+    embedding, blocks, head = _optimizers(model)
+    legacy = {
+        "model": model.state_dict(),
+        "optimizers": {
+            "embedding": embedding.state_dict(),
+            "blocks": [optimizer.state_dict() for optimizer in blocks],
+            "head": head.state_dict(),
+        },
+        "epoch": 2,
+        "best_val_loss": 1.5,
+        "rng_state": {},
+    }
+    checkpoint = decode_noprop_checkpoint(legacy)
+
+    assert checkpoint.engine.completed_epochs == 2
+    assert checkpoint.metadata["best_metric"] == 1.5
+    assert len(checkpoint.strategy["optimizers"]["blocks"]) == 2


### PR DESCRIPTION
## Summary
- add a NoProp task adapter and layer-local update strategy without model-specific engine branches
- preserve embedding, per-block, and head update topology plus legacy checkpoint aliases and curves
- add fixed-seed direct-update parity, exact interrupted resume, and complete optimizer-state tests
- complete Phase 5 documentation and update the development log

## Behavioral constraints
- NoProp remains one optimizer commit per microbatch; gradient accumulation is explicitly fixed at 1 because accumulation would change the algorithm
- frozen backbones and discriminative learning rates remain standard optimizer parameter-group concerns, not custom strategies

## Testing
- Ruff on changed Python files
- NoProp tests: 6 passed
- Full suite: 426 passed, 1 skipped, 1 xpassed