### PR TITLE
Migrate protein feature heads to shared engine

### DIFF
--- a/docs/DEVELOPMENT_LOG.md
+++ b/docs/DEVELOPMENT_LOG.md
@@ -1155,6 +1155,14 @@ Stage 2.6 review before freezing new datasets or rerunning scientific benchmarks
     validation, best/last checkpoints, RNG restoration, run completion, and callback
     reporting while legacy NoProp checkpoint aliases remain available. Fixed-seed
     tests cover direct-update parity, legacy translation, and interrupted resume.
+*   **Protein Feature-Head Migration (2026-08-09):** Migrated the standalone
+    Pfam, EC, and categorical-stability MLP feature classifiers to the shared
+    engine. A single AdamW instance remains equivalent to the former independent
+    optimizers because only one head receives gradients per batch, while enabling
+    atomic optimizer-boundary checkpoints and exact deterministic resume. Runs are
+    collision-safe, retain independently selected best states for every head, emit
+    per-head curves and a legacy-format unified artifact, and reject missing or
+    out-of-vocabulary labels instead of silently producing incomplete checkpoints.
 
 ---
 *End of Log*

--- a/docs/TRAINING_ENTRYPOINT_INVENTORY.md
+++ b/docs/TRAINING_ENTRYPOINT_INVENTORY.md
@@ -12,7 +12,7 @@ Diagnostic harnesses may execute optimizer steps but are not production trainers
 | `src/protein_lm/train_multi_task.py` | bidirectional multitask ProteinCritic | AdamW, accumulated backprop, mixed classification/regression loss | optimizer boundary | Phase 3 |
 | `src/protein_lm/train_ebm.py` | latent real-versus-corrupted ranking | shared engine: AdamW on EBM head; frozen critic | optimizer boundary | Phase 3 migrated |
 | `src/codonlm/train_noprop.py` | layer-local NoProp codon model | shared engine: embedding, per-block, and head optimizers committed by `NoPropUpdateStrategy` | optimizer boundary | Phase 5 migrated |
-| `src/protein_lm/train_mlp_heads.py` | standalone heads over frozen features | one AdamW optimizer per head | none | ancillary; migrate or explicitly guard |
+| `src/protein_lm/train_mlp_heads.py` | Pfam/EC/stability classifiers over frozen feature arrays | shared engine: one AdamW optimizer with independent head parameters | optimizer boundary | ancillary migrated |
 | `scripts/train_biophysics_fusion.py` | nucleotide biophysics encoder pretraining/fusion assembly | AdamW encoder pretraining | none | ancillary; migrate or explicitly guard |
 
 ## Diagnostic And Library Code
@@ -49,6 +49,12 @@ for algorithms that change update timing or gradient flow. NoProp is the referen
 its strategy owns the embedding, per-block, and head optimizers, while its task owns
 the layer-local denoising objectives and explicit detach boundaries. The generic
 engine requires no model-name branch.
+
+The feature-head trainer treats `--out_dir` as a collision-safe run root. Each run
+stores versioned `last.pt`/`best.pt` checkpoints, the selected legacy-format
+`checkpoints/mlp_heads.pt`, per-head loss curves, and a run log. Use `--resume` with
+the newest `last.pt` and the allocated `--run_id`; periodic and wall-time controls
+are available through `--checkpoint_every_steps` and `--max_time_minutes`.
 
 ## Checkpoint Compatibility Rules
 

--- a/src/protein_lm/mlp_heads_task.py
+++ b/src/protein_lm/mlp_heads_task.py
@@ -1,0 +1,145 @@
+"""Shared-engine task for independent classifiers over frozen features."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from src.training.contracts import MetricValue, StepContext, StepOutput, TrainingPhase
+
+
+@dataclass(frozen=True)
+class HeadBatch:
+    task_name: str
+    features: torch.Tensor
+    labels: torch.Tensor
+
+
+class HeadBatchStream:
+    """Present several finite head-specific loaders as one engine batch stream."""
+
+    def __init__(self, loaders: Mapping[str, Any]) -> None:
+        self.loaders = dict(loaders)
+
+    def __len__(self) -> int:
+        return sum(len(loader) for loader in self.loaders.values())
+
+    def __iter__(self):
+        for task_name, loader in self.loaders.items():
+            for batch in loader:
+                yield HeadBatch(task_name, batch["X"], batch["label"])
+
+
+class MLPHeadsTask:
+    """Independent cross-entropy objectives sharing a checkpointed head container."""
+
+    def __init__(
+        self,
+        *,
+        model: nn.Module,
+        train_loaders: Mapping[str, Any],
+        validation_loaders: Mapping[str, Any],
+        device: torch.device,
+        train_generators: Mapping[str, torch.Generator],
+        seed: int,
+        task_dims: Mapping[str, int],
+    ) -> None:
+        self.model = model
+        self.train_loaders = dict(train_loaders)
+        self.validation_loaders = dict(validation_loaders)
+        self.device = device
+        self.train_generators = dict(train_generators)
+        self.seed = int(seed)
+        self.task_dims = dict(task_dims)
+        self.criterion = nn.CrossEntropyLoss()
+        self.best_validation_losses = {
+            name: float("inf") for name in self.task_dims
+        }
+        self.best_head_states: dict[str, Mapping[str, Any]] = {}
+        self._loss_totals: dict[str, float] = {}
+        self._loss_counts: dict[str, int] = {}
+
+    def begin_phase(self, phase: TrainingPhase, epoch: int) -> None:
+        self._loss_totals = {}
+        self._loss_counts = {}
+        if phase == TrainingPhase.TRAIN:
+            for offset, generator in enumerate(self.train_generators.values()):
+                generator.manual_seed(self.seed + epoch + offset * 1_000_003)
+            self.model.train()
+        else:
+            self.model.eval()
+
+    def end_phase(self, phase: TrainingPhase, epoch: int):
+        metrics = {
+            f"{name}_loss": MetricValue(
+                self._loss_totals[name] / self._loss_counts[name]
+            )
+            for name in self._loss_totals
+        }
+        if phase == TrainingPhase.VALIDATION:
+            for name in self.task_dims:
+                loss = metrics[f"{name}_loss"].total
+                if loss < self.best_validation_losses[name]:
+                    self.best_validation_losses[name] = loss
+                    self.best_head_states[name] = copy.deepcopy(
+                        self.model.heads[name].state_dict()
+                    )
+        return metrics
+
+    def train_batches(self, epoch: int):
+        return HeadBatchStream(self.train_loaders)
+
+    def validation_batches(self, epoch: int):
+        return HeadBatchStream(self.validation_loaders)
+
+    def training_step(self, batch: HeadBatch, context: StepContext) -> StepOutput:
+        return self._step(batch)
+
+    def validation_step(self, batch: HeadBatch, context: StepContext) -> StepOutput:
+        return self._step(batch)
+
+    def _step(self, batch: HeadBatch) -> StepOutput:
+        features = batch.features.to(self.device)
+        labels = batch.labels.to(self.device)
+        logits = self.model.heads[batch.task_name](features)
+        loss = self.criterion(logits, labels)
+        detached_loss = float(loss.detach())
+        self._loss_totals[batch.task_name] = (
+            self._loss_totals.get(batch.task_name, 0.0) + detached_loss
+        )
+        self._loss_counts[batch.task_name] = self._loss_counts.get(batch.task_name, 0) + 1
+        return StepOutput(
+            loss=loss,
+            metrics={"loss": MetricValue(detached_loss)},
+            committed_units={"samples": int(labels.size(0))},
+        )
+
+    def restore_best_heads(self) -> None:
+        missing = set(self.task_dims).difference(self.best_head_states)
+        if missing:
+            raise RuntimeError(f"no selected checkpoint for heads: {sorted(missing)}")
+        for name, state in self.best_head_states.items():
+            self.model.heads[name].load_state_dict(state)
+
+    def state_dict(self) -> Mapping[str, Any]:
+        return {
+            "model": self.model.state_dict(),
+            "task_dims": self.task_dims,
+            "best_validation_losses": self.best_validation_losses,
+            "best_head_states": self.best_head_states,
+        }
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        if dict(state["task_dims"]) != self.task_dims:
+            raise ValueError("checkpoint task dimensions differ from configured vocabularies")
+        self.model.load_state_dict(state["model"])
+        self.best_validation_losses = {
+            name: float(value)
+            for name, value in state.get("best_validation_losses", {}).items()
+        }
+        self.best_head_states = dict(state.get("best_head_states", {}))

--- a/src/protein_lm/train_mlp_heads.py
+++ b/src/protein_lm/train_mlp_heads.py
@@ -1,200 +1,286 @@
+#!/usr/bin/env python3
+"""Train independent MLP feature heads through the shared training engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
-import json
-import argparse
-import numpy as np
-from pathlib import Path
 from sklearn.metrics import accuracy_score
+from torch.utils.data import DataLoader, Dataset
+
+from src.protein_lm.mlp_heads_task import MLPHeadsTask
+from src.training.engine import EngineConfig, TrainingEngine
+from src.training.run_lifecycle import TrainingRun, configuration_fingerprint
+from src.training.runtime import (
+    PeriodicCheckpointPolicy,
+    WallTimer,
+    default_device,
+    save_checkpoint_atomic,
+)
+from src.training.strategies import AccumulatedBackpropStrategy
+
 
 class TaskFeatureDataset(Dataset):
-    def __init__(self, npz_path, task_name):
-        data = np.load(npz_path)
-        X = torch.tensor(data["X"], dtype=torch.float32)
-        y = torch.tensor(data[f"y_{task_name}"], dtype=torch.long)
-        
-        # Filter out unlabelled samples (where label is -1)
-        mask = y != -1
-        self.X = X[mask]
-        self.y = y[mask]
+    def __init__(self, npz_path, task_name, *, num_classes: int):
+        with np.load(npz_path) as data:
+            features = torch.as_tensor(data["X"], dtype=torch.float32)
+            labels = torch.as_tensor(data[f"y_{task_name}"], dtype=torch.long)
+        if features.ndim != 2 or labels.ndim != 1 or len(features) != len(labels):
+            raise ValueError(f"invalid feature/label shapes for task {task_name!r}")
+        mask = labels.ne(-1)
+        self.X = features[mask]
+        self.y = labels[mask]
+        if len(self.y) and (int(self.y.min()) < 0 or int(self.y.max()) >= num_classes):
+            raise ValueError(f"labels for task {task_name!r} exceed its vocabulary")
 
     def __len__(self):
         return len(self.X)
 
-    def __getitem__(self, idx):
-        return {
-            "X": self.X[idx],
-            "label": self.y[idx]
-        }
+    def __getitem__(self, index):
+        return {"X": self.X[index], "label": self.y[index]}
+
 
 class MultiTaskMLPClassifier(nn.Module):
     def __init__(self, input_dim, task_dims):
         super().__init__()
-        # 2-layer MLP head per task
-        self.heads = nn.ModuleDict({
-            name: nn.Sequential(
-                nn.Linear(input_dim, 256),
-                nn.ReLU(),
-                nn.Dropout(0.1),
-                nn.Linear(256, dim)
-            ) for name, dim in task_dims.items()
-        })
+        self.heads = nn.ModuleDict(
+            {
+                name: nn.Sequential(
+                    nn.Linear(input_dim, 256),
+                    nn.ReLU(),
+                    nn.Dropout(0.1),
+                    nn.Linear(256, dim),
+                )
+                for name, dim in task_dims.items()
+            }
+        )
 
-    def forward(self, x):
-        return {name: head(x) for name, head in self.heads.items()}
+    def forward(self, features):
+        return {name: head(features) for name, head in self.heads.items()}
 
-def train_mlp_heads(train_npz, val_npz, vocabs_json, epochs=100, batch_size=64, lr=1e-3, out_dir="runs/protein_critic/checkpoints"):
-    device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
-    print(f"[*] Using device: {device}")
 
-    # Load vocabs
-    with open(vocabs_json, "r") as f:
-        vocabs = json.load(f)
-    task_dims = {
-        "family": len(vocabs["pfam"]),
-        "function": len(vocabs["ec"]),
-        "stability": len(vocabs["stability"])
-    }
+class _MLPHeadArtifacts:
+    def __init__(self, *, task, path: Path, curves_path: Path, epochs: int) -> None:
+        self.task = task
+        self.path = path
+        self.curves_path = curves_path
+        self.epochs = epochs
 
-    # Initialize model
-    # Load first npz to inspect dimensions
-    dummy_data = np.load(train_npz)
-    input_dim = dummy_data["X"].shape[1]
-    
-    model = MultiTaskMLPClassifier(input_dim, task_dims).to(device)
-    out_path = Path(out_dir)
-    out_path.mkdir(parents=True, exist_ok=True)
+    def on_event(self, event) -> None:
+        if event.name != "epoch_completed":
+            return
+        epoch = int(event.metadata["epoch"])
+        train = event.metadata["training_metrics"]
+        validation = event.metrics
+        summary = ", ".join(
+            f"{name}: train={train[f'{name}_loss'].total:.4f} "
+            f"val={validation[f'{name}_loss'].total:.4f}"
+            for name in self.task.task_dims
+        )
+        row = [str(epoch)]
+        for name in self.task.task_dims:
+            row.extend(
+                [
+                    f"{train[f'{name}_loss'].total:.6f}",
+                    f"{validation[f'{name}_loss'].total:.6f}",
+                ]
+            )
+        with self.curves_path.open("a") as handle:
+            handle.write(",".join(row) + "\n")
+        print(f"Epoch {epoch:03d}/{self.epochs:03d} | {summary}", flush=True)
+        if epoch == self.epochs:
+            self.task.restore_best_heads()
+            save_checkpoint_atomic(dict(self.task.model.state_dict()), self.path)
+            print(f"[success] Saved selected MLP heads to {self.path}", flush=True)
 
-    print(f"[*] Training independent MLP heads on {input_dim}-dim features...")
 
-    for task_name, task_dim in task_dims.items():
-        print(f"\n[*] Task: {task_name} (dimension: {task_dim})")
-        train_ds = TaskFeatureDataset(train_npz, task_name)
-        val_ds = TaskFeatureDataset(val_npz, task_name)
-        
-        if len(train_ds) == 0:
-            print(f"[!] Warning: No training samples for task {task_name}. Skipping.")
-            continue
-            
-        train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
-        val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False)
+def _load_task_dims(vocabs_json) -> dict[str, int]:
+    with open(vocabs_json) as handle:
+        vocabs = json.load(handle)
+    required = {"pfam": "family", "ec": "function", "stability": "stability"}
+    missing = set(required).difference(vocabs)
+    if missing:
+        raise ValueError(f"task vocabularies are missing: {sorted(missing)}")
+    task_dims = {task: len(vocabs[source]) for source, task in required.items()}
+    invalid = [name for name, size in task_dims.items() if size < 2]
+    if invalid:
+        raise ValueError(f"classification heads require at least two classes: {invalid}")
+    return task_dims
 
-        head = model.heads[task_name]
-        optimizer = torch.optim.AdamW(head.parameters(), lr=lr, weight_decay=0.01)
-        criterion = nn.CrossEntropyLoss()
 
-        best_val_loss = float("inf")
-        best_head_state = None
+def _make_loaders(path, task_dims, batch_size, *, shuffle, seed):
+    loaders = {}
+    generators = {}
+    for name, dimension in task_dims.items():
+        dataset = TaskFeatureDataset(path, name, num_classes=dimension)
+        if len(dataset) == 0:
+            raise ValueError(f"no labeled samples for task {name!r} in {path}")
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        loaders[name] = DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            generator=generator if shuffle else None,
+        )
+        generators[name] = generator
+    return loaders, generators
 
-        print(f"  Training on {len(train_ds)} samples, validating on {len(val_ds)} samples...")
 
-        for epoch in range(epochs):
-            head.train()
-            train_loss = 0.0
-            for batch in train_loader:
-                X = batch["X"].to(device)
-                targets = batch["label"].to(device)
-
-                optimizer.zero_grad()
-                logits = head(X)
-                loss = criterion(logits, targets)
-                loss.backward()
-                optimizer.step()
-                train_loss += loss.item()
-
-            train_loss /= len(train_loader)
-
-            # Validation
-            head.eval()
-            val_loss = 0.0
-            with torch.no_grad():
-                for batch in val_loader:
-                    X = batch["X"].to(device)
-                    targets = batch["label"].to(device)
-                    logits = head(X)
-                    loss = criterion(logits, targets)
-                    val_loss += loss.item()
-            val_loss /= len(val_loader)
-
-            if val_loss < best_val_loss:
-                best_val_loss = val_loss
-                best_head_state = {k: v.cpu().clone() for k, v in head.state_dict().items()}
-
-            if (epoch + 1) % 10 == 0 or epoch == 0:
-                print(f"  Epoch {epoch+1:03d}/{epochs:03d} | Train Loss: {train_loss:.4f} | Val Loss: {val_loss:.4f}")
-
-        # Load best state for this head
-        head.load_state_dict(best_head_state)
-        print(f"[success] Completed training {task_name} head. Best Val Loss: {best_val_loss:.4f}")
-
-    # Save overall model state dict
-    torch.save(model.state_dict(), out_path / "mlp_heads.pt")
-    print(f"\n[success] Saved unified MLP heads checkpoint to {out_path / 'mlp_heads.pt'}")
-
-    # Final evaluation with Top-K metrics
-    print("\n[*] Evaluating final independent MLP heads...")
+def _evaluate(model, loaders, device):
     model.eval()
-
-    results = {task: {"preds": [], "targets": [], "top5": [], "top10": []} for task in task_dims}
-
     with torch.no_grad():
-        for task in task_dims:
-            val_ds = TaskFeatureDataset(val_npz, task)
-            if len(val_ds) == 0:
-                continue
-            val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False)
-            head = model.heads[task]
-            head.eval()
-            
-            for batch in val_loader:
-                X = batch["X"].to(device)
-                targets = batch["label"]
-                logits = head(X)
+        for name, loader in loaders.items():
+            predictions, targets, top5, top10 = [], [], [], []
+            for batch in loader:
+                labels = batch["label"]
+                logits = model.heads[name](batch["X"].to(device))
+                predictions.extend(logits.argmax(dim=-1).cpu().tolist())
+                targets.extend(labels.tolist())
+                k = min(10, logits.size(-1))
+                topk = torch.topk(logits, k=k, dim=-1).indices.cpu()
+                correct = topk.eq(labels.unsqueeze(-1))
+                top5.extend(correct[:, : min(5, k)].any(dim=-1).tolist())
+                top10.extend(correct.any(dim=-1).tolist())
+            print(f"Task: {name} | Top-1 Accuracy: {accuracy_score(targets, predictions):.4f}")
+            if name in {"family", "function"}:
+                print(
+                    f"  Top-5 Accuracy: {sum(top5) / len(top5):.4f} | "
+                    f"Top-10 Accuracy: {sum(top10) / len(top10):.4f}"
+                )
 
-                preds = torch.argmax(logits, dim=-1)
-                results[task]["preds"].extend(preds.cpu().tolist())
-                results[task]["targets"].extend(targets.tolist())
 
-                # Top-K
-                num_classes = logits.size(-1)
-                k_val = min(10, num_classes)
-                _, topk_idx = torch.topk(logits, k=k_val, dim=-1)
-                correct_topk = (topk_idx == targets.unsqueeze(-1).to(device))
+def train_mlp_heads(
+    train_npz,
+    val_npz,
+    vocabs_json,
+    epochs=100,
+    batch_size=64,
+    lr=1e-3,
+    out_dir="runs/protein_critic",
+    *,
+    run_id=None,
+    resume=None,
+    seed=1337,
+    device_name=None,
+    max_time_minutes=None,
+    checkpoint_every_steps=0,
+):
+    for name, value in {"epochs": epochs, "batch_size": batch_size}.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError(f"{name} must be a positive integer")
+    if isinstance(lr, bool) or not isinstance(lr, (int, float)) or lr <= 0:
+        raise ValueError("lr must be positive")
+    if checkpoint_every_steps < 0:
+        raise ValueError("checkpoint_every_steps must be non-negative")
+    if max_time_minutes is not None and max_time_minutes < 0:
+        raise ValueError("max_time_minutes must be non-negative")
+    task_dims = _load_task_dims(vocabs_json)
+    with np.load(train_npz) as data:
+        input_dim = int(data["X"].shape[1])
+    fingerprint_data = {
+        "train_npz": str(Path(train_npz).resolve()),
+        "val_npz": str(Path(val_npz).resolve()),
+        "vocabs_json": str(Path(vocabs_json).resolve()),
+        "task_dims": task_dims,
+        "input_dim": input_dim,
+        "epochs": epochs,
+        "batch_size": batch_size,
+        "lr": lr,
+        "seed": seed,
+    }
+    fingerprint = configuration_fingerprint(fingerprint_data)
+    training_run = TrainingRun.open(
+        out_dir,
+        run_id or "mlp-heads",
+        resume=resume,
+        target_epochs=epochs,
+        config_fingerprint=fingerprint,
+    )
+    logger = training_run.logger()
+    logger.__enter__()
+    try:
+        device = torch.device(device_name) if device_name else default_device()
+        torch.manual_seed(seed)
+        train_loaders, generators = _make_loaders(
+            train_npz, task_dims, batch_size, shuffle=True, seed=seed
+        )
+        validation_loaders, _ = _make_loaders(
+            val_npz, task_dims, batch_size, shuffle=False, seed=seed
+        )
+        model = MultiTaskMLPClassifier(input_dim, task_dims).to(device)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=0.01)
+        task = MLPHeadsTask(
+            model=model,
+            train_loaders=train_loaders,
+            validation_loaders=validation_loaders,
+            device=device,
+            train_generators=generators,
+            seed=seed,
+            task_dims=task_dims,
+        )
+        artifact_path = training_run.checkpoints / "mlp_heads.pt"
+        curves_path = training_run.scores / "curves.csv"
+        if not curves_path.exists():
+            columns = ["epoch"]
+            for name in task_dims:
+                columns.extend([f"train_{name}_loss", f"val_{name}_loss"])
+            curves_path.write_text(",".join(columns) + "\n")
+        engine = TrainingEngine(
+            task=task,
+            strategy=AccumulatedBackpropStrategy(optimizer, parameters=model.parameters()),
+            run=training_run,
+            config=EngineConfig(epochs=epochs, grad_accum_steps=1),
+            device=device,
+            callbacks=[
+                _MLPHeadArtifacts(
+                    task=task,
+                    path=artifact_path,
+                    curves_path=curves_path,
+                    epochs=epochs,
+                )
+            ],
+            wall_timer=WallTimer(max_time_minutes),
+            checkpoint_policy=PeriodicCheckpointPolicy(
+                every_steps=checkpoint_every_steps
+            ),
+            run_fingerprint=fingerprint,
+        )
+        result = engine.fit()
+        if result.status == "complete":
+            _evaluate(model, validation_loaders, device)
+        return result
+    finally:
+        training_run.close()
+        logger.__exit__(*sys.exc_info())
 
-                k5 = min(5, num_classes)
-                has_top5 = correct_topk[:, :k5].any(dim=-1).cpu().tolist()
-                has_top10 = correct_topk[:, :k_val].any(dim=-1).cpu().tolist()
-
-                results[task]["top5"].extend(has_top5)
-                results[task]["top10"].extend(has_top10)
-
-    for task in task_dims:
-        y_true = results[task]["targets"]
-        y_pred = results[task]["preds"]
-        if len(y_true) > 0:
-            acc = accuracy_score(y_true, y_pred)
-            print("==================================================")
-            print(f"Task: {task}")
-            print(f"  Samples evaluated: {len(y_true)}")
-            print(f"  Top-1 Accuracy: {acc:.4f}")
-            if task in ["family", "function"]:
-                top5_acc = sum(results[task]["top5"]) / len(y_true)
-                top10_acc = sum(results[task]["top10"]) / len(y_true)
-                print(f"  Top-5 Accuracy: {top5_acc:.4f}")
-                print(f"  Top-10 Accuracy: {top10_acc:.4f}")
-            print("--------------------------------------------------")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--train_npz", required=True, help="Path to train features NPZ")
-    parser.add_argument("--val_npz", required=True, help="Path to val features NPZ")
-    parser.add_argument("--vocabs", default="data/processed/protein_lm/multitask/task_vocabs.json", help="Path to task vocabs json")
+    parser.add_argument("--val_npz", required=True, help="Path to validation features NPZ")
+    parser.add_argument(
+        "--vocabs",
+        default="data/processed/protein_lm/multitask/task_vocabs.json",
+        help="Path to task vocabularies JSON",
+    )
     parser.add_argument("--epochs", type=int, default=100)
     parser.add_argument("--batch_size", type=int, default=64)
     parser.add_argument("--lr", type=float, default=1e-3)
-    parser.add_argument("--out_dir", default="runs/protein_critic/checkpoints")
+    parser.add_argument("--out_dir", default="runs/protein_critic")
+    parser.add_argument("--run_id")
+    parser.add_argument("--resume")
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--device")
+    parser.add_argument("--max_time_minutes", type=float)
+    parser.add_argument("--checkpoint_every_steps", type=int, default=0)
     args = parser.parse_args()
-
     train_mlp_heads(
         args.train_npz,
         args.val_npz,
@@ -202,5 +288,11 @@ if __name__ == "__main__":
         epochs=args.epochs,
         batch_size=args.batch_size,
         lr=args.lr,
-        out_dir=args.out_dir
+        out_dir=args.out_dir,
+        run_id=args.run_id,
+        resume=args.resume,
+        seed=args.seed,
+        device_name=args.device,
+        max_time_minutes=args.max_time_minutes,
+        checkpoint_every_steps=args.checkpoint_every_steps,
     )

--- a/tests/test_mlp_heads_task.py
+++ b/tests/test_mlp_heads_task.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import numpy as np
+import torch
+
+from src.protein_lm.mlp_heads_task import HeadBatch, MLPHeadsTask
+from src.protein_lm.train_mlp_heads import (
+    MultiTaskMLPClassifier,
+    train_mlp_heads,
+)
+from src.training.contracts import StepContext, TrainingPhase
+
+
+def _task(model, batches, task_dims):
+    loaders = {
+        name: [
+            {"X": batch.features, "label": batch.labels}
+            for batch in batches
+            if batch.task_name == name
+        ]
+        for name in task_dims
+    }
+    return MLPHeadsTask(
+        model=model,
+        train_loaders=loaders,
+        validation_loaders=loaders,
+        device=torch.device("cpu"),
+        train_generators={name: torch.Generator() for name in task_dims},
+        seed=11,
+        task_dims=task_dims,
+    )
+
+
+def test_combined_optimizer_matches_independent_head_optimizers():
+    task_dims = {"family": 2, "function": 3}
+    batches = [
+        HeadBatch("family", torch.randn(3, 4), torch.tensor([0, 1, 0])),
+        HeadBatch("function", torch.randn(3, 4), torch.tensor([0, 1, 2])),
+    ]
+    torch.manual_seed(13)
+    combined_model = MultiTaskMLPClassifier(4, task_dims)
+    independent_model = copy.deepcopy(combined_model)
+    combined_task = _task(combined_model, batches, task_dims)
+    independent_task = _task(independent_model, batches, task_dims)
+    combined_optimizer = torch.optim.AdamW(
+        combined_model.parameters(), lr=1e-3, weight_decay=0.01
+    )
+    independent_optimizers = {
+        name: torch.optim.AdamW(head.parameters(), lr=1e-3, weight_decay=0.01)
+        for name, head in independent_model.heads.items()
+    }
+    context = StepContext(TrainingPhase.TRAIN, 0, 0, 0, torch.device("cpu"))
+
+    combined_task.begin_phase(TrainingPhase.TRAIN, 0)
+    independent_task.begin_phase(TrainingPhase.TRAIN, 0)
+    for batch in batches:
+        torch.manual_seed(29)
+        combined_optimizer.zero_grad(set_to_none=True)
+        combined_task.training_step(batch, context).loss.backward()
+        combined_optimizer.step()
+
+        torch.manual_seed(29)
+        optimizer = independent_optimizers[batch.task_name]
+        optimizer.zero_grad(set_to_none=True)
+        independent_task.training_step(batch, context).loss.backward()
+        optimizer.step()
+
+    for actual, expected in zip(
+        combined_model.parameters(), independent_model.parameters(), strict=True
+    ):
+        assert torch.allclose(actual, expected)
+
+
+def _write_fixture(tmp_path):
+    rng = np.random.default_rng(7)
+    train = tmp_path / "train.npz"
+    validation = tmp_path / "validation.npz"
+    arrays = {
+        "X": rng.normal(size=(12, 4)).astype(np.float32),
+        "y_family": np.array([0, 1] * 6),
+        "y_function": np.array([0, 1, 2] * 4),
+        "y_stability": np.array([1, 0] * 6),
+    }
+    np.savez(train, **arrays)
+    np.savez(validation, **arrays)
+    vocabs = tmp_path / "vocabs.json"
+    vocabs.write_text(
+        json.dumps(
+            {
+                "pfam": {"a": 0, "b": 1},
+                "ec": {"a": 0, "b": 1, "c": 2},
+                "stability": {"stable": 0, "unstable": 1},
+            }
+        )
+    )
+    return train, validation, vocabs
+
+
+def test_trainer_creates_collision_safe_selected_head_artifact(tmp_path):
+    train, validation, vocabs = _write_fixture(tmp_path)
+    root = tmp_path / "runs"
+    first = train_mlp_heads(
+        train,
+        validation,
+        vocabs,
+        epochs=1,
+        batch_size=4,
+        out_dir=root,
+        device_name="cpu",
+    )
+    second = train_mlp_heads(
+        train,
+        validation,
+        vocabs,
+        epochs=1,
+        batch_size=4,
+        out_dir=root,
+        device_name="cpu",
+    )
+
+    assert first.status == second.status == "complete"
+    assert (root / "mlp-heads" / "checkpoints" / "mlp_heads.pt").is_file()
+    assert (root / "mlp-heads-r002" / "checkpoints" / "mlp_heads.pt").is_file()
+    checkpoint = torch.load(
+        root / "mlp-heads" / "checkpoints" / "last.pt",
+        map_location="cpu",
+        weights_only=False,
+    )
+    assert set(checkpoint["task"]["best_head_states"]) == {
+        "family",
+        "function",
+        "stability",
+    }
+
+
+def test_dataset_rejects_out_of_vocabulary_labels(tmp_path):
+    train, _, _ = _write_fixture(tmp_path)
+    with np.load(train) as data:
+        arrays = {name: data[name] for name in data.files}
+    arrays["y_family"] = np.full(12, 2)
+    invalid = tmp_path / "invalid.npz"
+    np.savez(invalid, **arrays)
+
+    from src.protein_lm.train_mlp_heads import TaskFeatureDataset
+
+    try:
+        TaskFeatureDataset(invalid, "family", num_classes=2)
+    except ValueError as exc:
+        assert "exceed its vocabulary" in str(exc)
+    else:
+        raise AssertionError("out-of-range labels were accepted")
+
+
+def test_interrupted_resume_matches_uninterrupted_training(tmp_path):
+    train, validation, vocabs = _write_fixture(tmp_path)
+    reference_root = tmp_path / "reference"
+    resumed_root = tmp_path / "resumed"
+    train_mlp_heads(
+        train,
+        validation,
+        vocabs,
+        epochs=1,
+        batch_size=4,
+        out_dir=reference_root,
+        run_id="reference",
+        device_name="cpu",
+    )
+    interrupted = train_mlp_heads(
+        train,
+        validation,
+        vocabs,
+        epochs=1,
+        batch_size=4,
+        out_dir=resumed_root,
+        run_id="interrupted",
+        device_name="cpu",
+        max_time_minutes=0,
+    )
+    assert interrupted.status == "interrupted"
+    last = resumed_root / "interrupted" / "checkpoints" / "last.pt"
+    resumed = train_mlp_heads(
+        train,
+        validation,
+        vocabs,
+        epochs=1,
+        batch_size=4,
+        out_dir=resumed_root,
+        run_id="interrupted",
+        resume=last,
+        device_name="cpu",
+    )
+    assert resumed.status == "complete"
+
+    reference = torch.load(
+        reference_root / "reference" / "checkpoints" / "last.pt",
+        map_location="cpu",
+        weights_only=False,
+    )
+    actual = torch.load(last, map_location="cpu", weights_only=False)
+    for name, tensor in reference["task"]["model"].items():
+        assert torch.equal(actual["task"]["model"][name], tensor)
+    for parameter_id, state in reference["strategy"]["optimizer"]["state"].items():
+        actual_state = actual["strategy"]["optimizer"]["state"][parameter_id]
+        for state_name, value in state.items():
+            if torch.is_tensor(value):
+                assert torch.equal(actual_state[state_name], value)
+            else:
+                assert actual_state[state_name] == value


### PR DESCRIPTION
## Summary
- migrate the Pfam, EC, and categorical-stability feature heads to the shared training engine
- add collision-safe run directories, atomic checkpoints, periodic and wall-time interruption, exact resume, logs, and per-head curves
- retain independent best-head selection and emit the legacy-format unified mlp_heads.pt artifact inside each run
- reject missing labeled splits and labels outside vocabulary-derived class ranges
- document the migrated ancillary trainer and distinguish it from CodonLM offset-prior MLP heads

## Compatibility
A single AdamW optimizer is numerically equivalent to the former independent head optimizers because each task batch produces gradients for only one head. The output directory is now a run root so repeated training cannot overwrite previous results.

## Testing
- Ruff on changed Python files
- Feature-head tests: 4 passed
- Full suite: 430 passed, 1 skipped, 1 xpassed